### PR TITLE
Make context header consistent with other projects

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -11,7 +11,7 @@ import (
 type key int
 
 const (
-	ctxHeaderUUID = "X-CTX-Carbon-UUID"
+	ctxHeaderUUID = "X-CTX-CarbonAPI-UUID"
 
 	uuidKey key = 0
 )


### PR DESCRIPTION
Go-carbon expects to see either X-CTX-CarbonAPI-UUID or
X-CTX-CarbonZipper-UUID, so let's give it one of those.