### PR TITLE
fix empty result in moving functions

### DIFF
--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -66,14 +66,18 @@ func (f *moving) Do(e parser.Expr, from, until int32, values map[parser.MetricRe
 		return nil, err
 	}
 
+	var result []*types.MetricData
+
+	if len(arg) == 0 {
+		return result, nil
+	}
+
 	var offset int
 
 	if scaleByStep {
 		windowSize /= int(arg[0].StepTime)
 		offset = windowSize
 	}
-
-	var result []*types.MetricData
 
 	for _, a := range arg {
 		w := &types.Windowed{Data: make([]float64, windowSize)}

--- a/expr/functions/movingMedian/function.go
+++ b/expr/functions/movingMedian/function.go
@@ -67,14 +67,18 @@ func (f *movingMedian) Do(e parser.Expr, from, until int32, values map[parser.Me
 		return nil, err
 	}
 
+	var result []*types.MetricData
+
+	if len(arg) == 0 {
+		return result, nil
+	}
+
 	var offset int
 
 	if scaleByStep {
 		windowSize /= int(arg[0].StepTime)
 		offset = windowSize
 	}
-
-	var result []*types.MetricData
 
 	for _, a := range arg {
 		r := *a


### PR DESCRIPTION
On empty set panic 'index out of range' at expr/functions/moving/function.go:72