### PR TITLE
fix movingXyz error on intervals greater than 30 days

### DIFF
--- a/expr/functions/moving/function.go
+++ b/expr/functions/moving/function.go
@@ -86,30 +86,38 @@ func (f *moving) Do(e parser.Expr, from, until int32, values map[parser.MetricRe
 		r.StopTime = until
 
 		for i, v := range a.Values {
-			if a.IsAbsent[i] {
-				// make sure missing values are ignored
-				v = math.NaN()
-			}
+			if windowSize == 0 {
+				// Fix error on long time ranges (greater than 30 days), sampling to 10 min
+				r.Values = make([]float64, len(a.Values))
+				for i := range a.Values {
+					r.Values[i] = math.NaN()
+				}
+			} else {
+				if a.IsAbsent[i] {
+					// make sure missing values are ignored
+					v = math.NaN()
+				}
 
-			if ridx := i - offset; ridx >= 0 {
-				switch e.Target() {
-				case "movingAverage":
-					r.Values[ridx] = w.Mean()
-				case "movingSum":
-					r.Values[ridx] = w.Sum()
-					//TODO(cldellow): consider a linear time min/max-heap for these,
-					// e.g. http://stackoverflow.com/questions/8905525/computing-a-moving-maximum/8905575#8905575
-				case "movingMin":
-					r.Values[ridx] = w.Min()
-				case "movingMax":
-					r.Values[ridx] = w.Max()
+				if ridx := i - offset; ridx >= 0 {
+					switch e.Target() {
+					case "movingAverage":
+						r.Values[ridx] = w.Mean()
+					case "movingSum":
+						r.Values[ridx] = w.Sum()
+						//TODO(cldellow): consider a linear time min/max-heap for these,
+						// e.g. http://stackoverflow.com/questions/8905525/computing-a-moving-maximum/8905575#8905575
+					case "movingMin":
+						r.Values[ridx] = w.Min()
+					case "movingMax":
+						r.Values[ridx] = w.Max()
+					}
+					if i < windowSize || math.IsNaN(r.Values[ridx]) {
+						r.Values[ridx] = 0
+						r.IsAbsent[ridx] = true
+					}
 				}
-				if i < windowSize || math.IsNaN(r.Values[ridx]) {
-					r.Values[ridx] = 0
-					r.IsAbsent[ridx] = true
-				}
+				w.Push(v)
 			}
-			w.Push(v)
 		}
 		result = append(result, &r)
 	}


### PR DESCRIPTION
Becouse data was sampled to 10 min on query with long data range (over 30 days), for functions movingXyz (like movingMax(Series, '3min'))  windowSize == 0 and I'm get panic at (*Windowed).Push.