### PR TITLE
log referer for slow requests

### DIFF
--- a/app/carbonapi/api.go
+++ b/app/carbonapi/api.go
@@ -607,9 +607,11 @@ func (app *App) bucketRequestTimes(req *http.Request, t time.Duration) {
 
 	// This seems slow enough to count as a slow request
 	if bucket >= app.config.Buckets {
+		referer := req.Header.Get("Referer")
 		logger.Warn("Slow Request",
 			zap.Duration("time", t),
 			zap.String("url", req.URL.String()),
+			zap.String("referer", referer),
 		)
 	}
 }


### PR DESCRIPTION
Add log referer for slow requests (for simple identify slow grafana dashboards)