### PR TITLE
Add a minValue option to nonNegativeDerivative and perSecond

### DIFF
--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -341,6 +341,18 @@ func TestEvalExpression(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("nonNegativeDerivative(metric1,32)", []float64{math.NaN(), 2, 29, 10, 24, math.NaN(), math.NaN(), 32, math.NaN()}, 1, now32)},
 		},
 		{
+			parser.NewExpr("nonNegativeDerivative",
+				"metric1",
+				parser.NamedArgs{
+					"minValue": 1,
+				},
+			),
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 2, 10, 1, math.NaN(), 8, 40, 37}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("nonNegativeDerivative(metric1,minValue=1)", []float64{math.NaN(), 2, 2, 8, 1, math.NaN(), math.NaN(), 32, 37}, 1, now32)},
+		},
+		{
 			parser.NewExpr("perSecond",
 				"metric1",
 			),
@@ -357,6 +369,18 @@ func TestEvalExpression(t *testing.T) {
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 1, 2, 3, 4, 30, 0, 32, math.NaN()}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("perSecond(metric1,32)", []float64{math.NaN(), math.NaN(), 1, 1, 1, 26, 3, 32, math.NaN()}, 1, now32)},
+		},
+		{
+			parser.NewExpr("perSecond",
+				"metric1",
+				parser.NamedArgs{
+					"minValue": 1,
+				},
+			),
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 1, 2, 3, 4, 30, 3, 32, math.NaN()}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("perSecond(metric1,minValue=1)", []float64{math.NaN(), math.NaN(), 1, 1, 1, 26, 3, 29, math.NaN()}, 1, now32)},
 		},
 		{
 			parser.NewExpr("movingAverage",

--- a/expr/functions/nonNegativeDerivative/function.go
+++ b/expr/functions/nonNegativeDerivative/function.go
@@ -1,6 +1,7 @@
 package nonNegativeDerivative
 
 import (
+	"errors"
 	"fmt"
 	"github.com/bookingcom/carbonapi/expr/helper"
 	"github.com/bookingcom/carbonapi/expr/interfaces"
@@ -37,17 +38,39 @@ func (f *nonNegativeDerivative) Do(e parser.Expr, from, until int32, values map[
 	if err != nil {
 		return nil, err
 	}
-	_, ok := e.NamedArgs()["maxValue"]
-	if !ok {
-		ok = len(e.Args()) > 1
+	minValue, err := e.GetFloatNamedOrPosArgDefault("minValue", 2, math.NaN())
+	if err != nil {
+		return nil, err
+	}
+	hasMax := !math.IsNaN(maxValue)
+	hasMin := !math.IsNaN(minValue)
+
+	if hasMax && hasMin && maxValue <= minValue {
+		return nil, errors.New("minValue must be lower than maxValue")
+	}
+	if hasMax && !hasMin {
+		minValue = 0
+	}
+
+	argMask := 0
+	if _, ok := e.NamedArgs()["maxValue"]; ok || len(e.Args()) > 1 {
+		argMask |= 1
+	}
+	if _, ok := e.NamedArgs()["minValue"]; ok || len(e.Args()) > 2 {
+		argMask |= 2
 	}
 
 	var result []*types.MetricData
 	for _, a := range args {
 		var name string
-		if ok {
+		switch argMask {
+		case 3:
+			name = fmt.Sprintf("nonNegativeDerivative(%s,%g,%g)", a.Name, maxValue, minValue)
+		case 2:
+			name = fmt.Sprintf("nonNegativeDerivative(%s,minValue=%g)", a.Name, minValue)
+		case 1:
 			name = fmt.Sprintf("nonNegativeDerivative(%s,%g)", a.Name, maxValue)
-		} else {
+		case 0:
 			name = fmt.Sprintf("nonNegativeDerivative(%s)", a.Name)
 		}
 
@@ -66,8 +89,10 @@ func (f *nonNegativeDerivative) Do(e parser.Expr, from, until int32, values map[
 			diff := v - prev
 			if diff >= 0 {
 				r.Values[i] = diff
-			} else if !math.IsNaN(maxValue) && maxValue >= v {
-				r.Values[i] = ((maxValue - prev) + v + 1)
+			} else if hasMax && maxValue >= v {
+				r.Values[i] = ((maxValue - prev) + (v - minValue) + 1)
+			} else if hasMin && minValue <= v {
+				r.Values[i] = ((v - minValue) + 1)
 			} else {
 				r.Values[i] = 0
 				r.IsAbsent[i] = true
@@ -96,6 +121,10 @@ func (f *nonNegativeDerivative) Description() map[string]types.FunctionDescripti
 				},
 				{
 					Name: "maxValue",
+					Type: types.Float,
+				},
+				{
+					Name: "minValue",
 					Type: types.Float,
 				},
 			},

--- a/expr/functions/perSecond/function.go
+++ b/expr/functions/perSecond/function.go
@@ -1,6 +1,7 @@
 package perSecond
 
 import (
+	"errors"
 	"fmt"
 	"github.com/bookingcom/carbonapi/expr/helper"
 	"github.com/bookingcom/carbonapi/expr/interfaces"
@@ -34,19 +35,48 @@ func (f *perSecond) Do(e parser.Expr, from, until int32, values map[parser.Metri
 		return nil, err
 	}
 
-	maxValue, err := e.GetFloatArgDefault(1, math.NaN())
+	maxValue, err := e.GetFloatNamedOrPosArgDefault("maxValue", 1, math.NaN())
 	if err != nil {
 		return nil, err
+	}
+	minValue, err := e.GetFloatNamedOrPosArgDefault("minValue", 2, math.NaN())
+	if err != nil {
+		return nil, err
+	}
+	hasMax := !math.IsNaN(maxValue)
+	hasMin := !math.IsNaN(minValue)
+
+	if hasMax && hasMin && maxValue <= minValue {
+		return nil, errors.New("minValue must be lower than maxValue")
+	}
+	if hasMax && !hasMin {
+		minValue = 0
+	}
+
+	argMask := 0
+	if _, ok := e.NamedArgs()["maxValue"]; ok || len(e.Args()) > 1 {
+		argMask |= 1
+	}
+	if _, ok := e.NamedArgs()["minValue"]; ok || len(e.Args()) > 2 {
+		argMask |= 2
 	}
 
 	var result []*types.MetricData
 	for _, a := range args {
-		r := *a
-		if len(e.Args()) == 1 {
-			r.Name = fmt.Sprintf("%s(%s)", e.Target(), a.Name)
-		} else {
-			r.Name = fmt.Sprintf("%s(%s,%g)", e.Target(), a.Name, maxValue)
+		var name string
+		switch argMask {
+		case 3:
+			name = fmt.Sprintf("perSecond(%s,%g,%g)", a.Name, maxValue, minValue)
+		case 2:
+			name = fmt.Sprintf("perSecond(%s,minValue=%g)", a.Name, minValue)
+		case 1:
+			name = fmt.Sprintf("perSecond(%s,%g)", a.Name, maxValue)
+		case 0:
+			name = fmt.Sprintf("perSecond(%s)", a.Name)
 		}
+
+		r := *a
+		r.Name = name
 		r.Values = make([]float64, len(a.Values))
 		r.IsAbsent = make([]bool, len(a.Values))
 
@@ -60,8 +90,10 @@ func (f *perSecond) Do(e parser.Expr, from, until int32, values map[parser.Metri
 			diff := v - prev
 			if diff >= 0 {
 				r.Values[i] = diff / float64(a.StepTime)
-			} else if !math.IsNaN(maxValue) && maxValue >= v {
-				r.Values[i] = (maxValue - prev + v + 1) / float64(a.StepTime)
+			} else if hasMax && maxValue >= v {
+				r.Values[i] = ((maxValue - prev) + (v - minValue) + 1) / float64(a.StepTime)
+			} else if hasMin && minValue <= v {
+				r.Values[i] = ((v - minValue) + 1) / float64(a.StepTime)
 			} else {
 				r.Values[i] = 0
 				r.IsAbsent[i] = true
@@ -90,6 +122,10 @@ func (f *perSecond) Description() map[string]types.FunctionDescription {
 				},
 				{
 					Name: "maxValue",
+					Type: types.Float,
+				},
+				{
+					Name: "minValue",
 					Type: types.Float,
 				},
 			},


### PR DESCRIPTION
It works in a way similar to maxValue: when the counter wraps, instead of
producing a null value, it computes the difference assuming the counter wrapped
to minValue.

This implements the same logic as was added to Graphite in
PR #2375 (https://github.com/graphite-project/graphite-web/pull/2375).