### PR TITLE
CSV output respects timezone parameter

### DIFF
--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -466,7 +466,18 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 	case rawFormat:
 		body = types.MarshalRaw(results)
 	case csvFormat:
-		body = types.MarshalCSV(results)
+		tz := app.defaultTimeZone
+		if qtz != "" {
+			z, err := time.LoadLocation(qtz)
+			if err != nil {
+				logger.Warn("Invalid time zone",
+					zap.String("tz", qtz),
+				)
+			} else {
+				tz = z
+			}
+		}
+		body = types.MarshalCSV(results, tz)
 	case pickleFormat:
 		body = types.MarshalPickle(results)
 	case pngFormat:

--- a/expr/types/types.go
+++ b/expr/types/types.go
@@ -55,7 +55,7 @@ func MakeMetricData(name string, values []float64, step, start int32) *MetricDat
 }
 
 // MarshalCSV marshals metric data to CSV
-func MarshalCSV(results []*MetricData) []byte {
+func MarshalCSV(results []*MetricData, location *time.Location) []byte {
 
 	var b []byte
 
@@ -68,7 +68,13 @@ func MarshalCSV(results []*MetricData) []byte {
 			b = append(b, r.Name...)
 			b = append(b, '"')
 			b = append(b, ',')
-			b = append(b, time.Unix(int64(t), 0).Format("2006-01-02 15:04:05")...)
+
+			tmp := time.Unix(int64(t), 0)
+			if location != nil {
+				tmp = tmp.In(location)
+			}
+
+			b = append(b, tmp.Format("2006-01-02 15:04:05")...)
 			b = append(b, ',')
 			if !r.IsAbsent[i] {
 				b = strconv.AppendFloat(b, v, 'f', -1, 64)

--- a/expr/types/types_test.go
+++ b/expr/types/types_test.go
@@ -1,0 +1,57 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	pb "github.com/go-graphite/protocol/carbonapi_v2_pb"
+)
+
+func TestMarshalCSVInUTC(t *testing.T) {
+	results := []*MetricData{
+		&MetricData{
+			FetchResponse: pb.FetchResponse{
+				Name:      "foo",
+				StartTime: 0,
+				StopTime:  1,
+				StepTime:  1,
+				Values:    []float64{2},
+				IsAbsent:  []bool{false},
+			},
+		},
+	}
+
+	blob := MarshalCSV(results, time.UTC)
+	got := string(blob)
+
+	exp := "\"foo\",1970-01-01 00:00:00,2\n"
+
+	if got != exp {
+		t.Errorf("Expected '%s', got '%s'", exp, got)
+	}
+}
+
+func TestMarshalCSVNotInUTC(t *testing.T) {
+	results := []*MetricData{
+		&MetricData{
+			FetchResponse: pb.FetchResponse{
+				Name:      "foo",
+				StartTime: 0,
+				StopTime:  1,
+				StepTime:  1,
+				Values:    []float64{2},
+				IsAbsent:  []bool{false},
+			},
+		},
+	}
+
+	tz := time.FixedZone("UTC+1", int(time.Hour/time.Second))
+	blob := MarshalCSV(results, tz)
+	got := string(blob)
+
+	exp := "\"foo\",1970-01-01 01:00:00,2\n"
+
+	if got != exp {
+		t.Errorf("Expected '%s', got '%s'", exp, got)
+	}
+}


### PR DESCRIPTION
The CSV output of carbonapi consists of lines of the form:

    "metric.name",YYYY-MM-DD hh:mm:ss,value

The time is the epoch timestamp of the metric datapoint expressed in the
local time zone.

When the "tz" option is set in the configuration file, or when a user
passes in a "tz" URL parameter, we should express the timestamp in that
time zone.