### PR TITLE
1. Add handler supporting grafana requests for graphite tags.

### DIFF
--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -118,6 +118,8 @@ func initHandlers(app *App) http.Handler {
 	r.HandleFunc("/functions", httputil.TimeHandler(app.functionsHandler, app.bucketRequestTimes))
 	r.HandleFunc("/functions/", httputil.TimeHandler(app.functionsHandler, app.bucketRequestTimes))
 
+	r.HandleFunc("/tags/autoComplete/tags", httputil.TimeHandler(tagsHandler, app.bucketRequestTimes))
+
 	r.HandleFunc("/", httputil.TimeHandler(usageHandler, app.bucketRequestTimes))
 
 	return r
@@ -840,6 +842,12 @@ func (app *App) versionHandler(w http.ResponseWriter, r *http.Request) {
 		apiMetrics.Responses.Add(1)
 		prometheusMetrics.Responses.WithLabelValues("200", "version").Inc()
 	}()
+	// Use a specific version of graphite for grafana
+	// This handler is queried by grafana, and if needed, an override can be provided
+	if app.config.GraphiteVersionForGrafana != "" {
+		w.Write([]byte(app.config.GraphiteVersionForGrafana))
+		return
+	}
 
 	if app.config.GraphiteWeb09Compatibility {
 		w.Write([]byte("0.9.15\n"))
@@ -1087,6 +1095,7 @@ supported requests:
 	/metrics/find/?query=
 	/info/?target=
 	/functions/
+	/tags/autoComplete/tags
 `)
 
 func usageHandler(w http.ResponseWriter, r *http.Request) {
@@ -1098,6 +1107,18 @@ func usageHandler(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	w.Write(usageMsg)
+}
+
+//TODO : Fix this handler if and when tag support is added
+// This responds to grafana's tag requests, which were falling through to the usageHandler,
+// preventing a random, garbage list of tags (constructed from usageMsg) being added to the metrics list
+func tagsHandler(w http.ResponseWriter, r *http.Request) {
+	apiMetrics.Requests.Add(1)
+	prometheusMetrics.Requests.Inc()
+	defer func() {
+		apiMetrics.Responses.Add(1)
+		prometheusMetrics.Responses.WithLabelValues("200", "usage").Inc()
+	}()
 }
 
 func debugVersionHandler(w http.ResponseWriter, r *http.Request) {

--- a/cfg/api.go
+++ b/cfg/api.go
@@ -89,10 +89,11 @@ type API struct {
 	BlockHeaderUpdatePeriod time.Duration `yaml:"blockHeaderUpdatePeriod"`
 	HeadersToLog            []string      `yaml:"headersToLog"`
 
-	UnicodeRangeTables  []string          `yaml:"unicodeRangeTables"`
-	IgnoreClientTimeout bool              `yaml:"ignoreClientTimeout"`
-	DefaultColors       map[string]string `yaml:"defaultColors"`
-	FunctionsConfigs    map[string]string `yaml:"functionsConfig"`
+	UnicodeRangeTables        []string          `yaml:"unicodeRangeTables"`
+	IgnoreClientTimeout       bool              `yaml:"ignoreClientTimeout"`
+	DefaultColors             map[string]string `yaml:"defaultColors"`
+	FunctionsConfigs          map[string]string `yaml:"functionsConfig"`
+	GraphiteVersionForGrafana string            `yaml:"graphiteVersionForGrafana"`
 }
 
 type CacheConfig struct {


### PR DESCRIPTION
It currently returns no data, which would need to be changed once we start
supporting tags.
2. Add config to override /version with specific graphite version. This
is added to support overriding the actual graphite version with
something needed for grafana for now. It allows us to get integrated
function docs in grafana.