### PR TITLE
Fix off-by-one in minValue option handling

### DIFF
--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -350,7 +350,7 @@ func TestEvalExpression(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{2, 4, 2, 10, 1, math.NaN(), 8, 40, 37}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("nonNegativeDerivative(metric1,minValue=1)", []float64{math.NaN(), 2, 2, 8, 1, math.NaN(), math.NaN(), 32, 37}, 1, now32)},
+			[]*types.MetricData{types.MakeMetricData("nonNegativeDerivative(metric1,minValue=1)", []float64{math.NaN(), 2, 1, 8, 0, math.NaN(), math.NaN(), 32, 36}, 1, now32)},
 		},
 		{
 			parser.NewExpr("perSecond",
@@ -380,7 +380,7 @@ func TestEvalExpression(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{math.NaN(), 1, 2, 3, 4, 30, 3, 32, math.NaN()}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("perSecond(metric1,minValue=1)", []float64{math.NaN(), math.NaN(), 1, 1, 1, 26, 3, 29, math.NaN()}, 1, now32)},
+			[]*types.MetricData{types.MakeMetricData("perSecond(metric1,minValue=1)", []float64{math.NaN(), math.NaN(), 1, 1, 1, 26, 2, 29, math.NaN()}, 1, now32)},
 		},
 		{
 			parser.NewExpr("movingAverage",

--- a/expr/functions/nonNegativeDerivative/function.go
+++ b/expr/functions/nonNegativeDerivative/function.go
@@ -92,7 +92,7 @@ func (f *nonNegativeDerivative) Do(e parser.Expr, from, until int32, values map[
 			} else if hasMax && maxValue >= v {
 				r.Values[i] = ((maxValue - prev) + (v - minValue) + 1)
 			} else if hasMin && minValue <= v {
-				r.Values[i] = ((v - minValue) + 1)
+				r.Values[i] = (v - minValue)
 			} else {
 				r.Values[i] = 0
 				r.IsAbsent[i] = true

--- a/expr/functions/perSecond/function.go
+++ b/expr/functions/perSecond/function.go
@@ -93,7 +93,7 @@ func (f *perSecond) Do(e parser.Expr, from, until int32, values map[parser.Metri
 			} else if hasMax && maxValue >= v {
 				r.Values[i] = ((maxValue - prev) + (v - minValue) + 1) / float64(a.StepTime)
 			} else if hasMin && minValue <= v {
-				r.Values[i] = ((v - minValue) + 1) / float64(a.StepTime)
+				r.Values[i] = (v - minValue) / float64(a.StepTime)
 			} else {
 				r.Values[i] = 0
 				r.IsAbsent[i] = true


### PR DESCRIPTION
The +1 is correct for maxValue because that's a wrap-around case, while
minValue is meant to handle "reset to value on restart" case.