### PR TITLE
Mimicking graphite-web margin indentation for graphOnly=1

### DIFF
--- a/expr/functions/cairo/png/cairo.go
+++ b/expr/functions/cairo/png/cairo.go
@@ -1081,6 +1081,10 @@ func drawGraph(cr *cairoSurfaceContext, params *Params, results []*types.MetricD
 		params.hideGrid = true
 		params.hideAxes = true
 		params.hideYAxis = true
+		params.area.xmin = 0
+		params.area.xmax = params.width
+		params.area.ymin = 0
+		params.area.ymax = params.height
 	}
 
 	if params.yAxisSide == YAxisSideRight {


### PR DESCRIPTION
Fixes #41
https://github.com/graphite-project/graphite-web/blob/0.9.12/webapp/graphite/render/glyph.py#L560-L563