### PR TITLE
Added linear metrics for limiter usage

### DIFF
--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -117,7 +117,8 @@ func (app *App) registerPrometheusMetrics(logger *zap.Logger) {
 		prometheus.MustRegister(app.prometheusMetrics.Responses)
 		prometheus.MustRegister(app.prometheusMetrics.DurationsExp)
 		prometheus.MustRegister(app.prometheusMetrics.DurationsLin)
-		prometheus.MustRegister(app.prometheusMetrics.TimeInQueue)
+		prometheus.MustRegister(app.prometheusMetrics.TimeInQueueExp)
+		prometheus.MustRegister(app.prometheusMetrics.TimeInQueueLin)
 
 		writeTimeout := app.config.Timeouts.Global
 		if writeTimeout < 30*time.Second {

--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -298,6 +298,7 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 					atomic.AddInt64(&accessLogDetails.ZipperRequests, 1)
 
 					request := dataTypes.NewRenderRequest([]string{path}, from, until)
+					// TODO (grzkv): Do we need backend filtering for carbonapi?
 					bs := backend.Filter(app.backends, request.Targets)
 					metrics, err := backend.Renders(ctx, bs, request)
 

--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -47,9 +47,13 @@ const (
 )
 
 // for testing
+// TODO (grzkv): Clean up
 var timeNow = time.Now
 
+// Rule is a request blocking rule
 type Rule map[string]string
+
+// RuleConfig represents the request blocking rules
 type RuleConfig struct {
 	Rules []Rule
 }
@@ -146,6 +150,7 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 	apiMetrics.Requests.Add(1)
 	app.prometheusMetrics.Requests.Inc()
 
+	// TODO (grzkv): Move form management to a separate function
 	err := r.ParseForm()
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusBadRequest)+": "+err.Error(), http.StatusBadRequest)
@@ -297,9 +302,8 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 					metrics, err := backend.Renders(ctx, bs, request)
 
 					// time in queue is converted to ms
-					app.prometheusMetrics.TimeInQueue.Observe(float64(request.Trace.Report()[2]) / 1000 / 1000)
-
-					// TODO(gmagnusson): Account for request stats
+					app.prometheusMetrics.TimeInQueueExp.Observe(float64(request.Trace.Report()[2]) / 1000 / 1000)
+					app.prometheusMetrics.TimeInQueueLin.Observe(float64(request.Trace.Report()[2]) / 1000 / 1000)
 
 					metricData := make([]*types.MetricData, 0)
 					for i := range metrics {

--- a/app/carbonapi/metrics.go
+++ b/app/carbonapi/metrics.go
@@ -9,11 +9,12 @@ import (
 
 // PrometheusMetrics are metrix exported via /metrics endpoint for Prom scraping
 type PrometheusMetrics struct {
-	Requests     prometheus.Counter
-	Responses    *prometheus.CounterVec
-	DurationsExp prometheus.Histogram
-	DurationsLin prometheus.Histogram
-	TimeInQueue  prometheus.Histogram
+	Requests       prometheus.Counter
+	Responses      *prometheus.CounterVec
+	DurationsExp   prometheus.Histogram
+	DurationsLin   prometheus.Histogram
+	TimeInQueueExp prometheus.Histogram
+	TimeInQueueLin prometheus.Histogram
 }
 
 func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
@@ -51,7 +52,7 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 					config.Zipper.Common.Monitoring.RequestDurationLin.BucketsNum),
 			},
 		),
-		TimeInQueue: prometheus.NewHistogram(
+		TimeInQueueExp: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Name: "time_in_queue_ms_exp",
 				Help: "Time a request to backend spends in queue (exponential), in ms",
@@ -61,10 +62,21 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 					config.Zipper.Common.Monitoring.TimeInQueueExpHistogram.BucketsNum),
 			},
 		),
+		TimeInQueueLin: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name: "time_in_queue_ms_lin",
+				Help: "Time a request to backend spends in queue (linear), in ms",
+				Buckets: prometheus.LinearBuckets(
+					config.Zipper.Common.Monitoring.TimeInQueueLinHistogram.Start,
+					config.Zipper.Common.Monitoring.TimeInQueueLinHistogram.BucketSize,
+					config.Zipper.Common.Monitoring.TimeInQueueLinHistogram.BucketsNum),
+			},
+		),
 	}
 }
 
 // TODO (grzkv): Remove from global scope
+// TODO (grzkv): Consider substituting this with Prometheus
 var apiMetrics = struct {
 	// Total counts across all request types
 	Requests  *expvar.Int

--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -191,7 +191,8 @@ func (app *App) Start() {
 		prometheus.MustRegister(app.prometheusMetrics.Responses)
 		prometheus.MustRegister(app.prometheusMetrics.DurationsExp)
 		prometheus.MustRegister(app.prometheusMetrics.DurationsLin)
-		prometheus.MustRegister(app.prometheusMetrics.TimeInQueue)
+		prometheus.MustRegister(app.prometheusMetrics.TimeInQueueExp)
+		prometheus.MustRegister(app.prometheusMetrics.TimeInQueueLin)
 
 		writeTimeout := app.config.Timeouts.Global
 		if writeTimeout < 30*time.Second {

--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -244,7 +244,8 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request) {
 	bs := backend.Filter(app.backends, request.Targets)
 	metrics, err := backend.Renders(ctx, bs, request)
 	// time in queue is converted to ms
-	app.prometheusMetrics.TimeInQueue.Observe(float64(request.Trace.Report()[2]) / 1000 / 1000)
+	app.prometheusMetrics.TimeInQueueExp.Observe(float64(request.Trace.Report()[2]) / 1000 / 1000)
+	app.prometheusMetrics.TimeInQueueLin.Observe(float64(request.Trace.Report()[2]) / 1000 / 1000)
 
 	if err != nil {
 		msg := "error fetching the data"

--- a/app/carbonzipper/metrics.go
+++ b/app/carbonzipper/metrics.go
@@ -55,11 +55,12 @@ var Metrics = struct {
 
 // PrometheusMetrics keeps all the metrics exposed on /metrics endpoint
 type PrometheusMetrics struct {
-	Requests     prometheus.Counter
-	Responses    *prometheus.CounterVec
-	DurationsExp prometheus.Histogram
-	DurationsLin prometheus.Histogram
-	TimeInQueue  prometheus.Histogram
+	Requests       prometheus.Counter
+	Responses      *prometheus.CounterVec
+	DurationsExp   prometheus.Histogram
+	DurationsLin   prometheus.Histogram
+	TimeInQueueExp prometheus.Histogram
+	TimeInQueueLin prometheus.Histogram
 }
 
 // NewPrometheusMetrics creates a set of default Prom metrics
@@ -98,7 +99,7 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 					config.Monitoring.RequestDurationLin.BucketsNum),
 			},
 		),
-		TimeInQueue: prometheus.NewHistogram(
+		TimeInQueueExp: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Name: "time_in_queue_ms_exp",
 				Help: "Time a request spends in queue (exponential), ms",
@@ -106,6 +107,16 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 					config.Monitoring.TimeInQueueExpHistogram.Start,
 					config.Monitoring.TimeInQueueExpHistogram.BucketSize,
 					config.Monitoring.TimeInQueueExpHistogram.BucketsNum),
+			},
+		),
+		TimeInQueueLin: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name: "time_in_queue_ms_lin",
+				Help: "Time a request spends in queue (linear), ms",
+				Buckets: prometheus.LinearBuckets(
+					config.Monitoring.TimeInQueueLinHistogram.Start,
+					config.Monitoring.TimeInQueueLinHistogram.BucketSize,
+					config.Monitoring.TimeInQueueLinHistogram.BucketsNum),
 			},
 		),
 	}

--- a/cfg/common.go
+++ b/cfg/common.go
@@ -61,9 +61,14 @@ func DefaultCommonConfig() Common {
 		Logger: []zapwriter.Config{GetDefaultLoggerConfig()},
 		Monitoring: MonitoringConfig{
 			TimeInQueueExpHistogram: HistogramConfig{
-				Start:      0.05,
+				Start:      0.01,
 				BucketsNum: 25,
 				BucketSize: 2,
+			},
+			TimeInQueueLinHistogram: HistogramConfig{
+				Start:      0.0,
+				BucketsNum: 25,
+				BucketSize: 0.02,
 			},
 			RequestDurationExp: HistogramConfig{
 				Start:      0.05,
@@ -119,6 +124,7 @@ type MonitoringConfig struct {
 	RequestDurationExp      HistogramConfig `yaml:"requestDurationExpHistogram"`
 	RequestDurationLin      HistogramConfig `yaml:"requestDurationLinHistogram"`
 	TimeInQueueExpHistogram HistogramConfig `yaml:"timeInQueueExpHistogram"`
+	TimeInQueueLinHistogram HistogramConfig `yaml:"timeInQueueLinHistogram"`
 }
 
 // HistogramConfig is histogram config for Prometheus metrics

--- a/cfg/common_test.go
+++ b/cfg/common_test.go
@@ -33,6 +33,10 @@ monitoring:
         start: 0.3
         bucketsNum: 30
         bucketSize: 3
+    timeInQueueLinHistogram:
+        start: 0.0
+        bucketsNum: 33
+        bucketSize: 0.3
     requestDurationExpHistogram:
         start: 0.05
         bucketsNum: 30
@@ -82,6 +86,11 @@ monitoring:
 				Start:      0.3,
 				BucketsNum: 30,
 				BucketSize: 3,
+			},
+			TimeInQueueLinHistogram: HistogramConfig{
+				Start:      0.0,
+				BucketsNum: 33,
+				BucketSize: 0.3,
 			},
 			RequestDurationExp: HistogramConfig{
 				Start:      0.05,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -6,6 +6,8 @@ The definitions correspond to the types of responses to the /render, /info, and
 */
 package types
 
+// TODO (grzkv): Name of this module makes 0 sense
+
 import (
 	"sort"
 	"sync/atomic"
@@ -41,6 +43,8 @@ func SetCorruptionWatcher(threshold float64, logger *zap.Logger) {
 	corruptionThreshold = threshold
 	corruptionLogger = logger
 }
+
+// TODO (grzkv): Move to separate file
 
 type FindRequest struct {
 	Query string


### PR DESCRIPTION
Added linear histograms for time-in-queue for both `carbonapi` and `zipper`. 