### PR TITLE
Per-endpoint request duration histograms for /find and /render

### DIFF
--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -115,8 +115,10 @@ func (app *App) registerPrometheusMetrics(logger *zap.Logger) {
 	go func() {
 		prometheus.MustRegister(app.prometheusMetrics.Requests)
 		prometheus.MustRegister(app.prometheusMetrics.Responses)
-		prometheus.MustRegister(app.prometheusMetrics.DurationsExp)
-		prometheus.MustRegister(app.prometheusMetrics.DurationsLin)
+		prometheus.MustRegister(app.prometheusMetrics.DurationExp)
+		prometheus.MustRegister(app.prometheusMetrics.DurationLin)
+		prometheus.MustRegister(app.prometheusMetrics.RenderDurationExp)
+		prometheus.MustRegister(app.prometheusMetrics.FindDurationExp)
 		prometheus.MustRegister(app.prometheusMetrics.TimeInQueueExp)
 		prometheus.MustRegister(app.prometheusMetrics.TimeInQueueLin)
 
@@ -475,8 +477,15 @@ func (app *App) bucketRequestTimes(req *http.Request, t time.Duration) {
 	expBucketIdx := findBucketIndex(expTimeBuckets, expBucket)
 	atomic.AddInt64(&expTimeBuckets[expBucketIdx], 1)
 
-	app.prometheusMetrics.DurationsExp.Observe(t.Seconds())
-	app.prometheusMetrics.DurationsLin.Observe(t.Seconds())
+	app.prometheusMetrics.DurationExp.Observe(t.Seconds())
+	app.prometheusMetrics.DurationLin.Observe(t.Seconds())
+
+	if req.URL.Path == "/render" || req.URL.Path == "/render/" {
+		app.prometheusMetrics.RenderDurationExp.Observe(t.Seconds())
+	}
+	if req.URL.Path == "/metrics/find" || req.URL.Path == "/metrics/find/" {
+		app.prometheusMetrics.FindDurationExp.Observe(t.Seconds())
+	}
 
 	// This seems slow enough to count as a slow request
 	if bucket >= app.config.Buckets {

--- a/app/carbonapi/metrics.go
+++ b/app/carbonapi/metrics.go
@@ -9,12 +9,14 @@ import (
 
 // PrometheusMetrics are metrix exported via /metrics endpoint for Prom scraping
 type PrometheusMetrics struct {
-	Requests       prometheus.Counter
-	Responses      *prometheus.CounterVec
-	DurationsExp   prometheus.Histogram
-	DurationsLin   prometheus.Histogram
-	TimeInQueueExp prometheus.Histogram
-	TimeInQueueLin prometheus.Histogram
+	Requests          prometheus.Counter
+	Responses         *prometheus.CounterVec
+	DurationExp       prometheus.Histogram
+	DurationLin       prometheus.Histogram
+	RenderDurationExp prometheus.Histogram
+	FindDurationExp   prometheus.Histogram
+	TimeInQueueExp    prometheus.Histogram
+	TimeInQueueLin    prometheus.Histogram
 }
 
 func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
@@ -32,7 +34,7 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 			},
 			[]string{"code", "handler"},
 		),
-		DurationsExp: prometheus.NewHistogram(
+		DurationExp: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Name: "http_request_duration_seconds_exp",
 				Help: "The duration of HTTP requests (exponential)",
@@ -42,7 +44,7 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 					config.Zipper.Common.Monitoring.RequestDurationExp.BucketsNum),
 			},
 		),
-		DurationsLin: prometheus.NewHistogram(
+		DurationLin: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Name: "http_request_duration_seconds_lin",
 				Help: "The duration of HTTP requests (linear)",
@@ -50,6 +52,26 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 					config.Zipper.Common.Monitoring.RequestDurationLin.Start,
 					config.Zipper.Common.Monitoring.RequestDurationLin.BucketSize,
 					config.Zipper.Common.Monitoring.RequestDurationLin.BucketsNum),
+			},
+		),
+		RenderDurationExp: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name: "render_request_duration_seconds_exp",
+				Help: "The duration of render requests (exponential)",
+				Buckets: prometheus.ExponentialBuckets(
+					config.Zipper.Common.Monitoring.RenderDurationExp.Start,
+					config.Zipper.Common.Monitoring.RenderDurationExp.BucketSize,
+					config.Zipper.Common.Monitoring.RenderDurationExp.BucketsNum),
+			},
+		),
+		FindDurationExp: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name: "find_request_duration_seconds_exp",
+				Help: "The duration of find requests (exponential)",
+				Buckets: prometheus.ExponentialBuckets(
+					config.Zipper.Common.Monitoring.FindDurationExp.Start,
+					config.Zipper.Common.Monitoring.FindDurationExp.BucketSize,
+					config.Zipper.Common.Monitoring.FindDurationExp.BucketsNum),
 			},
 		),
 		TimeInQueueExp: prometheus.NewHistogram(

--- a/app/carbonzipper/metrics.go
+++ b/app/carbonzipper/metrics.go
@@ -55,12 +55,14 @@ var Metrics = struct {
 
 // PrometheusMetrics keeps all the metrics exposed on /metrics endpoint
 type PrometheusMetrics struct {
-	Requests       prometheus.Counter
-	Responses      *prometheus.CounterVec
-	DurationsExp   prometheus.Histogram
-	DurationsLin   prometheus.Histogram
-	TimeInQueueExp prometheus.Histogram
-	TimeInQueueLin prometheus.Histogram
+	Requests          prometheus.Counter
+	Responses         *prometheus.CounterVec
+	DurationExp       prometheus.Histogram
+	DurationLin       prometheus.Histogram
+	RenderDurationExp prometheus.Histogram
+	FindDurationExp   prometheus.Histogram
+	TimeInQueueExp    prometheus.Histogram
+	TimeInQueueLin    prometheus.Histogram
 }
 
 // NewPrometheusMetrics creates a set of default Prom metrics
@@ -79,7 +81,7 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 			},
 			[]string{"code", "handler"},
 		),
-		DurationsExp: prometheus.NewHistogram(
+		DurationExp: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Name: "http_request_duration_seconds_exp",
 				Help: "The duration of HTTP requests (exponential)",
@@ -89,7 +91,7 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 					config.Monitoring.RequestDurationExp.BucketsNum),
 			},
 		),
-		DurationsLin: prometheus.NewHistogram(
+		DurationLin: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Name: "http_request_duration_seconds_lin",
 				Help: "The duration of HTTP requests (linear)",
@@ -97,6 +99,26 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 					config.Monitoring.RequestDurationLin.Start,
 					config.Monitoring.RequestDurationLin.BucketSize,
 					config.Monitoring.RequestDurationLin.BucketsNum),
+			},
+		),
+		RenderDurationExp: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name: "render_request_duration_seconds_exp",
+				Help: "The duration of render requests (exponential)",
+				Buckets: prometheus.ExponentialBuckets(
+					config.Monitoring.RenderDurationExp.Start,
+					config.Monitoring.RenderDurationExp.BucketSize,
+					config.Monitoring.RenderDurationExp.BucketsNum),
+			},
+		),
+		FindDurationExp: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name: "find_request_duration_seconds_exp",
+				Help: "The duration of find requests (exponential)",
+				Buckets: prometheus.ExponentialBuckets(
+					config.Monitoring.FindDurationExp.Start,
+					config.Monitoring.FindDurationExp.BucketSize,
+					config.Monitoring.FindDurationExp.BucketsNum),
 			},
 		),
 		TimeInQueueExp: prometheus.NewHistogram(

--- a/cfg/common.go
+++ b/cfg/common.go
@@ -34,6 +34,7 @@ func ParseCommon(r io.Reader) (Common, error) {
 	return c, err
 }
 
+// DefaultCommonConfig gives the default config shared by carbonapi and zipper
 func DefaultCommonConfig() Common {
 	return Common{
 		Listen:         ":8080",
@@ -66,7 +67,7 @@ func DefaultCommonConfig() Common {
 				BucketSize: 2,
 			},
 			TimeInQueueLinHistogram: HistogramConfig{
-				Start:      0.0,
+				Start:      0.05,
 				BucketsNum: 25,
 				BucketSize: 0.02,
 			},
@@ -76,9 +77,19 @@ func DefaultCommonConfig() Common {
 				BucketsNum: 20,
 			},
 			RequestDurationLin: HistogramConfig{
-				Start:      0.0,
+				Start:      0.05,
 				BucketSize: 0.05,
 				BucketsNum: 40,
+			},
+			RenderDurationExp: HistogramConfig{
+				Start:      0.05,
+				BucketSize: 2,
+				BucketsNum: 20,
+			},
+			FindDurationExp: HistogramConfig{
+				Start:      0.05,
+				BucketSize: 2,
+				BucketsNum: 20,
 			},
 		},
 	}
@@ -123,6 +134,8 @@ type Common struct {
 type MonitoringConfig struct {
 	RequestDurationExp      HistogramConfig `yaml:"requestDurationExpHistogram"`
 	RequestDurationLin      HistogramConfig `yaml:"requestDurationLinHistogram"`
+	RenderDurationExp       HistogramConfig `yaml:"renderDurationExpHistogram"`
+	FindDurationExp         HistogramConfig `yaml:"findDurationExpHistogram"`
 	TimeInQueueExpHistogram HistogramConfig `yaml:"timeInQueueExpHistogram"`
 	TimeInQueueLinHistogram HistogramConfig `yaml:"timeInQueueLinHistogram"`
 }

--- a/cfg/common_test.go
+++ b/cfg/common_test.go
@@ -45,6 +45,14 @@ monitoring:
         start: 0.0
         bucketsNum: 30
         bucketSize: 0.03
+    renderDurationExpHistogram:
+        start: 0.03
+        bucketsNum: 30
+        bucketSize: 6
+    findDurationExpHistogram:
+        start: 0.06
+        bucketsNum: 60
+        bucketSize: 3
 
 `
 
@@ -101,6 +109,16 @@ monitoring:
 				Start:      0.0,
 				BucketSize: 0.03,
 				BucketsNum: 30,
+			},
+			RenderDurationExp: HistogramConfig{
+				Start:      0.03,
+				BucketsNum: 30,
+				BucketSize: 6,
+			},
+			FindDurationExp: HistogramConfig{
+				Start:      0.06,
+				BucketsNum: 60,
+				BucketSize: 3,
 			},
 		},
 	}

--- a/pkg/backend/net/net.go
+++ b/pkg/backend/net/net.go
@@ -332,6 +332,7 @@ func (b Backend) Render(ctx context.Context, request types.RenderRequest) ([]typ
 	contentType, resp, err := b.call(ctx, request.Trace, u, body)
 	if err != nil {
 		if ctx.Err() != nil {
+			// TODO (grzkv): This is wrong
 			return nil, types.ErrTimeout{Err: ctx.Err()}
 		}
 
@@ -459,6 +460,7 @@ func (b Backend) Find(ctx context.Context, request types.FindRequest) (types.Mat
 	contentType, resp, err := b.call(ctx, request.Trace, u, body)
 	if err != nil {
 		if ctx.Err() != nil {
+			// TODO (grzkv): This is wrong
 			return types.Matches{}, types.ErrTimeout{Err: ctx.Err()}
 		}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -25,12 +25,15 @@ var (
 	ErrInfoNotFound    = ErrNotFound("No information found")
 )
 
+// ErrNotFound signals the HTTP not found error
 type ErrNotFound string
 
+// Error makes ErrNotFound compliant with the error interface
 func (err ErrNotFound) Error() string {
 	return string(err)
 }
 
+// ErrTimeout signifies the HTTP timeout error
 type ErrTimeout struct {
 	Err error
 }
@@ -314,6 +317,7 @@ type Matches struct {
 	Matches []Match
 }
 
+// Match describes a single glob match
 type Match struct {
 	Path   string
 	IsLeaf bool


### PR DESCRIPTION
Added separate request duration histograms for `/find` and `/render` endpoints both in `carbonapi` and `carbonzipper`. This will allow us to draw better insights and have better visibility.

This resolves #79 