### PR TITLE
Allow application/octet-stream to be used as protobuf content type

### DIFF
--- a/pkg/backend/net/net.go
+++ b/pkg/backend/net/net.go
@@ -350,7 +350,7 @@ func (b Backend) Render(ctx context.Context, request types.RenderRequest) ([]typ
 	var metrics []types.Metric
 
 	switch contentType {
-	case "application/x-protobuf", "application/protobuf":
+	case "application/x-protobuf", "application/protobuf", "application/octet-stream":
 		metrics, err = carbonapi_v2.RenderDecoder(resp)
 
 		/* TODO(gmagnusson)
@@ -478,7 +478,7 @@ func (b Backend) Find(ctx context.Context, request types.FindRequest) (types.Mat
 	var matches types.Matches
 
 	switch contentType {
-	case "application/x-protobuf", "application/protobuf":
+	case "application/x-protobuf", "application/protobuf", "application/octet-stream":
 		matches, err = carbonapi_v2.FindDecoder(resp)
 
 	/* TODO(gmagnusson)
@@ -489,8 +489,8 @@ func (b Backend) Find(ctx context.Context, request types.FindRequest) (types.Mat
 	case "application/x-msgpack":
 
 	case "application/x-carbonapi-v3-pb":
+	TODO (grzkv): This is rather hypothetical
 	*/
-
 	default:
 		return types.Matches{}, errors.Errorf("Unknown content type '%s'", contentType)
 	}


### PR DESCRIPTION
This fixes #34 both for `carbonapi` and `zipper`.