### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ Install cairo:
 ```
 brew install Caskroom/cask/xquartz
 
-brew install cairo --with-x11
+brew install cairo
 ```
-
+Xquartz is a required dependency for cairo.
 
 ## Acknowledgement and history
 


### PR DESCRIPTION
Remove the no longer supported with-x11 flag while installing latest cairo on mac.