### PR TITLE
Second stage of error-related refactoring

### DIFF
--- a/app/carbonapi/app_test.go
+++ b/app/carbonapi/app_test.go
@@ -8,9 +8,8 @@ import (
 
 	"github.com/bookingcom/carbonapi/cache"
 	"github.com/bookingcom/carbonapi/cfg"
-	"github.com/bookingcom/carbonapi/pkg/backend"
 	"github.com/bookingcom/carbonapi/pkg/backend/mock"
-	dataTypes "github.com/bookingcom/carbonapi/pkg/types"
+	types "github.com/bookingcom/carbonapi/pkg/types"
 	"github.com/bookingcom/carbonapi/pkg/types/encoding/json"
 
 	"github.com/lomik/zapwriter"
@@ -19,24 +18,24 @@ import (
 
 var testApp *App
 
-func find(ctx context.Context, request dataTypes.FindRequest) (dataTypes.Matches, error) {
+func find(ctx context.Context, request types.FindRequest) (types.Matches, error) {
 	return getMetricGlobResponse(request.Query), nil
 }
 
-func info(ctx context.Context, request dataTypes.InfoRequest) ([]dataTypes.Info, error) {
+func info(ctx context.Context, request types.InfoRequest) ([]types.Info, error) {
 	return getMockInfoResponse(), nil
 }
 
-func getMockInfoResponse() []dataTypes.Info {
-	return []dataTypes.Info{
-		dataTypes.Info{
+func getMockInfoResponse() []types.Info {
+	return []types.Info{
+		types.Info{
 			Host:              "http://127.0.0.1:8080",
 			Name:              "foo.bar",
 			AggregationMethod: "Average",
 			MaxRetention:      157680000,
 			XFilesFactor:      0.5,
-			Retentions: []dataTypes.Retention{
-				dataTypes.Retention{
+			Retentions: []types.Retention{
+				types.Retention{
 					SecondsPerPoint: 60,
 					NumberOfPoints:  43200,
 				},
@@ -45,9 +44,9 @@ func getMockInfoResponse() []dataTypes.Info {
 	}
 }
 
-func render(ctx context.Context, request dataTypes.RenderRequest) ([]dataTypes.Metric, error) {
-	return []dataTypes.Metric{
-		dataTypes.Metric{
+func render(ctx context.Context, request types.RenderRequest) ([]types.Metric, error) {
+	return []types.Metric{
+		types.Metric{
 			Name:      "foo.bar",
 			StartTime: 1510913280,
 			StopTime:  1510913880,
@@ -58,31 +57,31 @@ func render(ctx context.Context, request dataTypes.RenderRequest) ([]dataTypes.M
 	}, nil
 }
 
-func getMetricGlobResponse(metric string) dataTypes.Matches {
-	match := dataTypes.Match{
+func getMetricGlobResponse(metric string) types.Matches {
+	match := types.Match{
 		Path:   metric,
 		IsLeaf: true,
 	}
 
 	switch metric {
 	case "foo.bar*":
-		return dataTypes.Matches{
+		return types.Matches{
 			Name:    "foo.bar",
-			Matches: []dataTypes.Match{match},
+			Matches: []types.Match{match},
 		}
 
 	case "foo.bar":
-		return dataTypes.Matches{
+		return types.Matches{
 			Name:    "foo.bar",
-			Matches: []dataTypes.Match{match},
+			Matches: []types.Match{match},
 		}
 
 	case "foo.b*":
-		return dataTypes.Matches{
+		return types.Matches{
 			Name: "foo.b",
-			Matches: []dataTypes.Match{
+			Matches: []types.Match{
 				match,
-				dataTypes.Match{
+				types.Match{
 					Path:   "foo.bat",
 					IsLeaf: true,
 				},
@@ -90,7 +89,7 @@ func getMetricGlobResponse(metric string) dataTypes.Matches {
 		}
 	}
 
-	return dataTypes.Matches{}
+	return types.Matches{}
 }
 
 func init() {
@@ -112,13 +111,11 @@ func setUpTestConfig() *App {
 		findCache:         cache.NewExpireCache(1000),
 		prometheusMetrics: newPrometheusMetrics(config),
 	}
-	app.backends = []backend.Backend{
-		mock.New(mock.Config{
-			Find:   find,
-			Info:   info,
-			Render: render,
-		}),
-	}
+	app.backend = mock.New(mock.Config{
+		Find:   find,
+		Info:   info,
+		Render: render,
+	})
 
 	app.config.ConcurrencyLimitPerServer = 1024
 

--- a/cfg/api.go
+++ b/cfg/api.go
@@ -83,6 +83,8 @@ type API struct {
 	// It should probably refer to the common one
 	Zipper `yaml:",inline"`
 
+	// TODO (grzkv): Move backends list to a single backend here
+
 	ExtrapolateExperiment   bool          `yaml:"extrapolateExperiment"`
 	SendGlobsAsIs           bool          `yaml:"sendGlobsAsIs"`
 	AlwaysSendGlobsAsIs     bool          `yaml:"alwaysSendGlobsAsIs"`

--- a/pkg/backend/rpc.go
+++ b/pkg/backend/rpc.go
@@ -78,12 +78,6 @@ func Renders(ctx context.Context, backends []Backend, request types.RenderReques
 	return types.MergeMetrics(msgs), errs
 }
 
-// Render makes Render calls to a single backend.
-func Render(ctx context.Context, b Backend, request types.RenderRequest) ([]types.Metric, error) {
-	request.IncCall()
-	return b.Render(ctx, request)
-}
-
 // Infos makes Info calls to multiple backends.
 func Infos(ctx context.Context, backends []Backend, request types.InfoRequest) ([]types.Info, error) {
 	if len(backends) == 0 {

--- a/pkg/backend/rpc.go
+++ b/pkg/backend/rpc.go
@@ -78,6 +78,12 @@ func Renders(ctx context.Context, backends []Backend, request types.RenderReques
 	return types.MergeMetrics(msgs), errs
 }
 
+// Render makes Render calls to a single backend.
+func Render(ctx context.Context, b Backend, request types.RenderRequest) ([]types.Metric, error) {
+	request.IncCall()
+	return b.Render(ctx, request)
+}
+
 // Infos makes Info calls to multiple backends.
 func Infos(ctx context.Context, backends []Backend, request types.InfoRequest) ([]types.Info, error) {
 	if len(backends) == 0 {


### PR DESCRIPTION
1. Refactored `api` from having multiple back-end semantics but using only one to having single back-end semantics
2. This allowed to remove some obsolete code: filters, checks, etc.
3. The error logic in `api` became much simpler, clearer, and easier to handle
4. `200` is returned for not found; not found is returned when back-end returns not found