### PR TITLE
Fixed version for go 1.11.X to be 1.11.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ after_success:
 matrix:
   include:
     - go: 1.10.x
-    - go: 1.11.x
+    - go: 1.11.6


### PR DESCRIPTION
The *gcc* linking with `cgo` fails on go version `1.11.7`, but succeeds on `1.11.6`. This fixes the used `1.11.X` version to be `1.11.6`. This should fix all the failing CI.