### PR TITLE
Added metrics for context cancellation counting

### DIFF
--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -116,6 +116,7 @@ func (app *App) registerPrometheusMetrics(logger *zap.Logger) {
 		prometheus.MustRegister(app.prometheusMetrics.Requests)
 		prometheus.MustRegister(app.prometheusMetrics.Responses)
 		prometheus.MustRegister(app.prometheusMetrics.FindNotFound)
+		prometheus.MustRegister(app.prometheusMetrics.RequestCancel)
 		prometheus.MustRegister(app.prometheusMetrics.DurationExp)
 		prometheus.MustRegister(app.prometheusMetrics.DurationLin)
 		prometheus.MustRegister(app.prometheusMetrics.RenderDurationExp)

--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bookingcom/carbonapi/expr/functions/cairo/png"
 	"github.com/bookingcom/carbonapi/expr/metadata"
 	"github.com/bookingcom/carbonapi/expr/types"
+	"github.com/bookingcom/carbonapi/pkg/backend/net"
 	"github.com/bookingcom/carbonapi/pkg/parser"
 	dataTypes "github.com/bookingcom/carbonapi/pkg/types"
 	"github.com/bookingcom/carbonapi/pkg/types/encoding/carbonapi_v2"
@@ -256,6 +257,10 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 			for i := 0; i < len(renderRequests); i++ {
 				resp := <-rch
 				if resp.error != nil {
+					if e, ok := resp.error.(net.ErrContextCancel); ok {
+						app.prometheusMetrics.RequestCancel.WithLabelValues("render", e.CancelCause()).Inc()
+					}
+
 					errors = append(errors, resp.error)
 					continue
 				}
@@ -545,6 +550,9 @@ func (app *App) resolveGlobs(ctx context.Context, metric string, useCache bool, 
 	request.IncCall()
 	matches, err := app.backend.Find(ctx, request)
 	if err != nil {
+		if e, ok := err.(net.ErrContextCancel); ok {
+			app.prometheusMetrics.RequestCancel.WithLabelValues("find", e.CancelCause()).Inc()
+		}
 		return matches, err
 	}
 
@@ -643,6 +651,10 @@ func (app *App) findHandler(w http.ResponseWriter, r *http.Request) {
 			// returned a 404 code to Prometheus.
 			app.prometheusMetrics.FindNotFound.Inc()
 		} else {
+			if e, ok := err.(net.ErrContextCancel); ok {
+				app.prometheusMetrics.RequestCancel.WithLabelValues("find", e.CancelCause()).Inc()
+			}
+
 			msg := "error fetching the data"
 			code := http.StatusInternalServerError
 
@@ -811,6 +823,10 @@ func (app *App) infoHandler(w http.ResponseWriter, r *http.Request) {
 	request.IncCall()
 	infos, err := app.backend.Info(ctx, request)
 	if err != nil {
+		if e, ok := err.(net.ErrContextCancel); ok {
+			app.prometheusMetrics.RequestCancel.WithLabelValues("info", e.CancelCause()).Inc()
+		}
+
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		accessLogDetails.HttpCode = http.StatusInternalServerError
 		accessLogDetails.Reason = err.Error()

--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -258,7 +258,8 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 				resp := <-rch
 				if resp.error != nil {
 					if e, ok := resp.error.(net.ErrContextCancel); ok {
-						app.prometheusMetrics.RequestCancel.WithLabelValues("render", e.CancelCause()).Inc()
+						app.prometheusMetrics.RequestCancel.WithLabelValues(
+							"render", net.ContextCancelCause(e.Err)).Inc()
 					}
 
 					errors = append(errors, resp.error)
@@ -551,7 +552,8 @@ func (app *App) resolveGlobs(ctx context.Context, metric string, useCache bool, 
 	matches, err := app.backend.Find(ctx, request)
 	if err != nil {
 		if e, ok := err.(net.ErrContextCancel); ok {
-			app.prometheusMetrics.RequestCancel.WithLabelValues("find", e.CancelCause()).Inc()
+			app.prometheusMetrics.RequestCancel.WithLabelValues("find",
+				net.ContextCancelCause(e.Err)).Inc()
 		}
 		return matches, err
 	}
@@ -652,7 +654,8 @@ func (app *App) findHandler(w http.ResponseWriter, r *http.Request) {
 			app.prometheusMetrics.FindNotFound.Inc()
 		} else {
 			if e, ok := err.(net.ErrContextCancel); ok {
-				app.prometheusMetrics.RequestCancel.WithLabelValues("find", e.CancelCause()).Inc()
+				app.prometheusMetrics.RequestCancel.WithLabelValues("find",
+					net.ContextCancelCause(e.Err)).Inc()
 			}
 
 			msg := "error fetching the data"
@@ -824,7 +827,7 @@ func (app *App) infoHandler(w http.ResponseWriter, r *http.Request) {
 	infos, err := app.backend.Info(ctx, request)
 	if err != nil {
 		if e, ok := err.(net.ErrContextCancel); ok {
-			app.prometheusMetrics.RequestCancel.WithLabelValues("info", e.CancelCause()).Inc()
+			app.prometheusMetrics.RequestCancel.WithLabelValues("info", net.ContextCancelCause(e.Err)).Inc()
 		}
 
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/app/carbonapi/metrics.go
+++ b/app/carbonapi/metrics.go
@@ -12,6 +12,7 @@ type PrometheusMetrics struct {
 	Requests          prometheus.Counter
 	Responses         *prometheus.CounterVec
 	FindNotFound      prometheus.Counter
+	RequestCancel     *prometheus.CounterVec
 	DurationExp       prometheus.Histogram
 	DurationLin       prometheus.Histogram
 	RenderDurationExp prometheus.Histogram
@@ -40,6 +41,13 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 				Name: "find_not_found",
 				Help: "Count of not-found /find responses",
 			},
+		),
+		RequestCancel: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "request_cancel",
+				Help: "Context cancellations or incoming requests due to manual cancels or timeouts",
+			},
+			[]string{"handler", "cause"},
 		),
 		DurationExp: prometheus.NewHistogram(
 			prometheus.HistogramOpts{

--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -234,6 +234,7 @@ func metricsServer(app *App, logger *zap.Logger) {
 	prometheus.MustRegister(app.prometheusMetrics.Requests)
 	prometheus.MustRegister(app.prometheusMetrics.Responses)
 	prometheus.MustRegister(app.prometheusMetrics.FindNotFound)
+	prometheus.MustRegister(app.prometheusMetrics.RequestCancel)
 	prometheus.MustRegister(app.prometheusMetrics.DurationExp)
 	prometheus.MustRegister(app.prometheusMetrics.DurationLin)
 	prometheus.MustRegister(app.prometheusMetrics.RenderDurationExp)

--- a/app/carbonzipper/metrics.go
+++ b/app/carbonzipper/metrics.go
@@ -58,6 +58,7 @@ type PrometheusMetrics struct {
 	Requests          prometheus.Counter
 	Responses         *prometheus.CounterVec
 	FindNotFound      prometheus.Counter
+	RequestCancel     *prometheus.CounterVec
 	DurationExp       prometheus.Histogram
 	DurationLin       prometheus.Histogram
 	RenderDurationExp prometheus.Histogram
@@ -87,6 +88,13 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 				Name: "find_not_found",
 				Help: "Count of not-found /find responses",
 			},
+		),
+		RequestCancel: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "request_cancel",
+				Help: "Context cancellations or incoming requests due to manual cancels or timeouts",
+			},
+			[]string{"handler", "cause"},
 		),
 		DurationExp: prometheus.NewHistogram(
 			prometheus.HistogramOpts{

--- a/pkg/backend/net/net_test.go
+++ b/pkg/backend/net/net_test.go
@@ -59,7 +59,7 @@ func TestContains(t *testing.T) {
 		return
 	}
 
-	b.paths.Set("foo", struct{}{}, 0, 30)
+	b.cache.Set("foo", struct{}{}, 0, 30)
 
 	if ok := b.Contains([]string{"foo"}); !ok {
 		t.Error("Expected true")
@@ -81,7 +81,7 @@ func TestContains(t *testing.T) {
 		t.Error("Expected false")
 	}
 
-	b.paths = expirecache.New(0)
+	b.cache = expirecache.New(0)
 	if ok := b.Contains([]string{"foo"}); ok {
 		t.Error("Expected false")
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -17,8 +17,10 @@ import (
 )
 
 var (
+	// TODO (grzkv): Remove from global scope and to metrics package
 	corruptionThreshold = 1.0
-	corruptionLogger    = zap.New(nil)
+	// TODO (grzkv): Remove from global scope and to metrics package
+	corruptionLogger = zap.New(nil)
 
 	ErrMetricsNotFound = ErrNotFound("No metrics returned")
 	ErrMatchesNotFound = ErrNotFound("No matches found")
@@ -31,15 +33,6 @@ type ErrNotFound string
 // Error makes ErrNotFound compliant with the error interface
 func (err ErrNotFound) Error() string {
 	return string(err)
-}
-
-// ErrTimeout signifies the HTTP timeout error
-type ErrTimeout struct {
-	Err error
-}
-
-func (err ErrTimeout) Error() string {
-	return err.Err.Error()
 }
 
 func SetCorruptionWatcher(threshold float64, logger *zap.Logger) {
@@ -88,6 +81,8 @@ func NewRenderRequest(targets []string, from int32, until int32) RenderRequest {
 		Trace:   NewTrace(),
 	}
 }
+
+// TODO (grzkv): Move to a separate package
 
 type Trace struct {
 	callCount     *int64
@@ -180,6 +175,8 @@ with an implementation
 
 The interface would probably need to have a Merge(other) method as well.
 */
+
+// TODO (grzkv): Move to a separate package
 
 // Metric represents a part of a time series.
 type Metric struct {


### PR DESCRIPTION
Added *Prometheus* metrics to count context cancels due to timeouts or manual cancels:

- in `api` it counts request cancels both for main request and sub-requests to `zipper`
- in `zipper` it counts main request context cancels. It is to be decided how to count partial cancels in multiple requests to backends