### PR TITLE
Fix builds without cairo

### DIFF
--- a/expr/functions/cairo/png/pixel_ratio.go
+++ b/expr/functions/cairo/png/pixel_ratio.go
@@ -1,4 +1,5 @@
 // +build cairo
+
 package png
 
 import "github.com/evmar/gocairo/cairo"

--- a/expr/functions/cairo/png/pixel_ratio.go
+++ b/expr/functions/cairo/png/pixel_ratio.go
@@ -1,3 +1,4 @@
+// +build cairo
 package png
 
 import "github.com/evmar/gocairo/cairo"


### PR DESCRIPTION
I'm not a golang developer, but after a lot of fighting with the build,
I *think* this restores the option to build this without libcairo.