### PR TITLE
Continuation of errors refactoring

### DIFF
--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -431,7 +431,7 @@ func (app *App) deferredAccessLogging(r *http.Request, accessLogDetails *carbona
 		apiMetrics.Errors.Add(1)
 	} else {
 		// TODO (grzkv) The code can differ from the real one. Clean up
-		accessLogDetails.HttpCode = http.StatusOK
+		// accessLogDetails.HttpCode = http.StatusOK
 		accessLogger.Info("request served", zap.Any("data", *accessLogDetails))
 		apiMetrics.Responses.Add(1)
 	}

--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -214,7 +214,7 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 	if totalErr != nil {
 		toLog.Reason = totalErr.Error()
 		if _, ok := totalErr.(dataTypes.ErrNotFound); ok {
-			w.WriteHeader(http.StatusNotFound)
+			http.Error(w, totalErr.Error(), http.StatusNotFound)
 			toLog.HttpCode = http.StatusNotFound
 			logAsError = true
 		} else {
@@ -227,12 +227,8 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 
 	body, err := app.renderWriteBody(results, form, r, logger)
 	if err != nil {
-		logger.Error("request failed",
-			zap.Int("http_code", http.StatusInternalServerError),
-			zap.String("reason", err.Error()),
-			zap.Duration("runtime", time.Since(t0)),
-		)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		toLog.Reason = err.Error()
 		toLog.HttpCode = http.StatusInternalServerError
 		logAsError = true
 		return
@@ -554,7 +550,6 @@ func targetErrsFanIn(errs []error, n int) error {
 		errStr = errStr + e.Error()
 		if _, ok := e.(dataTypes.ErrNotFound); !ok {
 			allErrorsNotFound = false
-			break
 		}
 	}
 

--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -66,10 +66,10 @@ func (app *App) validateRequest(h http.Handler, handler string) http.HandlerFunc
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		blockingRules := app.blockHeaderRules.Load().(RuleConfig)
 		if shouldBlockRequest(r, blockingRules.Rules) {
-			accessLogDetails := carbonapipb.NewAccessLogDetails(r, handler, &app.config)
-			accessLogDetails.HttpCode = http.StatusForbidden
+			toLog := carbonapipb.NewAccessLogDetails(r, handler, &app.config)
+			toLog.HttpCode = http.StatusForbidden
 			defer func() {
-				app.deferredAccessLogging(r, &accessLogDetails, t0, true)
+				app.deferredAccessLogging(r, &toLog, t0, true)
 			}()
 			w.WriteHeader(http.StatusForbidden)
 		} else {
@@ -137,7 +137,7 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	toLog := carbonapipb.NewAccessLogDetails(r, "render", &app.config)
-	// TODO (grzkv): Pass logger from above
+	// TODO (grzkv): Replace with access logger
 	logger := zapwriter.Logger("render").With(
 		zap.String("carbonapi_uuid", util.GetUUID(ctx)),
 		zap.String("username", toLog.Username),
@@ -194,14 +194,23 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 	// TODO (grzkv) Modification of *form* inside the loop is never applied
 	for _, target := range form.targets {
 		// TODO (grzkv): Log UUID wherever possible
-		targetErr, metricSize := app.getTargetData(ctx, target, metricMap, &results, &form, &toLog, logger)
+		exp, e, err := parser.ParseExpr(target)
+		if err != nil || e != "" {
+			msg := buildParseErrorString(target, e, err)
+			http.Error(w, msg, http.StatusBadRequest)
+			toLog.Reason = msg
+			toLog.HttpCode = http.StatusBadRequest
+			logAsError = true
+			return
+		}
+		targetErr, metricSize := app.getTargetData(ctx, target, exp, metricMap, &results, &form, &toLog, logger)
 		if targetErr != nil {
 			targetErrs = append(targetErrs, targetErr)
 		}
 		size += metricSize
 	}
 
-	totalErr := optimistFanIn(targetErrs, len(form.targets))
+	totalErr := targetErrsFanIn(targetErrs, len(form.targets))
 	if totalErr != nil {
 		toLog.Reason = totalErr.Error()
 		if _, ok := totalErr.(dataTypes.ErrNotFound); ok {
@@ -237,6 +246,8 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 		td := time.Since(tc).Nanoseconds()
 		apiMetrics.RenderCacheOverheadNS.Add(td)
 	}
+
+	toLog.HttpCode = http.StatusOK
 }
 
 func evalExprRender(exp parser.Expr, res *([]*types.MetricData), metricMap map[parser.MetricRequest][]*types.MetricData,
@@ -257,14 +268,11 @@ func evalExprRender(exp parser.Expr, res *([]*types.MetricData), metricMap map[p
 	return nil
 }
 
-func (app *App) getTargetData(ctx context.Context, target string, metricMap map[parser.MetricRequest][]*types.MetricData,
-	results *([]*types.MetricData), form *renderForm, toLog *carbonapipb.AccessLogDetails, lg *zap.Logger) (error, int) {
+func (app *App) getTargetData(ctx context.Context, target string, exp parser.Expr,
+	metricMap map[parser.MetricRequest][]*types.MetricData, results *([]*types.MetricData),
+	form *renderForm, toLog *carbonapipb.AccessLogDetails, lg *zap.Logger) (error, int) {
 
 	size := 0
-	exp, e, err := parser.ParseExpr(target)
-	if err != nil || e != "" {
-		return errors.New(buildParseErrorString(target, e, err)), size
-	}
 
 	var targetMetricFetches []parser.MetricRequest
 	var metricErrs []error
@@ -328,7 +336,7 @@ func (app *App) getTargetData(ctx context.Context, target string, metricMap map[
 	var rewritten bool
 	var newTargets []string
 	logStepTimeMismatch(targetMetricFetches, metricMap, lg, target)
-	rewritten, newTargets, err = expr.RewriteExpr(exp, form.from32, form.until32, metricMap)
+	rewritten, newTargets, err := expr.RewriteExpr(exp, form.from32, form.until32, metricMap)
 	if err != nil && err != parser.ErrSeriesDoesNotExist {
 		return errors.Wrap(err, "expression rewrite failed"), size
 	}
@@ -366,10 +374,10 @@ func pessimistFanIn(errs []error) error {
 	}
 
 	if allErrorsNotFound {
-		return dataTypes.ErrNotFound("all returned not found")
+		return dataTypes.ErrNotFound("all returned not found: " + errStr)
 	}
 
-	return errors.Errorf("failed with mixed errrors: %s", errStr)
+	return errors.New("failed with mixed errrors" + errStr)
 }
 
 func (app *App) sendRenderRequest(ctx context.Context, ch chan<- renderResponse,
@@ -528,7 +536,7 @@ func (app *App) renderWriteBody(results []*types.MetricData, form renderForm, r 
 	return body, nil
 }
 
-func optimistFanIn(errs []error, n int) error {
+func targetErrsFanIn(errs []error, n int) error {
 	nErrs := len(errs)
 	if nErrs == 0 {
 		return nil
@@ -541,7 +549,9 @@ func optimistFanIn(errs []error, n int) error {
 	// everything failed.
 	// If all the failures are not-founds, it's a not-found
 	allErrorsNotFound := true
+	errStr := ""
 	for _, e := range errs {
+		errStr = errStr + e.Error()
 		if _, ok := e.(dataTypes.ErrNotFound); !ok {
 			allErrorsNotFound = false
 			break
@@ -549,10 +559,10 @@ func optimistFanIn(errs []error, n int) error {
 	}
 
 	if allErrorsNotFound {
-		return dataTypes.ErrNotFound("all returned not found")
+		return dataTypes.ErrNotFound("all targets not found: " + errStr)
 	}
 
-	return errors.New("all failed with mixed errrors")
+	return errors.New("all targets failed with mixed errrors: " + errStr)
 }
 
 func (app *App) sendGlobs(glob dataTypes.Matches) bool {
@@ -617,19 +627,19 @@ func (app *App) resolveGlobs(ctx context.Context, metric string, useCache bool, 
 	return matches, nil
 }
 
-func (app *App) getRenderRequests(ctx context.Context, m parser.MetricRequest, useCache bool, accessLogDetails *carbonapipb.AccessLogDetails, logger *zap.Logger) ([]string, error) {
+func (app *App) getRenderRequests(ctx context.Context, m parser.MetricRequest, useCache bool, toLog *carbonapipb.AccessLogDetails, logger *zap.Logger) ([]string, error) {
 	if app.config.AlwaysSendGlobsAsIs {
-		accessLogDetails.SendGlobs = true
+		toLog.SendGlobs = true
 		return []string{m.Metric}, nil
 	}
 
-	glob, err := app.resolveGlobs(ctx, m.Metric, useCache, accessLogDetails, logger)
+	glob, err := app.resolveGlobs(ctx, m.Metric, useCache, toLog, logger)
 	if err != nil {
 		return nil, err
 	}
 
 	if app.sendGlobs(glob) {
-		accessLogDetails.SendGlobs = true
+		toLog.SendGlobs = true
 		return []string{m.Metric}, nil
 	}
 
@@ -656,17 +666,17 @@ func (app *App) findHandler(w http.ResponseWriter, r *http.Request) {
 	jsonp := r.FormValue("jsonp")
 	query := r.FormValue("query")
 
-	accessLogDetails := carbonapipb.NewAccessLogDetails(r, "find", &app.config)
+	toLog := carbonapipb.NewAccessLogDetails(r, "find", &app.config)
 
 	// TODO (grzkv): Pass logger in from above
 	logger := zapwriter.Logger("find").With(
 		zap.String("carbonapi_uuid", util.GetUUID(ctx)),
-		zap.String("username", accessLogDetails.Username),
+		zap.String("username", toLog.Username),
 	)
 
 	logAsError := false
 	defer func() {
-		app.deferredAccessLogging(r, &accessLogDetails, t0, logAsError)
+		app.deferredAccessLogging(r, &toLog, t0, logAsError)
 	}()
 
 	if format == "completer" {
@@ -679,8 +689,8 @@ func (app *App) findHandler(w http.ResponseWriter, r *http.Request) {
 
 	if query == "" {
 		http.Error(w, "missing parameter `query`", http.StatusBadRequest)
-		accessLogDetails.HttpCode = http.StatusBadRequest
-		accessLogDetails.Reason = "missing parameter `query`"
+		toLog.HttpCode = http.StatusBadRequest
+		toLog.Reason = "missing parameter `query`"
 		logAsError = true
 		return
 	}
@@ -709,8 +719,8 @@ func (app *App) findHandler(w http.ResponseWriter, r *http.Request) {
 			msg := "error fetching the data"
 			code := http.StatusInternalServerError
 
-			accessLogDetails.HttpCode = int32(code)
-			accessLogDetails.Reason = err.Error()
+			toLog.HttpCode = int32(code)
+			toLog.Reason = err.Error()
 			logAsError = true
 
 			http.Error(w, msg, code)
@@ -748,8 +758,8 @@ func (app *App) findHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError),
 			http.StatusInternalServerError)
-		accessLogDetails.HttpCode = http.StatusInternalServerError
-		accessLogDetails.Reason = err.Error()
+		toLog.HttpCode = http.StatusInternalServerError
+		toLog.Reason = err.Error()
 		logAsError = true
 		return
 	}
@@ -764,6 +774,8 @@ func (app *App) findHandler(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", contentType)
 		w.Write(blob)
 	}
+
+	toLog.HttpCode = http.StatusOK
 }
 
 func getCompleterQuery(query string) string {
@@ -854,19 +866,19 @@ func (app *App) infoHandler(w http.ResponseWriter, r *http.Request) {
 		format = jsonFormat
 	}
 
-	accessLogDetails := carbonapipb.NewAccessLogDetails(r, "info", &app.config)
-	accessLogDetails.Format = format
+	toLog := carbonapipb.NewAccessLogDetails(r, "info", &app.config)
+	toLog.Format = format
 
 	logAsError := false
 	defer func() {
-		app.deferredAccessLogging(r, &accessLogDetails, t0, logAsError)
+		app.deferredAccessLogging(r, &toLog, t0, logAsError)
 	}()
 
 	query := r.FormValue("target")
 	if query == "" {
 		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
-		accessLogDetails.HttpCode = http.StatusBadRequest
-		accessLogDetails.Reason = "no target specified"
+		toLog.HttpCode = http.StatusBadRequest
+		toLog.Reason = "no target specified"
 		logAsError = true
 		return
 	}
@@ -880,8 +892,8 @@ func (app *App) infoHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		accessLogDetails.HttpCode = http.StatusInternalServerError
-		accessLogDetails.Reason = err.Error()
+		toLog.HttpCode = http.StatusInternalServerError
+		toLog.Reason = err.Error()
 		logAsError = true
 		return
 	}
@@ -901,8 +913,8 @@ func (app *App) infoHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		accessLogDetails.HttpCode = http.StatusInternalServerError
-		accessLogDetails.Reason = err.Error()
+		toLog.HttpCode = http.StatusInternalServerError
+		toLog.Reason = err.Error()
 		logAsError = true
 		return
 	}
@@ -910,7 +922,8 @@ func (app *App) infoHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", contentType)
 	w.Write(b)
 
-	accessLogDetails.Runtime = time.Since(t0).Seconds()
+	toLog.Runtime = time.Since(t0).Seconds()
+	toLog.HttpCode = http.StatusOK
 }
 
 func (app *App) lbcheckHandler(w http.ResponseWriter, r *http.Request) {
@@ -925,10 +938,11 @@ func (app *App) lbcheckHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Write([]byte("Ok\n"))
 
-	accessLogDetails := carbonapipb.NewAccessLogDetails(r, "lbcheck", &app.config)
-	accessLogDetails.Runtime = time.Since(t0).Seconds()
+	toLog := carbonapipb.NewAccessLogDetails(r, "lbcheck", &app.config)
+	toLog.Runtime = time.Since(t0).Seconds()
+	toLog.HttpCode = http.StatusOK
 	// TODO (grzkv): Pass logger from above
-	zapwriter.Logger("access").Info("request served", zap.Any("data", accessLogDetails))
+	zapwriter.Logger("access").Info("request served", zap.Any("data", toLog))
 }
 
 func (app *App) versionHandler(w http.ResponseWriter, r *http.Request) {
@@ -953,10 +967,10 @@ func (app *App) versionHandler(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("1.0.0\n"))
 	}
 
-	accessLogDetails := carbonapipb.NewAccessLogDetails(r, "version", &app.config)
-	accessLogDetails.Runtime = time.Since(t0).Seconds()
+	toLog := carbonapipb.NewAccessLogDetails(r, "version", &app.config)
+	toLog.Runtime = time.Since(t0).Seconds()
 	// TODO (grzkv): Pass logger from above
-	zapwriter.Logger("access").Info("request served", zap.Any("data", accessLogDetails))
+	zapwriter.Logger("access").Info("request served", zap.Any("data", toLog))
 }
 
 func (app *App) functionsHandler(w http.ResponseWriter, r *http.Request) {
@@ -966,18 +980,18 @@ func (app *App) functionsHandler(w http.ResponseWriter, r *http.Request) {
 	apiMetrics.Requests.Add(1)
 	app.prometheusMetrics.Requests.Inc()
 
-	accessLogDetails := carbonapipb.NewAccessLogDetails(r, "functions", &app.config)
+	toLog := carbonapipb.NewAccessLogDetails(r, "functions", &app.config)
 
 	logAsError := false
 	defer func() {
-		app.deferredAccessLogging(r, &accessLogDetails, t0, logAsError)
+		app.deferredAccessLogging(r, &toLog, t0, logAsError)
 	}()
 
 	err := r.ParseForm()
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusBadRequest)+": "+err.Error(), http.StatusBadRequest)
-		accessLogDetails.HttpCode = http.StatusBadRequest
-		accessLogDetails.Reason = err.Error()
+		toLog.HttpCode = http.StatusBadRequest
+		toLog.Reason = err.Error()
 		logAsError = true
 		return
 	}
@@ -1060,15 +1074,15 @@ func (app *App) functionsHandler(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		accessLogDetails.HttpCode = http.StatusInternalServerError
-		accessLogDetails.Reason = err.Error()
+		toLog.HttpCode = http.StatusInternalServerError
+		toLog.Reason = err.Error()
 		logAsError = true
 		return
 	}
 
 	w.Write(b)
-	accessLogDetails.Runtime = time.Since(t0).Seconds()
-	accessLogDetails.HttpCode = http.StatusOK
+	toLog.Runtime = time.Since(t0).Seconds()
+	toLog.HttpCode = http.StatusOK
 }
 
 // Add block rules on the basis of headers to block certain requests
@@ -1083,11 +1097,11 @@ func (app *App) blockHeaders(w http.ResponseWriter, r *http.Request) {
 
 	apiMetrics.Requests.Add(1)
 
-	accessLogDetails := carbonapipb.NewAccessLogDetails(r, "blockHeaders", &app.config)
+	toLog := carbonapipb.NewAccessLogDetails(r, "blockHeaders", &app.config)
 
 	logAsError := false
 	defer func() {
-		app.deferredAccessLogging(r, &accessLogDetails, t0, logAsError)
+		app.deferredAccessLogging(r, &toLog, t0, logAsError)
 	}()
 
 	queryParams := r.URL.Query()
@@ -1104,7 +1118,7 @@ func (app *App) blockHeaders(w http.ResponseWriter, r *http.Request) {
 	failResponse := []byte(`{"success":"false"}`)
 	if app.config.BlockHeaderFile == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		accessLogDetails.HttpCode = http.StatusBadRequest
+		toLog.HttpCode = http.StatusBadRequest
 		w.Write(failResponse)
 		return
 	}
@@ -1123,11 +1137,13 @@ func (app *App) blockHeaders(w http.ResponseWriter, r *http.Request) {
 
 	if len(m) == 0 || err1 != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		accessLogDetails.HttpCode = http.StatusBadRequest
+		toLog.HttpCode = http.StatusBadRequest
 		w.Write(failResponse)
 		return
 	}
 	w.Write([]byte(`{"success":"true"}`))
+
+	toLog.HttpCode = http.StatusOK
 }
 
 func appendRuleToConfig(ruleConfig RuleConfig, m Rule, logger *zap.Logger, blockHeaderFile string) error {
@@ -1156,22 +1172,24 @@ func writeBlockRuleToFile(output []byte, blockHeaderFile string) error {
 func (app *App) unblockHeaders(w http.ResponseWriter, r *http.Request) {
 	t0 := time.Now()
 	apiMetrics.Requests.Add(1)
-	accessLogDetails := carbonapipb.NewAccessLogDetails(r, "unblockHeaders", &app.config)
+	toLog := carbonapipb.NewAccessLogDetails(r, "unblockHeaders", &app.config)
 
 	logAsError := false
 	defer func() {
-		app.deferredAccessLogging(r, &accessLogDetails, t0, logAsError)
+		app.deferredAccessLogging(r, &toLog, t0, logAsError)
 	}()
 
 	w.Header().Set("Content-Type", contentTypeJSON)
 	err := os.Remove(app.config.BlockHeaderFile)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		accessLogDetails.HttpCode = http.StatusBadRequest
+		toLog.HttpCode = http.StatusBadRequest
 		w.Write([]byte(`{"success":"false"}`))
 		return
 	}
 	w.Write([]byte(`{"success":"true"}`))
+
+	toLog.HttpCode = http.StatusOK
 }
 
 func isBlockingHeaderRule(r *http.Request, rule Rule) bool {

--- a/app/carbonapi/http_handlers_test.go
+++ b/app/carbonapi/http_handlers_test.go
@@ -153,7 +153,7 @@ func TestOptimistErrsFanIn(t *testing.T) {
 
 	for _, tst := range tests {
 		t.Run(tst.name, func(t *testing.T) {
-			err := optimistFanIn(tst.in, tst.n)
+			err := targetErrsFanIn(tst.in, tst.n)
 
 			if err != nil {
 				if !tst.isErr {

--- a/carbonapipb/carbonapi.pb.go
+++ b/carbonapipb/carbonapi.pb.go
@@ -8,6 +8,8 @@ import (
 	"github.com/bookingcom/carbonapi/util"
 )
 
+// TODO (grzkv) All this seems to be in a completely wron package
+
 type AccessLogDetails struct {
 	Handler                       string            `json:"handler,omitempty"`
 	CarbonapiUuid                 string            `json:"carbonapi_uuid,omitempty"`
@@ -36,6 +38,7 @@ type AccessLogDetails struct {
 	Tz                            string            `json:"tz,omitempty"`
 	FromRaw                       string            `json:"from_raw,omitempty"`
 	UntilRaw                      string            `json:"until_raw,omitempty"`
+	Path                          string            `json:"path,omitempty"`
 	Uri                           string            `json:"uri,omitempty"`
 	FromCache                     bool              `json:"from_cache"`
 	ZipperRequests                int64             `json:"zipper_requests,omitempty"`
@@ -61,13 +64,16 @@ func NewAccessLogDetails(r *http.Request, handler string, config *cfg.API) Acces
 		Username:      username,
 		CarbonapiUuid: util.GetUUID(r.Context()),
 		HeadersData:   getHeadersData(r, config.HeadersToLog),
-		Url:           r.URL.RequestURI(),
+		Url:           r.URL.String(),
 		PeerIp:        srcIP,
 		PeerPort:      srcPort,
 		Host:          r.Host,
+		Path:          r.URL.Path,
 		Referer:       r.Referer(),
-		Uri:           r.RequestURI,
-		HttpCode:      http.StatusOK,
+		// TODO (grzkv) Do we need this?
+		Uri: r.RequestURI,
+		// 0 means the code is not specified
+		HttpCode: 0,
 	}
 }
 


### PR DESCRIPTION
- some expression parsing cases are treated as wrong reqeusts now in ender handler in api
- added additional error info
- fixed http code logging: by default there is no code; substituting code for 200 disabled
- generic refactoring