### PR TITLE
Gysingh/zipper tld

### DIFF
--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -537,6 +537,7 @@ func initBackend(config cfg.API, logger *zap.Logger) (backend.Backend, error) {
 		Timeout:            config.Timeouts.AfterStarted,
 		Limit:              config.ConcurrencyLimitPerServer,
 		PathCacheExpirySec: uint32(config.ExpireDelaySec),
+		TLDExpirySec:       uint32(config.InternalRoutingCache),
 		Logger:             logger,
 	})
 

--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -537,7 +537,6 @@ func initBackend(config cfg.API, logger *zap.Logger) (backend.Backend, error) {
 		Timeout:            config.Timeouts.AfterStarted,
 		Limit:              config.ConcurrencyLimitPerServer,
 		PathCacheExpirySec: uint32(config.ExpireDelaySec),
-		TLDExpirySec:       uint32(config.InternalRoutingCache),
 		Logger:             logger,
 	})
 

--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -188,7 +188,6 @@ func initBackends(config cfg.Zipper, logger *zap.Logger) ([]backend.Backend, err
 			Timeout:            config.Timeouts.AfterStarted,
 			Limit:              config.ConcurrencyLimitPerServer,
 			PathCacheExpirySec: uint32(config.ExpireDelaySec),
-			TLDExpirySec:       uint32(2 * config.InternalRoutingCache),
 			Logger:             logger,
 		})
 

--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -56,7 +56,7 @@ func New(config cfg.Zipper, logger *zap.Logger, buildVersion string) (*App, erro
 		config:            config,
 		prometheusMetrics: NewPrometheusMetrics(config),
 		backends:          bs,
-		probeTicker:       time.NewTicker(300 * time.Second),
+		probeTicker:       time.NewTicker(time.Duration(config.InternalRoutingCache) * time.Second),
 		ProbeQuit:         make(chan struct{}),
 		ProbeForce:        make(chan int),
 	}
@@ -199,6 +199,7 @@ func initBackends(config cfg.Zipper, logger *zap.Logger) ([]backend.Backend, err
 			Timeout:            config.Timeouts.AfterStarted,
 			Limit:              config.ConcurrencyLimitPerServer,
 			PathCacheExpirySec: uint32(config.ExpireDelaySec),
+			TLDExpirySec:       uint32(config.InternalRoutingCache),
 			Logger:             logger,
 		})
 

--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -199,7 +199,7 @@ func initBackends(config cfg.Zipper, logger *zap.Logger) ([]backend.Backend, err
 			Timeout:            config.Timeouts.AfterStarted,
 			Limit:              config.ConcurrencyLimitPerServer,
 			PathCacheExpirySec: uint32(config.ExpireDelaySec),
-			TLDExpirySec:       uint32(config.InternalRoutingCache),
+			TLDExpirySec:       uint32(2 * config.InternalRoutingCache),
 			Logger:             logger,
 		})
 

--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/bookingcom/carbonapi/pkg/backend"
@@ -499,7 +500,7 @@ func (app *App) lbCheckHandler(w http.ResponseWriter, req *http.Request) {
 func (app *App) filterBackendByTopLevelDomain(targets []string) []backend.Backend {
 	targetTlds := make([]string, 0, len(targets))
 	for _, target := range targets {
-		targetTlds = append(targetTlds, backend.GetTLD(target))
+		targetTlds = append(targetTlds, getTopLevelDomain(target))
 	}
 
 	bs := app.filterByTopLevelDomain(app.backends, targetTlds)
@@ -507,6 +508,10 @@ func (app *App) filterBackendByTopLevelDomain(targets []string) []backend.Backen
 		return bs
 	}
 	return app.backends
+}
+
+func getTopLevelDomain(target string) string {
+	return strings.SplitN(target, ".", 2)[0]
 }
 
 func (app *App) filterByTopLevelDomain(backends []backend.Backend, targetTLDs []string) []backend.Backend {

--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -80,7 +80,8 @@ func (app *App) findHandler(w http.ResponseWriter, req *http.Request) {
 	)
 
 	request := types.NewFindRequest(originalQuery)
-	bs := backend.Filter(app.backends, []string{originalQuery})
+	bs := app.filterBackendByTopLevelDomain([]string{originalQuery})
+	bs = backend.Filter(bs, []string{originalQuery})
 	metrics, errs := backend.Finds(ctx, bs, request)
 	err := errorsFanIn(ctx, errs, len(bs))
 
@@ -268,7 +269,8 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	request := types.NewRenderRequest([]string{target}, int32(from), int32(until))
-	bs := backend.Filter(app.backends, request.Targets)
+	bs := app.filterBackendByTopLevelDomain(request.Targets)
+	bs = backend.Filter(bs, request.Targets)
 	metrics, errs := backend.Renders(ctx, bs, request)
 	err = errorsFanIn(ctx, errs, len(bs))
 
@@ -412,7 +414,8 @@ func (app *App) infoHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	request := types.NewInfoRequest(target)
-	bs := backend.Filter(app.backends, []string{target})
+	bs := app.filterBackendByTopLevelDomain([]string{target})
+	bs = backend.Filter(bs, []string{target})
 	infos, errs := backend.Infos(ctx, bs, request)
 	err = errorsFanIn(ctx, errs, len(bs))
 	if err != nil {
@@ -491,6 +494,50 @@ func (app *App) lbCheckHandler(w http.ResponseWriter, req *http.Request) {
 	Metrics.Responses.Add(1)
 	app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusOK),
 		"lbcheck").Inc()
+}
+
+func (app *App) filterBackendByTopLevelDomain(targets []string) []backend.Backend {
+	targetTlds := make([]string, 0, len(targets))
+	for _, target := range targets {
+		targetTlds = append(targetTlds, backend.GetTLD(target))
+	}
+
+	bs := app.filterByTopLevelDomain(app.backends, targetTlds)
+	if len(bs) > 0 {
+		return bs
+	}
+	return app.backends
+}
+
+func (app *App) filterByTopLevelDomain(backends []backend.Backend, targetTLDs []string) []backend.Backend {
+	bs := make([]backend.Backend, 0)
+	allTLDBackends := make([]*backend.Backend, 0)
+
+	topLevelDomainCache, _ := app.topLevelDomainCache.Get("tlds")
+	tldCache := make(map[string][]*backend.Backend)
+	if x, ok := topLevelDomainCache.(map[string][]*backend.Backend); ok {
+		tldCache = x
+	}
+
+	if tldCache == nil {
+		return backends
+	}
+	alreadyAddedBackends := make(map[string]bool)
+	for _, target := range targetTLDs {
+		tldBackends := tldCache[target]
+		for _, backend := range tldBackends {
+			a := *backend
+			if !alreadyAddedBackends[a.GetServerAddress()] {
+				alreadyAddedBackends[a.GetServerAddress()] = true
+				allTLDBackends = append(allTLDBackends, backend)
+			}
+		}
+	}
+	for _, tldBackend := range allTLDBackends {
+		bs = append(bs, *tldBackend)
+	}
+
+	return bs
 }
 
 func errorsFanIn(ctx context.Context, errs []error, numBackends int) error {

--- a/cfg/common.go
+++ b/cfg/common.go
@@ -50,7 +50,8 @@ func DefaultCommonConfig() Common {
 		KeepAliveInterval:         30 * time.Second,
 		MaxIdleConnsPerHost:       100,
 
-		ExpireDelaySec: int32(10 * time.Minute / time.Second),
+		ExpireDelaySec:       int32(10 * time.Minute / time.Second),
+		InternalRoutingCache: int32(5 * time.Minute / time.Second),
 
 		Buckets: 10,
 		Graphite: GraphiteConfig{
@@ -120,6 +121,7 @@ type Common struct {
 	MaxIdleConnsPerHost       int           `yaml:"maxIdleConnsPerHost"`
 
 	ExpireDelaySec             int32   `yaml:"expireDelaySec"`
+	InternalRoutingCache       int32   `yaml:"internalRoutingCache"`
 	GraphiteWeb09Compatibility bool    `yaml:"graphite09compat"`
 	CorruptionThreshold        float64 `yaml:"corruptionThreshold"`
 

--- a/pkg/backend/mock/mock.go
+++ b/pkg/backend/mock/mock.go
@@ -101,3 +101,7 @@ func New(cfg Config) Backend {
 func (b Backend) Contains(targets []string) bool {
 	return b.contains(targets)
 }
+
+func (b Backend) GetTLD() map[string]bool {
+	return nil
+}

--- a/pkg/backend/mock/mock.go
+++ b/pkg/backend/mock/mock.go
@@ -64,11 +64,6 @@ func (b Backend) Logger() *zap.Logger {
 	return noLog
 }
 
-// Probe is a no-op.
-func (b Backend) Probe() []string {
-	return nil
-}
-
 // New creates a new mock backend.
 func New(cfg Config) Backend {
 	b := Backend{}

--- a/pkg/backend/mock/mock.go
+++ b/pkg/backend/mock/mock.go
@@ -104,10 +104,6 @@ func (b Backend) Contains(targets []string) bool {
 	return b.contains(targets)
 }
 
-func (b Backend) GetTLD() map[string]bool {
-	return nil
-}
-
 func (b Backend) GetServerAddress() string {
 	return ""
 }

--- a/pkg/backend/mock/mock.go
+++ b/pkg/backend/mock/mock.go
@@ -65,7 +65,9 @@ func (b Backend) Logger() *zap.Logger {
 }
 
 // Probe is a no-op.
-func (b Backend) Probe() {}
+func (b Backend) Probe() []string {
+	return nil
+}
 
 // New creates a new mock backend.
 func New(cfg Config) Backend {
@@ -104,4 +106,8 @@ func (b Backend) Contains(targets []string) bool {
 
 func (b Backend) GetTLD() map[string]bool {
 	return nil
+}
+
+func (b Backend) GetServerAddress() string {
+	return ""
 }

--- a/pkg/backend/net/net.go
+++ b/pkg/backend/net/net.go
@@ -71,7 +71,6 @@ type Backend struct {
 	limiter           chan struct{}
 	logger            *zap.Logger
 	cache             *expirecache.Cache
-	tldCache          *expirecache.Cache
 	cacheExpirySec    int32
 	cacheTLDExpirySec int32
 }
@@ -98,20 +97,13 @@ var fmtProto = []string{"protobuf"}
 // New creates a new backend from the given configuration.
 func New(cfg Config) (*Backend, error) {
 	b := &Backend{
-		cache:    expirecache.New(0),
-		tldCache: expirecache.New(0),
+		cache: expirecache.New(0),
 	}
 
 	if cfg.PathCacheExpirySec > 0 {
 		b.cacheExpirySec = int32(cfg.PathCacheExpirySec)
 	} else {
 		b.cacheExpirySec = int32(10 * time.Minute / time.Second)
-	}
-
-	if cfg.TLDExpirySec > 0 {
-		b.cacheTLDExpirySec = int32(cfg.TLDExpirySec)
-	} else {
-		b.cacheTLDExpirySec = 86400
 	}
 
 	address, scheme, err := parseAddress(cfg.Address)
@@ -166,14 +158,6 @@ func (b Backend) url(path string) *url.URL {
 		Host:   b.address,
 		Path:   path,
 	}
-}
-
-func (b Backend) GetTLD() map[string]bool {
-	x, _ := b.tldCache.Get("tlds")
-	if y, ok := x.(map[string]bool); ok {
-		return y
-	}
-	return nil
 }
 
 func (b Backend) GetServerAddress() string {

--- a/pkg/backend/net/net.go
+++ b/pkg/backend/net/net.go
@@ -64,15 +64,14 @@ func ContextCancelCause(err error) string {
 
 // Backend represents a host that accepts requests for metrics over HTTP.
 type Backend struct {
-	address           string
-	scheme            string
-	client            *http.Client
-	timeout           time.Duration
-	limiter           chan struct{}
-	logger            *zap.Logger
-	cache             *expirecache.Cache
-	cacheExpirySec    int32
-	cacheTLDExpirySec int32
+	address        string
+	scheme         string
+	client         *http.Client
+	timeout        time.Duration
+	limiter        chan struct{}
+	logger         *zap.Logger
+	cache          *expirecache.Cache
+	cacheExpirySec int32
 }
 
 // Config configures an HTTP backend.
@@ -88,7 +87,6 @@ type Config struct {
 	Timeout            time.Duration // Set request timeout. Defaults to no timeout.
 	Limit              int           // Set limit of concurrent requests to backend. Defaults to no limit.
 	PathCacheExpirySec uint32        // Set time in seconds before items in path cache expire. Defaults to 10 minutes.
-	TLDExpirySec       uint32        // Set time in seconds before items in tld cache expire.
 	Logger             *zap.Logger   // Logger to use. Defaults to a no-op logger.
 }
 

--- a/pkg/backend/net/net.go
+++ b/pkg/backend/net/net.go
@@ -313,23 +313,6 @@ func (b Backend) call(ctx context.Context, trace types.Trace, u *url.URL, body i
 	return b.do(ctx, trace, req)
 }
 
-// Probe returns the backend's top-level domains.
-func (b *Backend) Probe() []string {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	request := types.NewFindRequest("*")
-	matches, err := b.Find(ctx, request)
-	if err != nil {
-		return nil
-	}
-	var paths []string
-	for _, m := range matches.Matches {
-		paths = append(paths, m.Path)
-	}
-	return paths
-}
-
 // TODO(gmagnusson): Should Contains become something different, where instead
 // of answering yes/no to whether the backend contains any of the given
 // targets, it returns a filtered list of targets that the backend contains?

--- a/pkg/backend/rpc.go
+++ b/pkg/backend/rpc.go
@@ -31,7 +31,6 @@ type Backend interface {
 
 	Contains([]string) bool // Reports whether a backend contains any of the given targets.
 	Logger() *zap.Logger    // A logger used to communicate non-fatal warnings.
-	Probe() []string        // Probe updates internal state of the backend.
 	GetServerAddress() string
 }
 

--- a/pkg/backend/rpc.go
+++ b/pkg/backend/rpc.go
@@ -32,8 +32,9 @@ type Backend interface {
 
 	Contains([]string) bool // Reports whether a backend contains any of the given targets.
 	Logger() *zap.Logger    // A logger used to communicate non-fatal warnings.
-	Probe()                 // Probe updates internal state of the backend.
+	Probe() []string        // Probe updates internal state of the backend.
 	GetTLD() map[string]bool
+	GetServerAddress() string
 }
 
 // TODO(gmagnusson): ^ Remove IsAbsent: IsAbsent[i] => Values[i] == NaN
@@ -144,24 +145,15 @@ func Finds(ctx context.Context, backends []Backend, request types.FindRequest) (
 	return types.MergeMatches(msgs), errs
 }
 
-func getTLD(metric string) string {
+func GetTLD(metric string) string {
 	return strings.SplitN(metric, ".", 2)[0]
 }
 
 // Filter filters the given backends by whether they Contain() the given targets.
 func Filter(backends []Backend, targets []string) []Backend {
-	targetTlds := make([]string, 0, len(targets))
-	for _, target := range targets {
-		targetTlds = append(targetTlds, getTLD(target))
-	}
-
-	if bs := filterByTLD(backends, targetTlds); len(bs) > 0 {
-		backends = bs
-	}
 	if bs := filter(backends, targets); len(bs) > 0 {
 		return bs
 	}
-
 	return backends
 }
 

--- a/pkg/backend/rpc.go
+++ b/pkg/backend/rpc.go
@@ -17,7 +17,6 @@ package backend
 
 import (
 	"context"
-	"strings"
 
 	"github.com/bookingcom/carbonapi/pkg/types"
 
@@ -33,7 +32,6 @@ type Backend interface {
 	Contains([]string) bool // Reports whether a backend contains any of the given targets.
 	Logger() *zap.Logger    // A logger used to communicate non-fatal warnings.
 	Probe() []string        // Probe updates internal state of the backend.
-	GetTLD() map[string]bool
 	GetServerAddress() string
 }
 
@@ -143,10 +141,6 @@ func Finds(ctx context.Context, backends []Backend, request types.FindRequest) (
 	}
 
 	return types.MergeMatches(msgs), errs
-}
-
-func GetTLD(metric string) string {
-	return strings.SplitN(metric, ".", 2)[0]
 }
 
 // Filter filters the given backends by whether they Contain() the given targets.

--- a/pkg/backend/rpc.go
+++ b/pkg/backend/rpc.go
@@ -167,17 +167,3 @@ func filter(backends []Backend, targets []string) []Backend {
 
 	return bs
 }
-
-func filterByTLD(backends []Backend, targetTLDs []string) []Backend {
-	bs := make([]Backend, 0)
-	for _, b := range backends {
-		backendTLDs := b.GetTLD()
-		for _, target := range targetTLDs {
-			if backendTLDs[target] {
-				bs = append(bs, b)
-				break
-			}
-		}
-	}
-	return bs
-}


### PR DESCRIPTION
Sets up probes to cache tld for each backend store in zipper. This enables cutting down unnecessary requests.