### PR TITLE
limit max time duration and response size for upstream query

### DIFF
--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -538,6 +538,7 @@ func initBackend(config cfg.API, logger *zap.Logger) (backend.Backend, error) {
 		Limit:              config.ConcurrencyLimitPerServer,
 		PathCacheExpirySec: uint32(config.ExpireDelaySec),
 		Logger:             logger,
+		MaxSize:            config.Limits.MaxSize,
 	})
 
 	if err != nil {

--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -168,6 +168,13 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 		logAsError = true
 		return
 	}
+	if app.config.Limits.MaxDuration > 0 && form.from32+app.config.Limits.MaxDuration < form.until32 { // Limit duration (from/until)
+		http.Error(w, "Too long time range", http.StatusBadRequest)
+		toLog.HttpCode = http.StatusBadRequest
+		toLog.Reason = "Too long time range"
+		logAsError = true
+		return
+	}
 
 	if form.useCache {
 		tc := time.Now()

--- a/cfg/api.go
+++ b/cfg/api.go
@@ -52,6 +52,11 @@ func ParseAPIConfig(r io.Reader) (API, error) {
 		api.Backends = pre.Upstreams.Backends
 	}
 
+	if pre.Upstreams.Limits != defaultCfg.Limits {
+		api.Limits = pre.Upstreams.Limits
+		api.Limits.MaxDuration *= 3600 * 24
+	}
+
 	return api, nil
 }
 

--- a/cfg/api_test.go
+++ b/cfg/api_test.go
@@ -143,6 +143,9 @@ upstreams:
         connect: "200ms"
         global: "600s"
         afterStarted: "600s"
+    limits:
+        maxSize: 1048576
+        maxDuration: 1825
     concurrencyLimit: 1024
     keepAliveInterval: "30s"
     maxIdleConnsPerHost: 1024
@@ -165,7 +168,8 @@ logger:
 	expected := API{
 		Zipper: Zipper{
 			Common: Common{
-				Listen: ":8081",
+				Listen:         ":8081",
+				ListenInternal: ":7080",
 				Backends: []string{
 					"http://localhost:8000",
 				},
@@ -175,6 +179,10 @@ logger:
 					Global:       10 * time.Minute,
 					AfterStarted: 10 * time.Minute,
 					Connect:      200 * time.Millisecond,
+				},
+				Limits: Limits{
+					MaxSize:     1048576,
+					MaxDuration: 1825 * 24 * 3600,
 				},
 				ConcurrencyLimitPerServer: 1024,
 				KeepAliveInterval:         30 * time.Second,

--- a/cfg/common.go
+++ b/cfg/common.go
@@ -46,6 +46,10 @@ func DefaultCommonConfig() Common {
 			AfterStarted: 2 * time.Second,
 			Connect:      200 * time.Millisecond,
 		},
+		Limits: Limits{
+			MaxSize:     0,
+			MaxDuration: 0,
+		},
 		ConcurrencyLimitPerServer: 20,
 		KeepAliveInterval:         30 * time.Second,
 		MaxIdleConnsPerHost:       100,
@@ -115,6 +119,7 @@ type Common struct {
 
 	MaxProcs                  int           `yaml:"maxProcs"`
 	Timeouts                  Timeouts      `yaml:"timeouts"`
+	Limits                    Limits        `yaml:"limits"`
 	ConcurrencyLimitPerServer int           `yaml:"concurrencyLimit"`
 	KeepAliveInterval         time.Duration `yaml:"keepAliveInterval"`
 	MaxIdleConnsPerHost       int           `yaml:"maxIdleConnsPerHost"`
@@ -152,4 +157,10 @@ type Timeouts struct {
 	Global       time.Duration `yaml:"global"`
 	AfterStarted time.Duration `yaml:"afterStarted"`
 	Connect      time.Duration `yaml:"connect"`
+}
+
+// Limits for query upstream
+type Limits struct {
+	MaxSize     int   `yaml:"maxSize"`
+	MaxDuration int32 `yaml:"maxDuration"`
 }

--- a/cfg/common_test.go
+++ b/cfg/common_test.go
@@ -75,6 +75,10 @@ monitoring:
 			AfterStarted: 15 * time.Second,
 			Connect:      200 * time.Millisecond,
 		},
+		Limits: Limits{
+			MaxSize:     0,
+			MaxDuration: 0,
+		},
 		ConcurrencyLimitPerServer: 2048,
 		KeepAliveInterval:         30 * time.Second,
 		MaxIdleConnsPerHost:       1024,
@@ -132,6 +136,7 @@ type comparableCommon struct {
 	Listen                     string
 	MaxProcs                   int
 	Timeouts                   Timeouts
+	Limits                     Limits
 	ConcurrencyLimitPerServer  int
 	KeepAliveInterval          time.Duration
 	MaxIdleConnsPerHost        int
@@ -146,6 +151,7 @@ func toComparableCommon(a Common) comparableCommon {
 		Listen:                     a.Listen,
 		MaxProcs:                   a.MaxProcs,
 		Timeouts:                   a.Timeouts,
+		Limits:                     a.Limits,
 		ConcurrencyLimitPerServer:  a.ConcurrencyLimitPerServer,
 		KeepAliveInterval:          a.KeepAliveInterval,
 		MaxIdleConnsPerHost:        a.MaxIdleConnsPerHost,

--- a/config/carbonapi.yaml
+++ b/config/carbonapi.yaml
@@ -91,6 +91,13 @@ upstreams:
     # Control http.MaxIdleConnsPerHost. Large values can lead to more idle
     # connections on the backend servers which may bump into limits; tune with care.
     maxIdleConnsPerHost: 1030
+
+    limits:
+#    # Limit maximum responce size from upstream (in bytes)
+#        maxSize: 1048576
+#    # Limit maximum time duration for request (beetween from/until) (in DAYS !!)
+#        maxDuration: 1825
+
     backends:
       - http://zipper:8000
 


### PR DESCRIPTION
Limits for upstream query:
maxDuration - limit from/until time duration (for protect  from malformed requests with incorrect timestamps)
maxSize - limit for upstream response size