### PR TITLE
updated documentation build steps with pkg-config note

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ To build the binaries with debug symbols, run:
 make debug
 ```
 
+Note: build process requires pkg-config to be installed:
+
+### Mac OS X
+
+```
+curl https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.tar.gz -o pkgconfig.tgz
+tar -zxf pkgconfig.tgz && cd pkg-config-0.29
+```
+There is a circular dependency between pkg-config and glib. To break it, pkg-config includes a version of glib, which is enough to break the dependency cycle and compile it with  --with-internal-glib key:
+
+```
+env LDFLAGS="-framework CoreFoundation -framework Carbon" ./configure --with-internal-glib && make install
+```
+
 We do not provide packages for install at this time. Contact us if you're
 interested in those.
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,14 @@ To build the binaries with debug symbols, run:
 make debug
 ```
 
-Note: build process requires pkg-config to be installed:
+**Note**: build process might require pkg-config to be installed:
 
 ### Mac OS X
 
+find pkg-config version on you want to install and run script below with replaced "VERSION_TO_INSTALL":
 ```
-curl https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.tar.gz -o pkgconfig.tgz
-tar -zxf pkgconfig.tgz && cd pkg-config-0.29
+PKG_CONFIG_VERSION="VERSION_TO_INSTALL" bash -c 'curl https://pkgconfig.freedesktop.org/releases/pkg-config-$PKG_CONFIG_VERSION.tar.gz -o pkgconfig.tgz'
+mkdir pkg-config && tar -zxf pkgconfig.tgz -C pkg-config --strip-components 1 && cd pkg-config
 ```
 There is a circular dependency between pkg-config and glib. To break it, pkg-config includes a version of glib, which is enough to break the dependency cycle and compile it with  --with-internal-glib key:
 


### PR DESCRIPTION
Build process requires pkg-config to be installed. Since it is not obvious step makes sense to include its installation steps into documentation.