### PR TITLE
fixing errors in default config to reflect the state of code

### DIFF
--- a/config/carbonapi.yaml
+++ b/config/carbonapi.yaml
@@ -62,8 +62,8 @@ graphite:
     # {prefix} will be replaced with the content of {prefix}
     # {fqdn} will be repalced with fqdn
     pattern: "{prefix}.{fqdn}"
-# Maximium idle connections to carbonzipper
-idleConnections: 10
+# Configures how often keep alive packets will be sent out
+keepAliveInterval: "30s"
 # Config to ensure we return version needed for providing integrated graphite docs in grafana
 # without supporting tags
 graphiteVersionForGrafana: 1.1.0
@@ -84,8 +84,6 @@ upstreams:
 #        connect: "200ms"
         global: "600s"
 #        afterStarted: "600s"
-    # Configures how often keep alive packets will be sent out
-    keepAliveInterval: "30s"
     # Control http.MaxIdleConnsPerHost. Large values can lead to more idle
     # connections on the backend servers which may bump into limits; tune with care.
     maxIdleConnsPerHost: 1030


### PR DESCRIPTION
removing unused idleConnections
placing keepAliveInterval from the upstreams section where it was
silently ignored the top