### PR TITLE
bringing back xFilesFactor field to json info decoder

### DIFF
--- a/app/carbonzipper/handlers_test.go
+++ b/app/carbonzipper/handlers_test.go
@@ -900,7 +900,7 @@ func TestInfoSingleBackend(t *testing.T) {
 		{
 			path: "/info?target=foo.bar",
 			code: http.StatusOK,
-			body: `{"http://127.0.0.1:8080":{"name":"foo.bar","aggregationMethod":"Average","maxRetention":157680000,"retentions":[{"secondsPerPoint":60,"numberOfPoints":43200}]}}`,
+			body: `{"http://127.0.0.1:8080":{"name":"foo.bar","aggregationMethod":"Average","maxRetention":157680000,"xFilesFactor":0.5,"retentions":[{"secondsPerPoint":60,"numberOfPoints":43200}]}}`,
 		},
 		{
 			path: "/info?target=foo.bar&format=wrongformat",

--- a/pkg/types/encoding/json/encoding.go
+++ b/pkg/types/encoding/json/encoding.go
@@ -91,6 +91,7 @@ type jsonInfo struct {
 	Name              string    `json:"name"`
 	AggregationMethod string    `json:"aggregationMethod"`
 	MaxRetention      int32     `json:"maxRetention"`
+	XFilesFactor      float32   `json:"xFilesFactor"`
 	Retentions        []jsonRet `json:"retentions"`
 }
 
@@ -108,6 +109,7 @@ func InfoEncoder(infos []types.Info) ([]byte, error) {
 			Name:              info.Name,
 			AggregationMethod: info.AggregationMethod,
 			MaxRetention:      info.MaxRetention,
+			XFilesFactor:      info.XFilesFactor,
 			Retentions:        make([]jsonRet, 0, len(info.Retentions)),
 		}
 
@@ -138,6 +140,7 @@ func InfoDecoder(blob []byte) ([]types.Info, error) {
 			Name:              info.Name,
 			AggregationMethod: info.AggregationMethod,
 			MaxRetention:      info.MaxRetention,
+			XFilesFactor:      info.XFilesFactor,
 			Retentions:        make([]types.Retention, 0, len(info.Retentions)),
 		}
 


### PR DESCRIPTION
the /info endpoint is mostly used by humans and somehow we missed
that part of reply from carbonserver which tells us a xFilesFactor of
a whisper archive. This makes said humans sad. Fixing that.