### PR TITLE
Graphite tags

### DIFF
--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -659,7 +659,7 @@ func (app *App) resolveGlobs(ctx context.Context, metric string, useCache bool, 
 
 func (app *App) getRenderRequests(ctx context.Context, m parser.MetricRequest, useCache bool,
 	toLog *carbonapipb.AccessLogDetails, logger *zap.Logger) ([]string, error) {
-	if app.config.AlwaysSendGlobsAsIs {
+	if app.config.AlwaysSendGlobsAsIs || strings.HasPrefix(m.Metric, "seriesByTag(") {
 		toLog.SendGlobs = true
 		return []string{m.Metric}, nil
 	}

--- a/app/carbonapi/routes.go
+++ b/app/carbonapi/routes.go
@@ -52,7 +52,7 @@ func initHandlers(app *App) http.Handler {
 	r.HandleFunc("/functions", httputil.TimeHandler(app.functionsHandler, app.bucketRequestTimes))
 	r.HandleFunc("/functions/", httputil.TimeHandler(app.functionsHandler, app.bucketRequestTimes))
 
-	r.HandleFunc("/tags/autoComplete/tags", httputil.TimeHandler(app.tagsHandler, app.bucketRequestTimes))
+	r.HandleFunc("/tags/autoComplete/", httputil.TimeHandler(app.tagsHandler, app.bucketRequestTimes))
 
 	r.HandleFunc("/", httputil.TimeHandler(app.usageHandler, app.bucketRequestTimes))
 

--- a/expr/functions/aliasByTags/function.go
+++ b/expr/functions/aliasByTags/function.go
@@ -1,0 +1,111 @@
+package aliasByTags
+
+import (
+	"github.com/bookingcom/carbonapi/expr/helper"
+	"github.com/bookingcom/carbonapi/expr/interfaces"
+	"github.com/bookingcom/carbonapi/expr/types"
+	"github.com/bookingcom/carbonapi/pkg/parser"
+
+	"strings"
+)
+
+const NAME = "name"
+
+type aliasByTags struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &aliasByTags{}
+	for _, n := range []string{"aliasByTags"} {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+func metricToTagMap(s string) map[string]string {
+	r := make(map[string]string)
+	for _, p := range strings.Split(s, ";") {
+		if strings.Contains(p, "=") {
+			tagValue := strings.SplitN(p, "=", 2)
+			r[tagValue[0]] = tagValue[1]
+		} else {
+			r[NAME] = p
+		}
+	}
+	return r
+}
+
+func (f *aliasByTags) Do(e parser.Expr, from, until int32, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+
+	tags, err := e.GetNodeOrTagArgs(1)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*types.MetricData
+
+	for _, a := range args {
+		var matched []string
+		metricTags := metricToTagMap(a.Name)
+		nodes := strings.Split(metricTags["name"], ".")
+		for _, tag := range tags {
+			if tag.IsTag {
+				tagStr := tag.Value.(string)
+				matched = append(matched, metricTags[tagStr])
+			} else {
+				f := tag.Value.(int)
+				if f < 0 {
+					f += len(nodes)
+				}
+				if f >= len(nodes) || f < 0 {
+					continue
+				}
+				matched = append(matched, nodes[f])
+			}
+		}
+
+		r := *a
+		if len(matched) > 0 {
+			r.Name = strings.Join(matched, ".")
+		}
+		results = append(results, &r)
+	}
+
+	return results, nil
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *aliasByTags) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"aliasByTags": {
+			Description: "Takes a seriesList and applies an alias derived from one or more tags",
+			Function:    "aliasByTags(seriesList, *tags)",
+			Group:       "Alias",
+			Module:      "graphite.render.functions",
+			Name:        "aliasByTags",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Multiple: true,
+					Name:     "tags",
+					Required: true,
+					Type:     types.NodeOrTag,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/aliasByTags/function_test.go
+++ b/expr/functions/aliasByTags/function_test.go
@@ -1,0 +1,65 @@
+package aliasByTags
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bookingcom/carbonapi/expr/helper"
+	"github.com/bookingcom/carbonapi/expr/metadata"
+	"github.com/bookingcom/carbonapi/expr/types"
+	"github.com/bookingcom/carbonapi/pkg/parser"
+	th "github.com/bookingcom/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestAliasByTags(t *testing.T) {
+	now32 := int32(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			`aliasByTags(*, "foo")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"*", 0, 1}: {types.MakeMetricData("metric1.foo.bar.baz;foo=bar;baz=bam", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("bar", []float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			`aliasByTags(*, "foo", "name")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"*", 0, 1}: {types.MakeMetricData("metric1;foo=bar", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("bar.metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			`aliasByTags(*, 2, "blah", "foo", 1)`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"*", 0, 1}: {types.MakeMetricData("base.metric1;foo=bar;baz=bam", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData(".bar.metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+		{
+			`aliasByTags(*, 2, "baz", "foo", 1)`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"*", 0, 1}: {types.MakeMetricData("base.metric1;foo=bar;baz=bam", []float64{1, 2, 3, 4, 5}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("bam.bar.metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+
+}

--- a/expr/functions/averageSeries/function.go
+++ b/expr/functions/averageSeries/function.go
@@ -18,7 +18,7 @@ func GetOrder() interfaces.Order {
 func New(configFile string) []interfaces.FunctionMetadata {
 	f := &averageSeries{}
 	res := make([]interfaces.FunctionMetadata, 0)
-	for _, n := range []string{"avg", "averageSeries"} {
+	for _, n := range []string{"avg", "average", "averageSeries"} {
 		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
 	}
 	return res

--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bookingcom/carbonapi/expr/functions/alias"
 	"github.com/bookingcom/carbonapi/expr/functions/aliasByMetric"
 	"github.com/bookingcom/carbonapi/expr/functions/aliasByNode"
+	"github.com/bookingcom/carbonapi/expr/functions/aliasByTags"
 	"github.com/bookingcom/carbonapi/expr/functions/aliasSub"
 	"github.com/bookingcom/carbonapi/expr/functions/asPercent"
 	"github.com/bookingcom/carbonapi/expr/functions/averageSeries"
@@ -31,6 +32,7 @@ import (
 	"github.com/bookingcom/carbonapi/expr/functions/grep"
 	"github.com/bookingcom/carbonapi/expr/functions/group"
 	"github.com/bookingcom/carbonapi/expr/functions/groupByNode"
+	"github.com/bookingcom/carbonapi/expr/functions/groupByTags"
 	"github.com/bookingcom/carbonapi/expr/functions/highest"
 	"github.com/bookingcom/carbonapi/expr/functions/hitcount"
 	"github.com/bookingcom/carbonapi/expr/functions/holtWintersAberration"
@@ -72,6 +74,7 @@ import (
 	"github.com/bookingcom/carbonapi/expr/functions/removeEmptySeries"
 	"github.com/bookingcom/carbonapi/expr/functions/scale"
 	"github.com/bookingcom/carbonapi/expr/functions/scaleToSeconds"
+	"github.com/bookingcom/carbonapi/expr/functions/seriesByTag"
 	"github.com/bookingcom/carbonapi/expr/functions/seriesList"
 	"github.com/bookingcom/carbonapi/expr/functions/sortBy"
 	"github.com/bookingcom/carbonapi/expr/functions/sortByName"
@@ -107,6 +110,8 @@ func New(configs map[string]string) {
 	funcs = append(funcs, initFunc{name: "aliasByMetric", order: aliasByMetric.GetOrder(), f: aliasByMetric.New})
 
 	funcs = append(funcs, initFunc{name: "aliasByNode", order: aliasByNode.GetOrder(), f: aliasByNode.New})
+
+	funcs = append(funcs, initFunc{name: "aliasByTags", order: aliasByTags.GetOrder(), f: aliasByTags.New})
 
 	funcs = append(funcs, initFunc{name: "aliasSub", order: aliasSub.GetOrder(), f: aliasSub.New})
 
@@ -153,6 +158,8 @@ func New(configs map[string]string) {
 	funcs = append(funcs, initFunc{name: "group", order: group.GetOrder(), f: group.New})
 
 	funcs = append(funcs, initFunc{name: "groupByNode", order: groupByNode.GetOrder(), f: groupByNode.New})
+
+	funcs = append(funcs, initFunc{name: "groupByTags", order: groupByTags.GetOrder(), f: groupByTags.New})
 
 	funcs = append(funcs, initFunc{name: "highest", order: highest.GetOrder(), f: highest.New})
 
@@ -235,6 +242,8 @@ func New(configs map[string]string) {
 	funcs = append(funcs, initFunc{name: "scale", order: scale.GetOrder(), f: scale.New})
 
 	funcs = append(funcs, initFunc{name: "scaleToSeconds", order: scaleToSeconds.GetOrder(), f: scaleToSeconds.New})
+
+	funcs = append(funcs, initFunc{name: "seriesByTag", order: seriesByTag.GetOrder(), f: seriesByTag.New})
 
 	funcs = append(funcs, initFunc{name: "seriesList", order: seriesList.GetOrder(), f: seriesList.New})
 

--- a/expr/functions/groupByTags/function.go
+++ b/expr/functions/groupByTags/function.go
@@ -88,7 +88,10 @@ func (f *groupByTags) Do(e parser.Expr, from, until int32, values map[parser.Met
 			parser.MetricRequest{"stub", from, until}: v,
 		}
 
-		r, _ := f.Evaluator.EvalExpr(nexpr, from, until, nvalues)
+		r, err := f.Evaluator.EvalExpr(nexpr, from, until, nvalues)
+		if err != nil {
+			return nil, err
+		}
 		if r != nil {
 			r[0].Name = names[k] + k
 			results = append(results, r...)

--- a/expr/functions/groupByTags/function.go
+++ b/expr/functions/groupByTags/function.go
@@ -1,0 +1,130 @@
+package groupByTags
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/bookingcom/carbonapi/expr/helper"
+	"github.com/bookingcom/carbonapi/expr/interfaces"
+	"github.com/bookingcom/carbonapi/expr/types"
+	"github.com/bookingcom/carbonapi/pkg/parser"
+)
+
+type groupByTags struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &groupByTags{}
+	functions := []string{"groupByTags"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+// seriesByTag("name=cpu")|groupByTags("average","dc","os")
+func (f *groupByTags) Do(e parser.Expr, from, until int32, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	args, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+	callback, err := e.GetStringArg(1)
+	if err != nil {
+		return nil, err
+	}
+
+	tags, err := e.GetStringArgs(2)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(tags)
+
+	var results []*types.MetricData
+
+	names := make(map[string]string)
+	groups := make(map[string][]*types.MetricData)
+
+	// TODO(civil): Think how to optimize it, as it's ugly
+	for _, a := range args {
+		metricTags := helper.ExtractTags(a.Name)
+		var keyBuilder strings.Builder
+		for _, tag := range tags {
+			value := metricTags[tag]
+			keyBuilder.WriteString(";" + tag + "=" + value)
+		}
+		key := keyBuilder.String()
+		groups[key] = append(groups[key], a)
+
+		if name, ok := names[key]; ok {
+			if name != metricTags["name"] {
+				names[key] = callback
+			}
+		} else {
+			names[key] = metricTags["name"]
+		}
+	}
+
+	for k, v := range groups {
+		k := k // k's reference is used later, so it's important to make it unique per loop
+		v := v
+
+		expr := fmt.Sprintf("%s(stub)", callback)
+
+		// create a stub context to evaluate the callback in
+		nexpr, _, err := parser.ParseExpr(expr)
+		if err != nil {
+			return nil, err
+		}
+
+		nvalues := map[parser.MetricRequest][]*types.MetricData{
+			parser.MetricRequest{"stub", from, until}: v,
+		}
+
+		r, _ := f.Evaluator.EvalExpr(nexpr, from, until, nvalues)
+		if r != nil {
+			r[0].Name = names[k] + k
+			results = append(results, r...)
+		}
+	}
+
+	return results, nil
+}
+
+func (f *groupByTags) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"groupByTags": {
+			Description: "Takes a serieslist and maps a callback to subgroups within as defined by multiple tags\n\n.. code-block:: none\n\n  &target=seriesByTag(\"name=cpu\")|groupByTags(\"average\",\"dc\")\n\nWould return multiple series which are each the result of applying the \"averageSeries\" function\nto groups joined on the specified tags resulting in a list of targets like\n\n.. code-block :: none\n\n  averageSeries(seriesByTag(\"name=cpu\",\"dc=dc1\")),averageSeries(seriesByTag(\"name=cpu\",\"dc=dc2\")),...\n\nThis function can be used with all aggregation functions supported by\n:py:func:`aggregate <aggregate>`: ``average``, ``median``, ``sum``, ``min``, ``max``, ``diff``,\n``stddev``, ``range`` & ``multiply``.",
+			Function:    "groupByTags(seriesList, callback, *tags)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "groupByTags",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Name:     "callback",
+					Options:  helper.AvailableSummarizers,
+					Required: true,
+					Type:     types.AggFunc,
+				},
+				{
+					Name:     "tags",
+					Required: true,
+					Multiple: true,
+					Type:     types.Tag,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/groupByTags/function_test.go
+++ b/expr/functions/groupByTags/function_test.go
@@ -1,0 +1,76 @@
+package groupByTags
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bookingcom/carbonapi/expr/functions/sum"
+	"github.com/bookingcom/carbonapi/expr/helper"
+	"github.com/bookingcom/carbonapi/expr/metadata"
+	"github.com/bookingcom/carbonapi/expr/types"
+	"github.com/bookingcom/carbonapi/pkg/parser"
+	th "github.com/bookingcom/carbonapi/tests"
+)
+
+func init() {
+	s := sum.New("")
+	for _, m := range s {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+	md := New("")
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+
+	evaluator := th.EvaluatorFromFuncWithMetadata(metadata.FunctionMD.Functions)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+}
+
+func TestGroupByNode(t *testing.T) {
+	now32 := int32(time.Now().Unix())
+
+	tests := []th.MultiReturnEvalTestItem{
+		{
+			`groupByTags(metric1.foo.*, "sum", "dc")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.foo.*", 0, 1}: {
+					types.MakeMetricData("metric1.foo;cpu=cpu1;dc=dc1", []float64{1, 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric1.foo;cpu=cpu2;dc=dc1", []float64{6, 7, 8, 9, 10}, 1, now32),
+					types.MakeMetricData("metric1.foo;cpu=cpu3;dc=dc1", []float64{11, 12, 13, 14, 15}, 1, now32),
+					types.MakeMetricData("metric1.foo;cpu=cpu4;dc=dc1", []float64{7, 8, 9, 10, 11}, 1, now32),
+				},
+			},
+			"groupByTags",
+			map[string][]*types.MetricData{
+				"metric1.foo;dc=dc1": {types.MakeMetricData("metric1.foo;dc=dc1", []float64{25, 29, 33, 37, 41}, 1, now32)},
+			},
+		},
+		{
+			`groupByTags(metric1.foo.*, "sum", "dc", "cpu", "rack")`,
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1.foo.*", 0, 1}: {
+					types.MakeMetricData("metric1.foo;cpu=cpu1;dc=dc1", []float64{1, 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric1.foo;cpu=cpu2;dc=dc1", []float64{6, 7, 8, 9, 10}, 1, now32),
+					types.MakeMetricData("metric1.foo;cpu=cpu3;dc=dc1", []float64{11, 12, 13, 14, 15}, 1, now32),
+					types.MakeMetricData("metric1.foo;cpu=cpu4;dc=dc1", []float64{7, 8, 9, 10, 11}, 1, now32),
+				},
+			},
+			"groupByTags",
+			map[string][]*types.MetricData{
+				"metric1.foo;cpu=cpu1;dc=dc1;rack=": {types.MakeMetricData("metric1.foo;cpu=cpu1;dc=dc1;rack=", []float64{1, 2, 3, 4, 5}, 1, now32)},
+				"metric1.foo;cpu=cpu2;dc=dc1;rack=": {types.MakeMetricData("metric1.foo;cpu=cpu2;dc=dc1;rack=", []float64{6, 7, 8, 9, 10}, 1, now32)},
+				"metric1.foo;cpu=cpu3;dc=dc1;rack=": {types.MakeMetricData("metric1.foo;cpu=cpu3;dc=dc1;rack=", []float64{11, 12, 13, 14, 15}, 1, now32)},
+				"metric1.foo;cpu=cpu4;dc=dc1;rack=": {types.MakeMetricData("metric1.foo;cpu=cpu4;dc=dc1;rack=", []float64{7, 8, 9, 10, 11}, 1, now32)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestMultiReturnEvalExpr(t, &tt)
+		})
+	}
+
+}

--- a/expr/functions/seriesByTag/function.go
+++ b/expr/functions/seriesByTag/function.go
@@ -1,0 +1,55 @@
+package seriesByTag
+
+import (
+	"github.com/bookingcom/carbonapi/expr/interfaces"
+	"github.com/bookingcom/carbonapi/expr/types"
+	"github.com/bookingcom/carbonapi/pkg/parser"
+)
+
+type seriesByTag struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &seriesByTag{}
+	for _, n := range []string{"seriesByTag"} {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+func (f *seriesByTag) Do(e parser.Expr, from, until int32, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	var results []*types.MetricData
+	key := parser.MetricRequest{Metric: e.ToString(), From: from, Until: until}
+	data, ok := values[key]
+	if !ok {
+		return results, nil
+	}
+	return data, nil
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *seriesByTag) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"seriesByTag": {
+			Description: "Returns a SeriesList of series matching all the specified tag expressions.\n\nExample:\n\n.. code-block:: none\n\n  &target=seriesByTag(\"tag1=value1\",\"tag2!=value2\")\n\nReturns a seriesList of all series that have tag1 set to value1, AND do not have tag2 set to value2.\n\nTags specifiers are strings, and may have the following formats:\n\n.. code-block:: none\n\n  tag=spec    tag value exactly matches spec\n  tag!=spec   tag value does not exactly match spec\n  tag=~value  tag value matches the regular expression spec\n  tag!=~spec  tag value does not match the regular expression spec\n\nAny tag spec that matches an empty value is considered to match series that don't have that tag.\n\nAt least one tag spec must require a non-empty value.\n\nRegular expression conditions are treated as being anchored at the start of the value.\n\nSee :ref:`querying tagged series <querying-tagged-series>` for more detail.",
+			Function:    "seriesByTag(*tagExpressions)",
+			Group:       "Special",
+			Module:      "graphite.render.functions",
+			Name:        "seriesByTag",
+			Params: []types.FunctionParam{
+				{
+					Name:     "tagExpressions",
+					Required: true,
+					Type:     types.String,
+					Multiple: true,
+				},
+			},
+		},
+	}
+}

--- a/expr/helper/helper_test.go
+++ b/expr/helper/helper_test.go
@@ -1,0 +1,153 @@
+package helper
+
+import (
+	"math"
+	"testing"
+)
+
+func TestExtractTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		metric   string
+		expected map[string]string
+	}{
+		{
+			name:   "tagged metric",
+			metric: "cpu.usage_idle;cpu=cpu-total;host=test",
+			expected: map[string]string{
+				"name": "cpu.usage_idle",
+				"cpu":  "cpu-total",
+				"host": "test",
+			},
+		},
+		{
+			name:   "no tags in metric",
+			metric: "cpu.usage_idle",
+			expected: map[string]string{
+				"name": "cpu.usage_idle",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ExtractTags(tt.metric)
+			if len(actual) != len(tt.expected) {
+				t.Fatalf("amount of tags doesn't match: got %v, expected %v", actual, tt.expected)
+			}
+			for tag, value := range actual {
+				vExpected, ok := tt.expected[tag]
+				if !ok {
+					t.Fatalf("tag %v not found in %+v", value, actual)
+				} else if vExpected != value {
+					t.Errorf("unexpected tag-value, got %v, expected %v", value, vExpected)
+				}
+			}
+		})
+	}
+}
+
+func TestSummarizeValues(t *testing.T) {
+	epsilon := math.Nextafter(1, 2) - 1
+	tests := []struct {
+		name     string
+		function string
+		values   []float64
+		expected float64
+	}{
+		{
+			name:     "no values",
+			function: "sum",
+			values:   []float64{},
+			expected: math.NaN(),
+		},
+		{
+			name:     "sum",
+			function: "sum",
+			values:   []float64{1, 2, 3},
+			expected: 6,
+		},
+		{
+			name:     "sum alias",
+			function: "total",
+			values:   []float64{1, 2, 3},
+			expected: 6,
+		},
+		{
+			name:     "avg",
+			function: "avg",
+			values:   []float64{1, 2, 3, 4},
+			expected: 2.5,
+		},
+		{
+			name:     "max",
+			function: "max",
+			values:   []float64{1, 2, 3, 4},
+			expected: 4,
+		},
+		{
+			name:     "min",
+			function: "min",
+			values:   []float64{1, 2, 3, 4},
+			expected: 1,
+		},
+		{
+			name:     "last",
+			function: "last",
+			values:   []float64{1, 2, 3, 4},
+			expected: 4,
+		},
+		{
+			name:     "range",
+			function: "range",
+			values:   []float64{1, 2, 3, 4},
+			expected: 3,
+		},
+		{
+			name:     "median",
+			function: "median",
+			values:   []float64{1, 2, 3, 10, 11},
+			expected: 3,
+		},
+		{
+			name:     "multiply",
+			function: "multiply",
+			values:   []float64{1, 2, 3, 4},
+			expected: 24,
+		},
+		{
+			name:     "diff",
+			function: "diff",
+			values:   []float64{1, 2, 3, 4},
+			expected: -8,
+		},
+		{
+			name:     "count",
+			function: "count",
+			values:   []float64{1, 2, 3, 4},
+			expected: 4,
+		},
+		//{
+		//name:     "stddev",
+		//function: "stddev",
+		//values:   []float64{1, 2, 3, 4},
+		//expected: 1.118033988749895,
+		//},
+		{
+			name:     "p50 (fallback)",
+			function: "p50",
+			values:   []float64{1, 2, 3, 10, 11},
+			expected: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := SummarizeValues(tt.function, tt.values)
+			if math.Abs(actual-tt.expected) > epsilon {
+				t.Errorf("actual %v, expected %v", actual, tt.expected)
+			}
+		})
+	}
+
+}

--- a/expr/sort.go
+++ b/expr/sort.go
@@ -32,6 +32,9 @@ func (b byPartBase) Swap(i, j int) {
 
 func getPart(metric *types.MetricData, part int) string {
 	parts := strings.Split(metric.Name, ".")
+	if part >= len(parts) {
+		return ""
+	}
 	return parts[part]
 }
 

--- a/expr/sort_test.go
+++ b/expr/sort_test.go
@@ -51,6 +51,25 @@ func TestSortMetrics(t *testing.T) {
 				types.MakeMetricData(silver, []float64{}, 1, 0),
 			},
 		},
+		// With tags, it's now possible to have a query that returns metrics of different levels and level be higher
+		// or lower than the level for the metric request
+		{
+			[]*types.MetricData{
+				types.MakeMetricData("a.b.c", []float64{}, 1, 0),
+				types.MakeMetricData("a", []float64{}, 1, 0),
+				types.MakeMetricData("a.d", []float64{}, 1, 0),
+			},
+			parser.MetricRequest{
+				Metric: "seriesByTag(foo=~a.[bcd])",
+				From:   0,
+				Until:  1,
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("a", []float64{}, 1, 0),
+				types.MakeMetricData("a.b.c", []float64{}, 1, 0),
+				types.MakeMetricData("a.d", []float64{}, 1, 0),
+			},
+		},
 	}
 	for i, test := range tests {
 		if len(test.metrics) != len(test.sorted) {

--- a/pkg/backend/mock/mock.go
+++ b/pkg/backend/mock/mock.go
@@ -22,10 +22,12 @@ import (
 
 // Backend is a mock backend.
 type Backend struct {
-	find     func(context.Context, types.FindRequest) (types.Matches, error)
-	info     func(context.Context, types.InfoRequest) ([]types.Info, error)
-	render   func(context.Context, types.RenderRequest) ([]types.Metric, error)
-	contains func([]string) bool
+	find      func(context.Context, types.FindRequest) (types.Matches, error)
+	info      func(context.Context, types.InfoRequest) ([]types.Info, error)
+	render    func(context.Context, types.RenderRequest) ([]types.Metric, error)
+	tagnames  func(context.Context, types.TagsRequest, int64) ([]string, error)
+	tagvalues func(context.Context, types.TagsRequest, int64) ([]string, error)
+	contains  func([]string) bool
 }
 
 // Config configures a mock Backend. Define ad-hoc functions to return
@@ -33,10 +35,12 @@ type Backend struct {
 // default to one that returns an empty response and nil error.
 // A mock backend contains all targets by default.
 type Config struct {
-	Find     func(context.Context, types.FindRequest) (types.Matches, error)
-	Info     func(context.Context, types.InfoRequest) ([]types.Info, error)
-	Render   func(context.Context, types.RenderRequest) ([]types.Metric, error)
-	Contains func([]string) bool
+	Find      func(context.Context, types.FindRequest) (types.Matches, error)
+	Info      func(context.Context, types.InfoRequest) ([]types.Info, error)
+	Render    func(context.Context, types.RenderRequest) ([]types.Metric, error)
+	TagNames  func(context.Context, types.TagsRequest, int64) ([]string, error)
+	TagValues func(context.Context, types.TagsRequest, int64) ([]string, error)
+	Contains  func([]string) bool
 }
 
 var (
@@ -57,6 +61,14 @@ func (b Backend) Info(ctx context.Context, request types.InfoRequest) ([]types.I
 
 func (b Backend) Render(ctx context.Context, request types.RenderRequest) ([]types.Metric, error) {
 	return b.render(ctx, request)
+}
+
+func (b Backend) TagNames(ctx context.Context, request types.TagsRequest, limits int64) ([]string, error) {
+	return b.tagnames(ctx, request, limits)
+}
+
+func (b Backend) TagValues(ctx context.Context, request types.TagsRequest, limits int64) ([]string, error) {
+	return b.tagvalues(ctx, request, limits)
 }
 
 // Logger returns a no-op logger.

--- a/pkg/backend/rpc.go
+++ b/pkg/backend/rpc.go
@@ -28,6 +28,8 @@ type Backend interface {
 	Find(context.Context, types.FindRequest) (types.Matches, error)
 	Info(context.Context, types.InfoRequest) ([]types.Info, error)
 	Render(context.Context, types.RenderRequest) ([]types.Metric, error)
+	TagNames(context.Context, types.TagsRequest, int64) ([]string, error)
+	TagValues(context.Context, types.TagsRequest, int64) ([]string, error)
 
 	Contains([]string) bool // Reports whether a backend contains any of the given targets.
 	Logger() *zap.Logger    // A logger used to communicate non-fatal warnings.

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -48,6 +48,13 @@ var (
 	ErrUnknownTimeUnits = errors.New("unknown time units")
 )
 
+// NodeOrTag structure contains either Node (=integer) or Tag (=string)
+// They are distinguished by "IsTag" = true in case it's tag.
+type NodeOrTag struct {
+	IsTag bool
+	Value interface{}
+}
+
 // Expr defines an interface to talk with expressions
 type Expr interface {
 	// IsName checks if Expression is 'Series Name' expression
@@ -98,6 +105,8 @@ type Expr interface {
 
 	// GetIntervalArg returns n-th argument as string.
 	GetStringArg(n int) (string, error)
+	// GetStringArgs returns n-th argument as slice of strings.
+	GetStringArgs(n int) ([]string, error)
 	// GetIntervalArg returns n-th argument as string. It will replace it with Default value if none present.
 	GetStringArgDefault(n int, s string) (string, error)
 	// GetStringNamedOrPosArgDefault returns specific positioned string-typed argument or replace it with default if none found.
@@ -125,6 +134,9 @@ type Expr interface {
 	GetBoolArgDefault(n int, b bool) (bool, error)
 	// GetBoolNamedOrPosArgDefault returns specific positioned bool-typed argument or replace it with default if none found.
 	GetBoolNamedOrPosArgDefault(k string, n int, b bool) (bool, error)
+
+	// GetNodeOrTagArgs returns n-th argument as slice of NodeOrTag structures.
+	GetNodeOrTagArgs(n int) ([]NodeOrTag, error)
 
 	toExpr() interface{}
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -26,6 +26,7 @@ var (
 	ErrMetricsNotFound = ErrNotFound("No metrics returned")
 	ErrMatchesNotFound = ErrNotFound("No matches found")
 	ErrInfoNotFound    = ErrNotFound("No information found")
+	ErrTagsNotFound    = ErrNotFound("No tags found")
 )
 
 // ErrNotFound signals the HTTP not found error
@@ -80,6 +81,18 @@ func NewRenderRequest(targets []string, from int32, until int32) RenderRequest {
 		From:    from,
 		Until:   until,
 		Trace:   NewTrace(),
+	}
+}
+
+type TagsRequest struct {
+	Query string
+	Trace
+}
+
+func NewTagsRequest(query string) TagsRequest {
+	return TagsRequest{
+		Query: query,
+		Trace: NewTrace(),
 	}
 }
 


### PR DESCRIPTION
Initial support for graphite tags
At now function groupByTags support aggregation avg (average alias for compability with graphite-web), sum, min, max.