### PR TITLE
Added metric for render request durations per point pulled as an exponential histogram.

### DIFF
--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -150,6 +150,7 @@ func (app *App) registerPrometheusMetrics(logger *zap.Logger) {
 		prometheus.MustRegister(app.prometheusMetrics.DurationExp)
 		prometheus.MustRegister(app.prometheusMetrics.DurationLin)
 		prometheus.MustRegister(app.prometheusMetrics.RenderDurationExp)
+		prometheus.MustRegister(app.prometheusMetrics.RenderDurationPerPointExp)
 		prometheus.MustRegister(app.prometheusMetrics.FindDurationExp)
 		prometheus.MustRegister(app.prometheusMetrics.TimeInQueueExp)
 		prometheus.MustRegister(app.prometheusMetrics.TimeInQueueLin)

--- a/app/carbonapi/metrics.go
+++ b/app/carbonapi/metrics.go
@@ -9,17 +9,18 @@ import (
 
 // PrometheusMetrics are metrix exported via /metrics endpoint for Prom scraping
 type PrometheusMetrics struct {
-	Requests          prometheus.Counter
-	Responses         *prometheus.CounterVec
-	FindNotFound      prometheus.Counter
-	RenderPartialFail prometheus.Counter
-	RequestCancel     *prometheus.CounterVec
-	DurationExp       prometheus.Histogram
-	DurationLin       prometheus.Histogram
-	RenderDurationExp prometheus.Histogram
-	FindDurationExp   prometheus.Histogram
-	TimeInQueueExp    prometheus.Histogram
-	TimeInQueueLin    prometheus.Histogram
+	Requests                  prometheus.Counter
+	Responses                 *prometheus.CounterVec
+	FindNotFound              prometheus.Counter
+	RenderPartialFail         prometheus.Counter
+	RequestCancel             *prometheus.CounterVec
+	DurationExp               prometheus.Histogram
+	DurationLin               prometheus.Histogram
+	RenderDurationExp         prometheus.Histogram
+	RenderDurationPerPointExp prometheus.Histogram
+	FindDurationExp           prometheus.Histogram
+	TimeInQueueExp            prometheus.Histogram
+	TimeInQueueLin            prometheus.Histogram
 }
 
 func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
@@ -82,6 +83,16 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 				Help: "The duration of render requests (exponential)",
 				Buckets: prometheus.ExponentialBuckets(
 					config.Zipper.Common.Monitoring.RenderDurationExp.Start,
+					config.Zipper.Common.Monitoring.RenderDurationExp.BucketSize,
+					config.Zipper.Common.Monitoring.RenderDurationExp.BucketsNum),
+			},
+		),
+		RenderDurationPerPointExp: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name: "render_request_duration_perpoint_milliseconds_exp",
+				Help: "The duration of render requests (exponential)",
+				Buckets: prometheus.ExponentialBuckets(
+					config.Zipper.Common.Monitoring.RenderDurationExp.Start/10,
 					config.Zipper.Common.Monitoring.RenderDurationExp.BucketSize,
 					config.Zipper.Common.Monitoring.RenderDurationExp.BucketsNum),
 			},

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       dockerfile: docker/carbonapi/Dockerfile
       context: .
     ports:
+      - "7081:7081"
       - "8081:8081"
     links:
       - zipper


### PR DESCRIPTION
This metric is a good measure of `carbonapi` performance that is corrected for the request weight.