### PR TITLE
Prometheus latency metrics for render requests

### DIFF
--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -150,6 +150,8 @@ func (app *App) registerPrometheusMetrics(logger *zap.Logger) {
 		prometheus.MustRegister(app.prometheusMetrics.DurationExp)
 		prometheus.MustRegister(app.prometheusMetrics.DurationLin)
 		prometheus.MustRegister(app.prometheusMetrics.RenderDurationExp)
+		prometheus.MustRegister(app.prometheusMetrics.RenderDurationExpSimple)
+		prometheus.MustRegister(app.prometheusMetrics.RenderDurationExpComplex)
 		prometheus.MustRegister(app.prometheusMetrics.RenderDurationPerPointExp)
 		prometheus.MustRegister(app.prometheusMetrics.FindDurationExp)
 		prometheus.MustRegister(app.prometheusMetrics.TimeInQueueExp)

--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -198,7 +198,7 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 			app.prometheusMetrics.RenderDurationPerPointExp.Observe(time.Since(t0).Seconds() * 1000 / float64(size))
 		}
 		//2xx response code is treated as success
-		if toLog.HttpCode > 0 && toLog.HttpCode/100 == 2 {
+		if toLog.HttpCode/100 == 2 {
 			if toLog.TotalMetricCount < int64(app.config.MaxBatchSize) {
 				app.prometheusMetrics.RenderDurationExpSimple.Observe(time.Since(t0).Seconds())
 			} else {

--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -193,8 +193,17 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 	var targetErrs []error
 	size := 0
 	defer func() {
+		//TODO: cleanup RenderDurationPerPointExp
 		if size > 0 {
 			app.prometheusMetrics.RenderDurationPerPointExp.Observe(time.Since(t0).Seconds() * 1000 / float64(size))
+		}
+		//2xx response code is treated as success
+		if toLog.HttpCode > 0 && toLog.HttpCode%100 == 2 {
+			if toLog.TotalMetricCount < int64(app.config.MaxBatchSize) {
+				app.prometheusMetrics.RenderDurationExpSimple.Observe(time.Since(t0).Seconds())
+			} else {
+				app.prometheusMetrics.RenderDurationExpComplex.Observe(time.Since(t0).Seconds())
+			}
 		}
 	}()
 	// TODO (grzkv) Modification of *form* inside the loop is never applied

--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -198,7 +198,7 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 			app.prometheusMetrics.RenderDurationPerPointExp.Observe(time.Since(t0).Seconds() * 1000 / float64(size))
 		}
 		//2xx response code is treated as success
-		if toLog.HttpCode > 0 && toLog.HttpCode%100 == 2 {
+		if toLog.HttpCode > 0 && toLog.HttpCode/100 == 2 {
 			if toLog.TotalMetricCount < int64(app.config.MaxBatchSize) {
 				app.prometheusMetrics.RenderDurationExpSimple.Observe(time.Since(t0).Seconds())
 			} else {

--- a/app/carbonapi/metrics.go
+++ b/app/carbonapi/metrics.go
@@ -17,6 +17,8 @@ type PrometheusMetrics struct {
 	DurationExp               prometheus.Histogram
 	DurationLin               prometheus.Histogram
 	RenderDurationExp         prometheus.Histogram
+	RenderDurationExpSimple   prometheus.Histogram
+	RenderDurationExpComplex  prometheus.Histogram
 	RenderDurationPerPointExp prometheus.Histogram
 	FindDurationExp           prometheus.Histogram
 	TimeInQueueExp            prometheus.Histogram
@@ -81,6 +83,26 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 			prometheus.HistogramOpts{
 				Name: "render_request_duration_seconds_exp",
 				Help: "The duration of render requests (exponential)",
+				Buckets: prometheus.ExponentialBuckets(
+					config.Zipper.Common.Monitoring.RenderDurationExp.Start,
+					config.Zipper.Common.Monitoring.RenderDurationExp.BucketSize,
+					config.Zipper.Common.Monitoring.RenderDurationExp.BucketsNum),
+			},
+		),
+		RenderDurationExpSimple: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name: "render_request_duration_seconds_exp_simple",
+				Help: "The duration of simple render requests (exponential)",
+				Buckets: prometheus.ExponentialBuckets(
+					config.Zipper.Common.Monitoring.RenderDurationExp.Start,
+					config.Zipper.Common.Monitoring.RenderDurationExp.BucketSize,
+					config.Zipper.Common.Monitoring.RenderDurationExp.BucketsNum),
+			},
+		),
+		RenderDurationExpComplex: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name: "render_request_duration_seconds_exp_complex",
+				Help: "The duration of complex render requests (exponential)",
 				Buckets: prometheus.ExponentialBuckets(
 					config.Zipper.Common.Monitoring.RenderDurationExp.Start,
 					config.Zipper.Common.Monitoring.RenderDurationExp.BucketSize,


### PR DESCRIPTION
Adds prometheus latency metrics for render requests, dividing them into two branches, simple and complex, based on the heaviness of the requests, measured in total metrics queried.