### PR TITLE
Fix send globs in api access logs

### DIFF
--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -666,7 +666,6 @@ func (app *App) resolveGlobs(ctx context.Context, metric string, useCache bool, 
 func (app *App) getRenderRequests(ctx context.Context, m parser.MetricRequest, useCache bool,
 	toLog *carbonapipb.AccessLogDetails, logger *zap.Logger) ([]string, error) {
 	if app.config.AlwaysSendGlobsAsIs {
-		toLog.SendGlobs = true
 		return []string{m.Metric}, nil
 	}
 	if !strings.ContainsAny(m.Metric, "*{") {
@@ -680,10 +679,10 @@ func (app *App) getRenderRequests(ctx context.Context, m parser.MetricRequest, u
 	}
 
 	if app.sendGlobs(glob) {
-		toLog.SendGlobs = true
 		return []string{m.Metric}, nil
 	}
 
+	toLog.SendGlobs = false
 	renderRequests := make([]string, 0, len(glob.Matches))
 	for _, m := range glob.Matches {
 		if m.IsLeaf {

--- a/carbonapipb/carbonapi.pb.go
+++ b/carbonapipb/carbonapi.pb.go
@@ -69,6 +69,7 @@ func NewAccessLogDetails(r *http.Request, handler string, config *cfg.API) Acces
 		PeerIp:        srcIP,
 		PeerPort:      srcPort,
 		Host:          r.Host,
+		SendGlobs:     true,
 		Path:          r.URL.Path,
 		Referer:       r.Referer(),
 		// TODO (grzkv) Do we need this?

--- a/carbonapipb/carbonapi.pb.go
+++ b/carbonapipb/carbonapi.pb.go
@@ -32,7 +32,7 @@ type AccessLogDetails struct {
 	CarbonzipperResponseSizeBytes int64             `json:"carbonzipper_response_size_bytes,omitempty"`
 	CarbonapiResponseSizeBytes    int64             `json:"carbonapi_response_size_bytes,omitempty"`
 	Reason                        string            `json:"reason,omitempty"`
-	SendGlobs                     bool              `json:"send_globs,omitempty"`
+	SendGlobs                     bool              `json:"send_globs"`
 	From                          int32             `json:"from,omitempty"`
 	Until                         int32             `json:"until,omitempty"`
 	Tz                            string            `json:"tz,omitempty"`


### PR DESCRIPTION
This is currently broken for multi target requests.