### PR TITLE
Gysingh/render sli prom

### DIFF
--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -152,6 +152,7 @@ func (app *App) registerPrometheusMetrics(logger *zap.Logger) {
 		prometheus.MustRegister(app.prometheusMetrics.RenderDurationExp)
 		prometheus.MustRegister(app.prometheusMetrics.RenderDurationExpSimple)
 		prometheus.MustRegister(app.prometheusMetrics.RenderDurationExpComplex)
+		prometheus.MustRegister(app.prometheusMetrics.RenderDurationLinSimple)
 		prometheus.MustRegister(app.prometheusMetrics.RenderDurationPerPointExp)
 		prometheus.MustRegister(app.prometheusMetrics.FindDurationExp)
 		prometheus.MustRegister(app.prometheusMetrics.TimeInQueueExp)

--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -154,6 +154,7 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 		if toLog.HttpCode/100 == 2 {
 			if toLog.TotalMetricCount < int64(app.config.MaxBatchSize) {
 				app.prometheusMetrics.RenderDurationExpSimple.Observe(time.Since(t0).Seconds())
+				app.prometheusMetrics.RenderDurationLinSimple.Observe(time.Since(t0).Seconds())
 			} else {
 				app.prometheusMetrics.RenderDurationExpComplex.Observe(time.Since(t0).Seconds())
 			}

--- a/app/carbonapi/metrics.go
+++ b/app/carbonapi/metrics.go
@@ -95,9 +95,9 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 				Name: "render_request_duration_seconds_lin_simple",
 				Help: "The duration of render requests (linear)",
 				Buckets: prometheus.LinearBuckets(
-					config.Zipper.Common.Monitoring.RenderDurationExp.Start,
-					config.Zipper.Common.Monitoring.RenderDurationExp.BucketSize,
-					config.Zipper.Common.Monitoring.RenderDurationExp.BucketsNum),
+					config.Zipper.Common.Monitoring.RenderDurationLinSimple.Start,
+					config.Zipper.Common.Monitoring.RenderDurationLinSimple.BucketSize,
+					config.Zipper.Common.Monitoring.RenderDurationLinSimple.BucketsNum),
 			},
 		),
 		RenderDurationExpSimple: prometheus.NewHistogram(

--- a/app/carbonapi/metrics.go
+++ b/app/carbonapi/metrics.go
@@ -17,6 +17,7 @@ type PrometheusMetrics struct {
 	DurationExp               prometheus.Histogram
 	DurationLin               prometheus.Histogram
 	RenderDurationExp         prometheus.Histogram
+	RenderDurationLinSimple   prometheus.Histogram
 	RenderDurationExpSimple   prometheus.Histogram
 	RenderDurationExpComplex  prometheus.Histogram
 	RenderDurationPerPointExp prometheus.Histogram
@@ -84,6 +85,16 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 				Name: "render_request_duration_seconds_exp",
 				Help: "The duration of render requests (exponential)",
 				Buckets: prometheus.ExponentialBuckets(
+					config.Zipper.Common.Monitoring.RenderDurationExp.Start,
+					config.Zipper.Common.Monitoring.RenderDurationExp.BucketSize,
+					config.Zipper.Common.Monitoring.RenderDurationExp.BucketsNum),
+			},
+		),
+		RenderDurationLinSimple: prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name: "render_request_duration_seconds_lin",
+				Help: "The duration of render requests (exponential)",
+				Buckets: prometheus.LinearBuckets(
 					config.Zipper.Common.Monitoring.RenderDurationExp.Start,
 					config.Zipper.Common.Monitoring.RenderDurationExp.BucketSize,
 					config.Zipper.Common.Monitoring.RenderDurationExp.BucketsNum),

--- a/app/carbonapi/metrics.go
+++ b/app/carbonapi/metrics.go
@@ -92,8 +92,8 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 		),
 		RenderDurationLinSimple: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
-				Name: "render_request_duration_seconds_lin",
-				Help: "The duration of render requests (exponential)",
+				Name: "render_request_duration_seconds_lin_simple",
+				Help: "The duration of render requests (linear)",
 				Buckets: prometheus.LinearBuckets(
 					config.Zipper.Common.Monitoring.RenderDurationExp.Start,
 					config.Zipper.Common.Monitoring.RenderDurationExp.BucketSize,

--- a/cfg/common.go
+++ b/cfg/common.go
@@ -87,6 +87,11 @@ func DefaultCommonConfig() Common {
 				BucketSize: 2,
 				BucketsNum: 20,
 			},
+			RenderDurationLinSimple: HistogramConfig{
+				Start:      0.1,
+				BucketSize: 0.1,
+				BucketsNum: 20,
+			},
 			FindDurationExp: HistogramConfig{
 				Start:      0.05,
 				BucketSize: 2,
@@ -137,6 +142,7 @@ type MonitoringConfig struct {
 	RequestDurationExp      HistogramConfig `yaml:"requestDurationExpHistogram"`
 	RequestDurationLin      HistogramConfig `yaml:"requestDurationLinHistogram"`
 	RenderDurationExp       HistogramConfig `yaml:"renderDurationExpHistogram"`
+	RenderDurationLinSimple HistogramConfig `yaml:"renderDurationLinHistogram"`
 	FindDurationExp         HistogramConfig `yaml:"findDurationExpHistogram"`
 	TimeInQueueExpHistogram HistogramConfig `yaml:"timeInQueueExpHistogram"`
 	TimeInQueueLinHistogram HistogramConfig `yaml:"timeInQueueLinHistogram"`


### PR DESCRIPTION
Adding prometheus metric with linear buckets tracking 'simple' requests. Needed for more granular and uniform buckets, in comparison to exponential buckets.