### PR TITLE
Add timeLag function for computing a time lag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ TODO
 coverage.txt
 
 .vscode
-
+.idea
+*.swp
 # Docker runs data
 data

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -167,6 +167,7 @@ _When `format=png`_ (default if not specified)
 - powSeriesLists
 - removeZeroSeries
 - stdev
+- timeLag
 - tukeyAbove
 - tukeyBelow
 
@@ -288,6 +289,7 @@ _When `format=png`_ (default if not specified)
 | summarize(seriesList, intervalString, func='sum', alignToFrom=False)      |
 | threshold(value, label=None, color=None)                                  |
 | timeFunction(name, step=60), Short Alias: time()                          |
+| timeLag(consumeMaxOffsetSeries, produceMaxOffsetSeries)                   |
 | timeShift(seriesList, timeShift, resetEnd=True)                           |
 | timeStack(seriesList, timeShiftUnit, timeShiftStart, timeShiftEnd)        |
 | [tukeyAbove](https://en.wikipedia.org/wiki/Tukey%27s_range_test)(seriesList, basis, n, interval=0) |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -167,7 +167,8 @@ _When `format=png`_ (default if not specified)
 - powSeriesLists
 - removeZeroSeries
 - stdev
-- timeLag
+- timeLagSeries
+- timeLagSeriesLists
 - tukeyAbove
 - tukeyBelow
 
@@ -289,7 +290,8 @@ _When `format=png`_ (default if not specified)
 | summarize(seriesList, intervalString, func='sum', alignToFrom=False)      |
 | threshold(value, label=None, color=None)                                  |
 | timeFunction(name, step=60), Short Alias: time()                          |
-| timeLag(consumeMaxOffsetSeries, produceMaxOffsetSeries)                   |
+| timeLagSeries(consumeMaxOffsetSeries, produceMaxOffsetSeries)             |
+| timeLagSeriesLists(consumeMaxOffsetSeriesLists, produceMaxOffsetSeriesLists) |
 | timeShift(seriesList, timeShift, resetEnd=True)                           |
 | timeStack(seriesList, timeShiftUnit, timeShiftStart, timeShiftEnd)        |
 | [tukeyAbove](https://en.wikipedia.org/wiki/Tukey%27s_range_test)(seriesList, basis, n, interval=0) |

--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -83,6 +83,7 @@ import (
 	"github.com/bookingcom/carbonapi/expr/functions/sumSeriesWithWildcards"
 	"github.com/bookingcom/carbonapi/expr/functions/summarize"
 	"github.com/bookingcom/carbonapi/expr/functions/timeFunction"
+	"github.com/bookingcom/carbonapi/expr/functions/timeLag"
 	"github.com/bookingcom/carbonapi/expr/functions/timeShift"
 	"github.com/bookingcom/carbonapi/expr/functions/timeStack"
 	"github.com/bookingcom/carbonapi/expr/functions/transformNull"
@@ -98,7 +99,7 @@ type initFunc struct {
 }
 
 func New(configs map[string]string) {
-	funcs := make([]initFunc, 0, 83)
+	funcs := make([]initFunc, 0, 84)
 
 	funcs = append(funcs, initFunc{name: "absolute", order: absolute.GetOrder(), f: absolute.New})
 
@@ -257,6 +258,8 @@ func New(configs map[string]string) {
 	funcs = append(funcs, initFunc{name: "summarize", order: summarize.GetOrder(), f: summarize.New})
 
 	funcs = append(funcs, initFunc{name: "timeFunction", order: timeFunction.GetOrder(), f: timeFunction.New})
+
+	funcs = append(funcs, initFunc{name: "timeLag", order: timeLag.GetOrder(), f: timeLag.New})
 
 	funcs = append(funcs, initFunc{name: "timeShift", order: timeShift.GetOrder(), f: timeShift.New})
 

--- a/expr/functions/timeLag/function.go
+++ b/expr/functions/timeLag/function.go
@@ -1,7 +1,6 @@
 package timeLag
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/bookingcom/carbonapi/expr/helper"
@@ -21,17 +20,69 @@ func GetOrder() interfaces.Order {
 func New(configFile string) []interfaces.FunctionMetadata {
 	res := make([]interfaces.FunctionMetadata, 0)
 	f := &timeLag{}
-	functions := []string{"timeLagSeries"}
+	functions := []string{"timeLagSeries", "timeLagSeriesLists"}
 	for _, n := range functions {
 		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
 	}
 	return res
 }
 
-// timeLag(consumeMaxOffsetSeries, produceMaxOffsetSeries)
+func MakeTimeLag(consumerMetric, producerMetric *types.MetricData, name string) *types.MetricData {
+	pStart := producerMetric.StartTime
+	pStep := producerMetric.StepTime
+	pLen := (int32)(len(producerMetric.Values))
+	cStart := consumerMetric.StartTime
+	cStep := consumerMetric.StepTime
+
+	r := *consumerMetric
+	r.Name = name
+
+	r.Values = make([]float64, len(consumerMetric.Values))
+	r.IsAbsent = make([]bool, len(consumerMetric.Values))
+
+	var pIndex int32 = 0
+	for producerMetric.IsAbsent[pIndex] && pIndex+1 < pLen {
+		pIndex++
+	}
+
+	for i, v := range consumerMetric.Values {
+
+		if consumerMetric.IsAbsent[i] || len(producerMetric.Values) == 0 {
+			r.IsAbsent[i] = true
+			continue
+		}
+
+		npIndex := pIndex
+		// npIndex: find first index in producer metric that is higher than v
+		for (producerMetric.IsAbsent[npIndex] || producerMetric.Values[npIndex] <= v) && (npIndex+1) < pLen {
+			npIndex++
+			for producerMetric.IsAbsent[npIndex] && (npIndex+1) < pLen {
+				npIndex++
+			}
+			// maintain: pIndex is highest index for which producer metric <= v
+			if !producerMetric.IsAbsent[npIndex] && producerMetric.Values[npIndex] <= v {
+				pIndex = npIndex
+			}
+		}
+		// we can't compute timeLag for the value that is lower than the smallest data point in producer metric
+		if producerMetric.IsAbsent[pIndex] || producerMetric.Values[pIndex] > v {
+			r.IsAbsent[i] = true
+			continue
+		}
+
+		cTime := cStart + (int32)(i)*cStep
+		pTime := pStart + pIndex*pStep
+
+		r.Values[i] = (float64)(cTime - pTime)
+	}
+	return &r
+}
+
 func (f *timeLag) Do(e parser.Expr, from, until int32, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	if len(e.Args()) < 1 {
 		return nil, parser.ErrMissingTimeseries
+	} else if len(e.Args()) < 2 && e.Target() == "timeLagSeriesLists" {
+		return nil, fmt.Errorf("%s must be called with two lists of series", e.Target())
 	}
 
 	firstArg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
@@ -42,79 +93,49 @@ func (f *timeLag) Do(e parser.Expr, from, until int32, values map[parser.MetricR
 	var useMetricNames bool
 
 	var consumerMetrics []*types.MetricData
-	var producerMetric *types.MetricData
+	var producerMetrics []*types.MetricData
 	if len(e.Args()) == 2 {
 		useMetricNames = true
 		consumerMetrics = firstArg
-		producerMetrics, err := helper.GetSeriesArg(e.Args()[1], from, until, values)
+		var err error
+		producerMetrics, err = helper.GetSeriesArg(e.Args()[1], from, until, values)
 		if err != nil {
 			return nil, err
 		}
-		if len(producerMetrics) != 1 {
-			return nil, types.ErrWildcardNotAllowed
+		switch e.Target() {
+		case "timeLagSeries":
+			if len(producerMetrics) != 1 {
+				return nil, types.ErrWildcardNotAllowed
+			}
+		case "timeLagSeriesLists":
+			if len(producerMetrics) != len(consumerMetrics) {
+				return nil, fmt.Errorf("both %s arguments must have equal length", e.Target())
+			}
 		}
-
-		producerMetric = producerMetrics[0]
 	} else if len(firstArg) == 2 && len(e.Args()) == 1 {
 		consumerMetrics = append(consumerMetrics, firstArg[0])
-		producerMetric = firstArg[1]
+		producerMetrics = append(producerMetrics, firstArg[1])
 	} else {
-		return nil, errors.New("must be called with 2 series or a wildcard that matches exactly 2 series")
+		return nil, fmt.Errorf("%s must be called with 2 series or a wildcard that matches exactly 2 series", e.Target())
 	}
 
-    pStart := producerMetric.StartTime
-    pStep := producerMetric.StepTime
-    pLen := (int32)(len(producerMetric.Values))
 	var results []*types.MetricData
-	for _, consumerMetric := range consumerMetrics {
-        cStart := consumerMetric.StartTime
-        cStep := consumerMetric.StepTime
-
-        r := *consumerMetric
+	for i, consumerMetric := range consumerMetrics {
+		producerIndex := 0
+		if len(producerMetrics) > 1 { // can only be for timeLagSeriesLists
+			producerIndex = i
+		}
+		producerMetric := producerMetrics[producerIndex]
+		var name string
 		if useMetricNames {
-			r.Name = fmt.Sprintf("timeLagSeries(%s,%s)", consumerMetric.Name, producerMetric.Name)
+			name = fmt.Sprintf("timeLagSeries(%s,%s)", consumerMetric.Name, producerMetric.Name)
 		} else {
-			r.Name = fmt.Sprintf("timeLagSeries(%s)", e.RawArgs())
+			name = fmt.Sprintf("timeLagSeries(%s)", e.RawArgs())
 		}
-		r.Values = make([]float64, len(consumerMetric.Values))
-		r.IsAbsent = make([]bool, len(consumerMetric.Values))
 
-        var pIndex int32 = 0;
-        for producerMetric.IsAbsent[pIndex] && pIndex+1 < pLen {
-            pIndex++
-        }
+		r := MakeTimeLag(consumerMetric, producerMetric, name)
 
-		for i, v := range consumerMetric.Values {
-
-			if consumerMetric.IsAbsent[i] || len(producerMetric.Values) == 0 {
-				r.IsAbsent[i] = true
-				continue
-			}
-
-            npIndex := pIndex
-            // npIndex: find first index in producer metric that is higher than v
-            for (producerMetric.IsAbsent[npIndex] || producerMetric.Values[npIndex] <= v) && (npIndex+1) < pLen {
-                npIndex++
-                for producerMetric.IsAbsent[npIndex] && (npIndex + 1) < pLen {
-                    npIndex++
-                }
-                // maintain: pIndex is highest index for which producer metric <= v
-                if !producerMetric.IsAbsent[npIndex] && producerMetric.Values[npIndex] <= v {
-                    pIndex = npIndex
-                }
-            }
-            // we can't compute timeLag for the value that is lower than the smallest data point in producer metric
-            if producerMetric.IsAbsent[pIndex] || producerMetric.Values[pIndex] > v {
-				r.IsAbsent[i] = true
-				continue
-            }
-
-            cTime := cStart + (int32)(i)*cStep
-            pTime := pStart + pIndex*pStep
-
-            r.Values[i] = (float64)(cTime - pTime);
-		}
-		results = append(results, &r)
+		results = append(results, r)
 	}
 
 	return results, nil
@@ -127,7 +148,7 @@ func (f *timeLag) Description() map[string]types.FunctionDescription {
 			Description: "Computes time lag of two time series representing the time of processing the same data.\nA constant may *not* be passed.\n\nExample:\n\n.. code-block:: none\n\n  &target=timeLagSeries(service_a.consume.max_offset,service_b.produce.max_offset)",
 			Function:    "timeLagSeries(consumeMaxOffsetSeries, produceMaxOffsetSeries)",
 			Group:       "Combine",
-			Module:      "graphite.render.functions",
+			Module:      "graphite.render.functions.custom",
 			Name:        "timeLagSeries",
 			Params: []types.FunctionParam{
 				{
@@ -137,6 +158,25 @@ func (f *timeLag) Description() map[string]types.FunctionDescription {
 				},
 				{
 					Name:     "produceMaxOffsetSeries",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+		"timeLagSeriesLists": {
+			Description: "Iterates over a two lists and computes timeLagSeries(list1[0},list2[0}), timeLagSeries(list1[1},list2[1}) and so on.\nThe lists need to be the same length",
+			Function:    "timeLagSeriesLists(consumeMaxOffsetSeriesList, produceMaxOffsetSeriesList)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions.custom",
+			Name:        "timeLagSeriesLists",
+			Params: []types.FunctionParam{
+				{
+					Name:     "consumeMaxOffsetSeriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Name:     "produceMaxOffsetSeriesList",
 					Required: true,
 					Type:     types.SeriesList,
 				},

--- a/expr/functions/timeLag/function.go
+++ b/expr/functions/timeLag/function.go
@@ -21,7 +21,7 @@ func GetOrder() interfaces.Order {
 func New(configFile string) []interfaces.FunctionMetadata {
 	res := make([]interfaces.FunctionMetadata, 0)
 	f := &timeLag{}
-	functions := []string{"timeLag"}
+	functions := []string{"timeLagSeries"}
 	for _, n := range functions {
 		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
 	}
@@ -72,9 +72,9 @@ func (f *timeLag) Do(e parser.Expr, from, until int32, values map[parser.MetricR
 
         r := *consumerMetric
 		if useMetricNames {
-			r.Name = fmt.Sprintf("timeLag(%s,%s)", consumerMetric.Name, producerMetric.Name)
+			r.Name = fmt.Sprintf("timeLagSeries(%s,%s)", consumerMetric.Name, producerMetric.Name)
 		} else {
-			r.Name = fmt.Sprintf("timeLag(%s)", e.RawArgs())
+			r.Name = fmt.Sprintf("timeLagSeries(%s)", e.RawArgs())
 		}
 		r.Values = make([]float64, len(consumerMetric.Values))
 		r.IsAbsent = make([]bool, len(consumerMetric.Values))
@@ -123,12 +123,12 @@ func (f *timeLag) Do(e parser.Expr, from, until int32, values map[parser.MetricR
 
 func (f *timeLag) Description() map[string]types.FunctionDescription {
 	return map[string]types.FunctionDescription{
-		"timeLag": {
-			Description: "Computes time lag of two time series representing the time of processing the same data.\nA constant may *not* be passed.\n\nExample:\n\n.. code-block:: none\n\n  &target=timeLag(service_a.consume.max_offset,service_b.produce.max_offset)",
-			Function:    "timeLag(consumeMaxOffsetSeries, produceMaxOffsetSeries)",
+		"timeLagSeries": {
+			Description: "Computes time lag of two time series representing the time of processing the same data.\nA constant may *not* be passed.\n\nExample:\n\n.. code-block:: none\n\n  &target=timeLagSeries(service_a.consume.max_offset,service_b.produce.max_offset)",
+			Function:    "timeLagSeries(consumeMaxOffsetSeries, produceMaxOffsetSeries)",
 			Group:       "Combine",
 			Module:      "graphite.render.functions",
-			Name:        "timeLag",
+			Name:        "timeLagSeries",
 			Params: []types.FunctionParam{
 				{
 					Name:     "consumeMaxOffsetSeries",

--- a/expr/functions/timeLag/function.go
+++ b/expr/functions/timeLag/function.go
@@ -41,12 +41,11 @@ func MakeTimeLag(consumerMetric, producerMetric *types.MetricData, name string) 
 	r.IsAbsent = make([]bool, len(consumerMetric.Values))
 
 	var pIndex int32 = 0
-	for producerMetric.IsAbsent[pIndex] && pIndex+1 < pLen {
-		pIndex++
-	}
-
 	for i, v := range consumerMetric.Values {
-
+		// reset producer offset and scan it again if consumer offset decreased
+		if i > 0 && consumerMetric.Values[i-1] > v {
+			pIndex = 0
+		}
 		if consumerMetric.IsAbsent[i] || len(producerMetric.Values) == 0 {
 			r.IsAbsent[i] = true
 			continue

--- a/expr/functions/timeLag/function.go
+++ b/expr/functions/timeLag/function.go
@@ -1,0 +1,146 @@
+package timeLag
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bookingcom/carbonapi/expr/helper"
+	"github.com/bookingcom/carbonapi/expr/interfaces"
+	"github.com/bookingcom/carbonapi/expr/types"
+	"github.com/bookingcom/carbonapi/pkg/parser"
+)
+
+type timeLag struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &timeLag{}
+	functions := []string{"timeLag"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+// timeLag(consumeMaxOffsetSeries, produceMaxOffsetSeries)
+func (f *timeLag) Do(e parser.Expr, from, until int32, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	if len(e.Args()) < 1 {
+		return nil, parser.ErrMissingTimeseries
+	}
+
+	firstArg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+
+	var useMetricNames bool
+
+	var consumerMetrics []*types.MetricData
+	var producerMetric *types.MetricData
+	if len(e.Args()) == 2 {
+		useMetricNames = true
+		consumerMetrics = firstArg
+		producerMetrics, err := helper.GetSeriesArg(e.Args()[1], from, until, values)
+		if err != nil {
+			return nil, err
+		}
+		if len(producerMetrics) != 1 {
+			return nil, types.ErrWildcardNotAllowed
+		}
+
+		producerMetric = producerMetrics[0]
+	} else if len(firstArg) == 2 && len(e.Args()) == 1 {
+		consumerMetrics = append(consumerMetrics, firstArg[0])
+		producerMetric = firstArg[1]
+	} else {
+		return nil, errors.New("must be called with 2 series or a wildcard that matches exactly 2 series")
+	}
+
+    pStart := producerMetric.StartTime
+    pStep := producerMetric.StepTime
+    pLen := (int32)(len(producerMetric.Values))
+	var results []*types.MetricData
+	for _, consumerMetric := range consumerMetrics {
+        cStart := consumerMetric.StartTime
+        cStep := consumerMetric.StepTime
+
+        r := *consumerMetric
+		if useMetricNames {
+			r.Name = fmt.Sprintf("timeLag(%s,%s)", consumerMetric.Name, producerMetric.Name)
+		} else {
+			r.Name = fmt.Sprintf("timeLag(%s)", e.RawArgs())
+		}
+		r.Values = make([]float64, len(consumerMetric.Values))
+		r.IsAbsent = make([]bool, len(consumerMetric.Values))
+
+        var pIndex int32 = 0;
+        for producerMetric.IsAbsent[pIndex] && pIndex+1 < pLen {
+            pIndex++
+        }
+
+		for i, v := range consumerMetric.Values {
+
+			if consumerMetric.IsAbsent[i] || len(producerMetric.Values) == 0 {
+				r.IsAbsent[i] = true
+				continue
+			}
+
+            npIndex := pIndex
+            // npIndex: find first index in producer metric that is higher than v
+            for (producerMetric.IsAbsent[npIndex] || producerMetric.Values[npIndex] <= v) && (npIndex+1) < pLen {
+                npIndex++
+                for producerMetric.IsAbsent[npIndex] && (npIndex + 1) < pLen {
+                    npIndex++
+                }
+                // maintain: pIndex is highest index for which producer metric <= v
+                if !producerMetric.IsAbsent[npIndex] && producerMetric.Values[npIndex] <= v {
+                    pIndex = npIndex
+                }
+            }
+            // we can't compute timeLag for the value that is lower than the smallest data point in producer metric
+            if producerMetric.IsAbsent[pIndex] || producerMetric.Values[pIndex] > v {
+				r.IsAbsent[i] = true
+				continue
+            }
+
+            cTime := cStart + (int32)(i)*cStep
+            pTime := pStart + pIndex*pStep
+
+            r.Values[i] = (float64)(cTime - pTime);
+		}
+		results = append(results, &r)
+	}
+
+	return results, nil
+
+}
+
+func (f *timeLag) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"timeLag": {
+			Description: "Computes time lag of two time series representing the time of processing the same data.\nA constant may *not* be passed.\n\nExample:\n\n.. code-block:: none\n\n  &target=timeLag(service_a.consume.max_offset,service_b.produce.max_offset)",
+			Function:    "timeLag(consumeMaxOffsetSeries, produceMaxOffsetSeries)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "timeLag",
+			Params: []types.FunctionParam{
+				{
+					Name:     "consumeMaxOffsetSeries",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Name:     "produceMaxOffsetSeries",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/timeLag/function_test.go
+++ b/expr/functions/timeLag/function_test.go
@@ -1,0 +1,94 @@
+package timeLag
+
+import (
+	"testing"
+	"time"
+
+	"math"
+
+	"github.com/bookingcom/carbonapi/expr/helper"
+	"github.com/bookingcom/carbonapi/expr/metadata"
+	"github.com/bookingcom/carbonapi/expr/types"
+	"github.com/bookingcom/carbonapi/pkg/parser"
+	th "github.com/bookingcom/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestTimeLagMultiReturn(t *testing.T) {
+	now32 := int32(time.Now().Unix())
+
+	tests := []th.MultiReturnEvalTestItem{
+		{
+			"timeLag(metric[12],metric2)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[12]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, 4, 6, 8, 10}, 1, now32),
+				},
+				{"metric1", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
+				},
+				{"metric2", 0, 1}: {
+					types.MakeMetricData("metric2", []float64{2, 4, 6, 8, 10}, 1, now32),
+				},
+			},
+			"timeLag",
+			map[string][]*types.MetricData{
+				"timeLag(metric1,metric2)": {types.MakeMetricData("timeLag(metric1,metric2)", []float64{math.NaN(), 1, 2, 2, 3}, 1, now32)},
+				"timeLag(metric2,metric2)": {types.MakeMetricData("timeLag(metric2,metric2)", []float64{0, 0, 0, 0, 0}, 1, now32)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestMultiReturnEvalExpr(t, &tt)
+		})
+	}
+
+}
+
+func TestTimeLag(t *testing.T) {
+	now32 := int32(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			"timeLag(metric1,metric2)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32)},
+				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 12}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("timeLag(metric1,metric2)",
+				[]float64{math.NaN(), math.NaN(), math.NaN(), 1, 2, 0}, 1, now32)},
+		},
+		{
+			"timeLag(metric[12])",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric[12]", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32),
+					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 12}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("timeLag(metric[12])",
+				[]float64{math.NaN(), math.NaN(), math.NaN(), 1, 2, 0}, 1, now32)},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+
+}

--- a/expr/functions/timeLag/function_test.go
+++ b/expr/functions/timeLag/function_test.go
@@ -58,7 +58,7 @@ func TestTimeLagSeriesMultiReturn(t *testing.T) {
 
 }
 
-func TesttimeLagSeriesSeries(t *testing.T) {
+func TestTimeLagSeries(t *testing.T) {
 	now32 := int32(time.Now().Unix())
 
 	tests := []th.EvalTestItem{
@@ -88,6 +88,51 @@ func TesttimeLagSeriesSeries(t *testing.T) {
 		testName := tt.Target
 		t.Run(testName, func(t *testing.T) {
 			th.TestEvalExpr(t, &tt)
+		})
+	}
+
+}
+
+func TestTimeLagSeriesLists(t *testing.T) {
+	now32 := int32(time.Now().Unix())
+
+	tests := []th.MultiReturnEvalTestItem{
+		{
+			"timeLagSeriesLists(consumer.*,producer.*)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"consumer.*", 0, 1}: {
+					types.MakeMetricData("consumer.1", []float64{1, 2, 3, 4, 5}, 1, now32),
+					types.MakeMetricData("consumer.2", []float64{2, 4, 6, 8, 10}, 1, now32),
+				},
+				{"consumer.1", 0, 1}: {
+					types.MakeMetricData("consumer.1", []float64{1, 2, 3, 4, 5}, 1, now32),
+				},
+				{"consumer.2", 0, 1}: {
+					types.MakeMetricData("consumer.2", []float64{2, 4, 6, 8, 10}, 1, now32),
+				},
+				{"producer.*", 0, 1}: {
+					types.MakeMetricData("producer.1", []float64{1, 2, 4, 4, 6}, 1, now32),
+					types.MakeMetricData("producer.2", []float64{2, 4, 7, 8, 11}, 1, now32),
+				},
+				{"producer.1", 0, 1}: {
+					types.MakeMetricData("producer.1", []float64{1, 2, 4, 4, 6}, 1, now32),
+				},
+				{"producer.2", 0, 1}: {
+					types.MakeMetricData("producer.2", []float64{2, 4, 7, 8, 11}, 1, now32),
+				},
+			},
+			"timeLagSeriesLists",
+			map[string][]*types.MetricData{
+				"timeLagSeries(consumer.1,producer.1)": {types.MakeMetricData("timeLagSeries(consumer.1,producer.1)", []float64{0, 0, 1, 0, 1}, 1, now32)},
+				"timeLagSeries(consumer.2,producer.2)": {types.MakeMetricData("timeLagSeries(consumer.2,producer.2)", []float64{0, 0, 1, 0, 1}, 1, now32)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestMultiReturnEvalExpr(t, &tt)
 		})
 	}
 

--- a/expr/functions/timeLag/function_test.go
+++ b/expr/functions/timeLag/function_test.go
@@ -23,12 +23,12 @@ func init() {
 	}
 }
 
-func TestTimeLagMultiReturn(t *testing.T) {
+func TestTimeLagSeriesMultiReturn(t *testing.T) {
 	now32 := int32(time.Now().Unix())
 
 	tests := []th.MultiReturnEvalTestItem{
 		{
-			"timeLag(metric[12],metric2)",
+			"timeLagSeries(metric[12],metric2)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric[12]", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32),
@@ -41,10 +41,10 @@ func TestTimeLagMultiReturn(t *testing.T) {
 					types.MakeMetricData("metric2", []float64{2, 4, 6, 8, 10}, 1, now32),
 				},
 			},
-			"timeLag",
+			"timeLagSeries",
 			map[string][]*types.MetricData{
-				"timeLag(metric1,metric2)": {types.MakeMetricData("timeLag(metric1,metric2)", []float64{math.NaN(), 1, 2, 2, 3}, 1, now32)},
-				"timeLag(metric2,metric2)": {types.MakeMetricData("timeLag(metric2,metric2)", []float64{0, 0, 0, 0, 0}, 1, now32)},
+				"timeLagSeries(metric1,metric2)": {types.MakeMetricData("timeLagSeries(metric1,metric2)", []float64{math.NaN(), 1, 2, 2, 3}, 1, now32)},
+				"timeLagSeries(metric2,metric2)": {types.MakeMetricData("timeLagSeries(metric2,metric2)", []float64{0, 0, 0, 0, 0}, 1, now32)},
 			},
 		},
 	}
@@ -58,28 +58,28 @@ func TestTimeLagMultiReturn(t *testing.T) {
 
 }
 
-func TestTimeLag(t *testing.T) {
+func TesttimeLagSeriesSeries(t *testing.T) {
 	now32 := int32(time.Now().Unix())
 
 	tests := []th.EvalTestItem{
 		{
-			"timeLag(metric1,metric2)",
+			"timeLagSeries(metric1,metric2)",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32)},
 				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 12}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("timeLag(metric1,metric2)",
+			[]*types.MetricData{types.MakeMetricData("timeLagSeries(metric1,metric2)",
 				[]float64{math.NaN(), math.NaN(), math.NaN(), 1, 2, 0}, 1, now32)},
 		},
 		{
-			"timeLag(metric[12])",
+			"timeLagSeries(metric[12])",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric[12]", 0, 1}: {
 					types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32),
 					types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 12}, 1, now32),
 				},
 			},
-			[]*types.MetricData{types.MakeMetricData("timeLag(metric[12])",
+			[]*types.MetricData{types.MakeMetricData("timeLagSeries(metric[12])",
 				[]float64{math.NaN(), math.NaN(), math.NaN(), 1, 2, 0}, 1, now32)},
 		},
 	}

--- a/expr/functions/timeLag/function_test.go
+++ b/expr/functions/timeLag/function_test.go
@@ -82,6 +82,24 @@ func TestTimeLagSeries(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("timeLagSeries(metric[12])",
 				[]float64{math.NaN(), math.NaN(), math.NaN(), 1, 2, 0}, 1, now32)},
 		},
+		{
+			"timeLagSeries(metric1,metric2)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 1, 1, 1, 1, 1}, 1, now32)},
+				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, 2, 2, 2, 2, 2}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("timeLagSeries(metric1,metric2)",
+				[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, now32)},
+		},
+		{
+			"timeLagSeries(metric1,metric2)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 2, 3}, 1, now32)},
+				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, 3, 4, 5, 6, 7}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("timeLagSeries(metric1,metric2)",
+				[]float64{math.NaN(), 1, 1, 1, 4, 4}, 1, now32)},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Given two monotonically non-decreasing time series (series1,series2), for every datapoint of series1 it computes the time difference required for series1 metric to achieve value of series2.

The easiest way to vizualize its correct work is to produce some ramdom
monotonnically increasing metric. Let's call it 'local.random.diceroll'
and then render the following url: render?target=timeLag(timeStack(local.random.diceroll,'1min',0, 7), local.random.diceroll)&from=-10m
Even though metric values are random, the resulting graph should look like horizontal lines precisely matching time offsets passed to timeStack function