### PR TITLE
Support aggregation specifier symbol @ in metric names for mix aggregation policy

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -426,7 +426,7 @@ func IsNameChar(r byte) bool {
 		r == '[' || r == ']' ||
 		r == '^' || r == '$' ||
 		r == '<' || r == '>' ||
-		r == '&'
+		r == '&' || r == '@'
 }
 
 func isDigit(r byte) bool {


### PR DESCRIPTION
Hi, this is for supporting mix aggregation policy implemented for cwhisper and go-carbon.

Relevant PRs:
https://github.com/go-graphite/go-whisper/pull/5
https://github.com/lomik/go-carbon/pull/331/files
