### PR TITLE
Instrumenting zipper with per cluster/host performance metrics. 

### DIFF
--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -199,8 +199,9 @@ func initBackends(config cfg.Zipper, logger *zap.Logger) ([]backend.Backend, err
 		}).DialContext,
 	}
 
-	backends := make([]backend.Backend, 0, len(config.GetBackends()))
-	for _, host := range config.GetBackends() {
+	configBackendList := config.GetBackends()
+	backends := make([]backend.Backend, 0, len(configBackendList))
+	for _, host := range configBackendList {
 		cluster, _ := config.ClusterOfBackend(host)
 		b, err := bnet.New(bnet.Config{
 			Address:            host,

--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -199,10 +199,12 @@ func initBackends(config cfg.Zipper, logger *zap.Logger) ([]backend.Backend, err
 		}).DialContext,
 	}
 
-	backends := make([]backend.Backend, 0, len(config.Backends))
-	for _, host := range config.Backends {
+	backends := make([]backend.Backend, 0, len(config.GetBackends()))
+	for _, host := range config.GetBackends() {
+		cluster, _ := config.ClusterOfBackend(host)
 		b, err := bnet.New(bnet.Config{
 			Address:            host,
+			Cluster:            cluster,
 			Client:             client,
 			Timeout:            config.Timeouts.AfterStarted,
 			Limit:              config.ConcurrencyLimitPerServer,

--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -270,7 +270,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	request := types.NewRenderRequest([]string{target}, int32(from), int32(until))
-	request.Trace.OutDuration = &app.prometheusMetrics.RenderOutDurationExp
+	request.Trace.OutDuration = app.prometheusMetrics.RenderOutDurationExp
 	bs := app.filterBackendByTopLevelDomain(request.Targets)
 	bs = backend.Filter(bs, request.Targets)
 	metrics, errs := backend.Renders(ctx, bs, request)

--- a/app/carbonzipper/metrics.go
+++ b/app/carbonzipper/metrics.go
@@ -62,7 +62,7 @@ type PrometheusMetrics struct {
 	DurationExp          prometheus.Histogram
 	DurationLin          prometheus.Histogram
 	RenderDurationExp    prometheus.Histogram
-	RenderOutDurationExp prometheus.Histogram
+	RenderOutDurationExp *prometheus.HistogramVec
 	FindDurationExp      prometheus.Histogram
 	FindDurationLin      prometheus.Histogram
 	TimeInQueueExp       prometheus.Histogram
@@ -128,7 +128,7 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 					config.Monitoring.RenderDurationExp.BucketsNum),
 			},
 		),
-		RenderOutDurationExp: prometheus.NewHistogram(
+		RenderOutDurationExp: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Name: "render_outbound_request_duration_seconds_exp",
 				Help: "The durations of render requests sent to storages (exponential)",
@@ -139,6 +139,7 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 					config.Monitoring.RenderDurationExp.BucketSize,
 					config.Monitoring.RenderDurationExp.BucketsNum),
 			},
+			[]string{"cluster"},
 		),
 		FindDurationExp: prometheus.NewHistogram(
 			prometheus.HistogramOpts{

--- a/cfg/common_test.go
+++ b/cfg/common_test.go
@@ -20,8 +20,9 @@ timeouts:
     afterStarted: "15s"
 graphite09compat: true
 backends:
-        - "http://10.190.202.30:8080"
-        - "http://10.190.197.9:8080"
+    - "http://10.190.202.30:8080"
+    - "http://10.190.197.9:8080"
+    - "http://10.190.191.9:8080"
 logger:
     -
        logger: ""
@@ -78,8 +79,8 @@ monitoring:
 		Backends: []string{
 			"http://10.190.202.30:8080",
 			"http://10.190.197.9:8080",
+			"http://10.190.191.9:8080",
 		},
-
 		MaxProcs: 32,
 		Timeouts: Timeouts{
 			Global:       20 * time.Second,
@@ -149,6 +150,189 @@ monitoring:
 		},
 	}
 
+	var backendSize = len(expected.GetBackends())
+	var expectedSize = 3
+	if backendSize != expectedSize {
+		t.Fatalf("Received wrong number of backends: \nExpected %v but returned %v", expectedSize, backendSize)
+	}
+
+	if !eqCommon(got, expected) {
+		t.Fatalf("Didn't parse expected struct from config\nGot: %v\nExp: %v", got, expected)
+	}
+}
+
+func TestParseCommonCluster(t *testing.T) {
+	DEBUG = true
+
+	// TODO (grzkv): Move out to support proper indent with spaces
+	var input = `
+listen: ":8000"
+maxProcs: 32
+concurrencyLimit: 2048
+maxIdleConnsPerHost: 1024
+timeouts:
+    global: "20s"
+    afterStarted: "15s"
+graphite09compat: true
+backendsByCluster:
+    - name: "cluster1"
+      backends:
+      - "http://10.190.202.31:8080"
+      - "http://10.190.197.91:8080"
+    - name: "cluster2"
+      backends:
+      - "http://10.190.202.32:8080"
+      - "http://10.190.197.92:8080"
+logger:
+    -
+       logger: ""
+       file: "/var/log/carbonzipper/carbonzipper.log"
+       level: "info"
+       encoding: "json"
+monitoring:
+    timeInQueueExpHistogram:
+        start: 0.3
+        bucketsNum: 30
+        bucketSize: 3
+    timeInQueueLinHistogram:
+        start: 0.0
+        bucketsNum: 33
+        bucketSize: 0.3
+    requestDurationExpHistogram:
+        start: 0.05
+        bucketsNum: 30
+        bucketSize: 3.0
+    requestDurationLinHistogram:
+        start: 0.0
+        bucketsNum: 30
+        bucketSize: 0.03
+    renderDurationExpHistogram:
+        start: 0.03
+        bucketsNum: 30
+        bucketSize: 6
+    findDurationExpHistogram:
+        start: 0.06
+        bucketsNum: 60
+        bucketSize: 3
+    findDurationLinHistogram:
+        start: 0.1
+        bucketsNum: 20
+        bucketSize: 1
+    findDurationSimpleLinHistogram:
+        start: 0.1
+        bucketsNum: 20
+        bucketSize: 1
+    findDurationComplexLinHistogram:
+        start: 0.1
+        bucketsNum: 20
+        bucketSize: 1
+`
+
+	r := strings.NewReader(input)
+	got, err := ParseCommon(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := Common{
+		Listen: ":8000",
+		BackendsByCluster: []Cluster{
+			Cluster{
+				Name: "cluster1",
+				Backends: []string{
+					"http://10.190.202.31:8080",
+					"http://10.190.197.91:8080",
+				},
+			},
+			Cluster{
+				Name: "cluster2",
+				Backends: []string{
+					"http://10.190.202.32:8080",
+					"http://10.190.197.92:8080",
+				},
+			},
+		},
+		MaxProcs: 32,
+		Timeouts: Timeouts{
+			Global:       20 * time.Second,
+			AfterStarted: 15 * time.Second,
+			Connect:      200 * time.Millisecond,
+		},
+		ConcurrencyLimitPerServer: 2048,
+		KeepAliveInterval:         30 * time.Second,
+		MaxIdleConnsPerHost:       1024,
+
+		ExpireDelaySec:             600,
+		GraphiteWeb09Compatibility: true,
+
+		Buckets: 10,
+		Graphite: GraphiteConfig{
+			Pattern:  "{prefix}.{fqdn}",
+			Host:     "",
+			Interval: 60 * time.Second,
+			Prefix:   "carbon.zipper",
+		},
+		Monitoring: MonitoringConfig{
+			TimeInQueueExpHistogram: HistogramConfig{
+				Start:      0.3,
+				BucketsNum: 30,
+				BucketSize: 3,
+			},
+			TimeInQueueLinHistogram: HistogramConfig{
+				Start:      0.0,
+				BucketsNum: 33,
+				BucketSize: 0.3,
+			},
+			RequestDurationExp: HistogramConfig{
+				Start:      0.05,
+				BucketSize: 3,
+				BucketsNum: 30,
+			},
+			RequestDurationLin: HistogramConfig{
+				Start:      0.0,
+				BucketSize: 0.03,
+				BucketsNum: 30,
+			},
+			RenderDurationExp: HistogramConfig{
+				Start:      0.03,
+				BucketsNum: 30,
+				BucketSize: 6,
+			},
+			FindDurationExp: HistogramConfig{
+				Start:      0.06,
+				BucketsNum: 60,
+				BucketSize: 3,
+			},
+			FindDurationLin: HistogramConfig{
+				Start:      0.1,
+				BucketsNum: 20,
+				BucketSize: 1,
+			},
+			FindDurationLinSimple: HistogramConfig{
+				Start:      0.1,
+				BucketSize: 1,
+				BucketsNum: 20,
+			},
+			FindDurationLinComplex: HistogramConfig{
+				Start:      0.1,
+				BucketSize: 1,
+				BucketsNum: 20,
+			},
+		},
+	}
+
+	backendSize := len(expected.GetBackends())
+	expectedSize := 4
+	if backendSize != expectedSize {
+		t.Fatalf("Received wrong number of backends: \nExpected %v but returned %v", expectedSize, backendSize)
+	}
+
+	cluster, err := expected.ClusterOfBackend("http://10.190.202.32:8080")
+	expectedCluster := "cluster2"
+	if cluster != expectedCluster {
+		t.Fatalf("Problem in getting cluster of a backend: \nExpected %v but returned %v", expectedCluster, cluster)
+	}
+
 	if !eqCommon(got, expected) {
 		t.Fatalf("Didn't parse expected struct from config\nGot: %v\nExp: %v", got, expected)
 	}
@@ -184,5 +368,5 @@ func toComparableCommon(a Common) comparableCommon {
 
 func eqCommon(a, b Common) bool {
 	return toComparableCommon(a) == toComparableCommon(b) &&
-		eqStringSlice(a.Backends, b.Backends)
+		eqStringSlice(a.GetBackends(), b.GetBackends())
 }

--- a/cmd/carbonzipper/main.go
+++ b/cmd/carbonzipper/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/bookingcom/carbonapi/app/carbonzipper"
+	zipper "github.com/bookingcom/carbonapi/app/carbonzipper"
 	"github.com/bookingcom/carbonapi/cfg"
 	"github.com/facebookgo/pidfile"
 	"github.com/lomik/zapwriter"
@@ -60,7 +60,8 @@ func main() {
 	if config.MaxProcs != 0 {
 		runtime.GOMAXPROCS(config.MaxProcs)
 	}
-	if len(config.Backends) == 0 {
+
+	if len(config.GetBackends()) == 0 {
 		logger.Fatal("no Backends loaded -- exiting")
 	}
 

--- a/config/carbonzipper.yaml
+++ b/config/carbonzipper.yaml
@@ -41,8 +41,13 @@ expireDelaySec: 120
 
 # "http://host:port" array of instances of carbonserver stores
 # This is the *ONLY* config element that MUST be specified.
-backends:
-    - "http://go-carbon:8080"
+backendsByCluster:
+    - name: "sys"
+      backends:
+      - "http://go-carbon:8080"
+
+#backends:
+#    - "http://go-carbon:8080"
 
 # Enable compatibility with graphite-web 0.9
 # This will affect graphite-web 1.0+ with multiple cluster_servers

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -92,12 +92,12 @@ type Trace struct {
 	inHTTPCallNS  *int64
 	inReadBodyNS  *int64
 	inUnmarshalNS *int64
-	OutDuration   *prometheus.Histogram
+	OutDuration   *prometheus.HistogramVec
 }
 
-func (t Trace) ObserveOutDuration(ti time.Duration) {
-	if t.OutDuration != nil {
-		(*t.OutDuration).Observe(ti.Seconds())
+func (t Trace) ObserveOutDuration(ti time.Duration, cluster string) {
+	if t.OutDuration != nil { // TODO: check when it is nil
+		(*t.OutDuration).With(prometheus.Labels{"cluster": cluster}).Observe(ti.Seconds())
 	}
 }
 


### PR DESCRIPTION
Instrumenting zipper with per cluster/host performance metrics. 
We first changed configuration to include cluster info, then decorated zipper prometheus metrics with cluster information.