### PR TITLE
fix grace reload usage.

### DIFF
--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -109,7 +109,7 @@ func (app *App) Start() {
 	handler = util.UUIDHandler(handler)
 	handler = recoveryHandler(handler, logger)
 
-	app.registerPrometheusMetrics(logger)
+	prometheusServer := app.registerPrometheusMetrics(logger)
 
 	app.requestBlocker.ScheduleRuleReload()
 
@@ -119,7 +119,7 @@ func (app *App) Start() {
 		Handler:      handler,
 		ReadTimeout:  1 * time.Second,
 		WriteTimeout: app.config.Timeouts.Global,
-	})
+	}, prometheusServer)
 	if err != nil {
 		logger.Fatal("gracehttp failed",
 			zap.Error(err),
@@ -140,45 +140,39 @@ func recoveryHandler(h http.Handler, lg *zap.Logger) http.Handler {
 	})
 }
 
-func (app *App) registerPrometheusMetrics(logger *zap.Logger) {
-	go func() {
-		prometheus.MustRegister(app.prometheusMetrics.Requests)
-		prometheus.MustRegister(app.prometheusMetrics.Responses)
-		prometheus.MustRegister(app.prometheusMetrics.FindNotFound)
-		prometheus.MustRegister(app.prometheusMetrics.RenderPartialFail)
-		prometheus.MustRegister(app.prometheusMetrics.RequestCancel)
-		prometheus.MustRegister(app.prometheusMetrics.DurationExp)
-		prometheus.MustRegister(app.prometheusMetrics.DurationLin)
-		prometheus.MustRegister(app.prometheusMetrics.RenderDurationExp)
-		prometheus.MustRegister(app.prometheusMetrics.RenderDurationExpSimple)
-		prometheus.MustRegister(app.prometheusMetrics.RenderDurationExpComplex)
-		prometheus.MustRegister(app.prometheusMetrics.RenderDurationLinSimple)
-		prometheus.MustRegister(app.prometheusMetrics.RenderDurationPerPointExp)
-		prometheus.MustRegister(app.prometheusMetrics.FindDurationExp)
-		prometheus.MustRegister(app.prometheusMetrics.FindDurationLin)
-		prometheus.MustRegister(app.prometheusMetrics.FindDurationLinSimple)
-		prometheus.MustRegister(app.prometheusMetrics.FindDurationLinComplex)
-		prometheus.MustRegister(app.prometheusMetrics.TimeInQueueExp)
-		prometheus.MustRegister(app.prometheusMetrics.TimeInQueueLin)
+func (app *App) registerPrometheusMetrics(logger *zap.Logger) *http.Server {
+	prometheus.MustRegister(app.prometheusMetrics.Requests)
+	prometheus.MustRegister(app.prometheusMetrics.Responses)
+	prometheus.MustRegister(app.prometheusMetrics.FindNotFound)
+	prometheus.MustRegister(app.prometheusMetrics.RenderPartialFail)
+	prometheus.MustRegister(app.prometheusMetrics.RequestCancel)
+	prometheus.MustRegister(app.prometheusMetrics.DurationExp)
+	prometheus.MustRegister(app.prometheusMetrics.DurationLin)
+	prometheus.MustRegister(app.prometheusMetrics.RenderDurationExp)
+	prometheus.MustRegister(app.prometheusMetrics.RenderDurationExpSimple)
+	prometheus.MustRegister(app.prometheusMetrics.RenderDurationExpComplex)
+	prometheus.MustRegister(app.prometheusMetrics.RenderDurationLinSimple)
+	prometheus.MustRegister(app.prometheusMetrics.RenderDurationPerPointExp)
+	prometheus.MustRegister(app.prometheusMetrics.FindDurationExp)
+	prometheus.MustRegister(app.prometheusMetrics.FindDurationLin)
+	prometheus.MustRegister(app.prometheusMetrics.FindDurationLinSimple)
+	prometheus.MustRegister(app.prometheusMetrics.FindDurationLinComplex)
+	prometheus.MustRegister(app.prometheusMetrics.TimeInQueueExp)
+	prometheus.MustRegister(app.prometheusMetrics.TimeInQueueLin)
 
-		writeTimeout := app.config.Timeouts.Global
-		if writeTimeout < 30*time.Second {
-			writeTimeout = time.Minute
-		}
+	writeTimeout := app.config.Timeouts.Global
+	if writeTimeout < 30*time.Second {
+		writeTimeout = time.Minute
+	}
 
-		s := &http.Server{
-			Addr:         app.config.ListenInternal,
-			Handler:      initHandlersInternal(app),
-			ReadTimeout:  1 * time.Second,
-			WriteTimeout: writeTimeout,
-		}
+	s := &http.Server{
+		Addr:         app.config.ListenInternal,
+		Handler:      initHandlersInternal(app),
+		ReadTimeout:  1 * time.Second,
+		WriteTimeout: writeTimeout,
+	}
 
-		if err := s.ListenAndServe(); err != nil {
-			logger.Fatal("Internal handle server failed",
-				zap.Error(err),
-			)
-		}
-	}()
+	return s
 }
 
 func setUpConfig(app *App, logger *zap.Logger) {

--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -109,7 +109,7 @@ func (app *App) Start() {
 	}
 
 	go app.probeTopLevelDomains(logger)
-	go metricsServer(app, logger)
+	metricsServer := metricsServer(app, logger)
 
 	gracehttp.SetLogger(zap.NewStdLog(logger))
 	err := gracehttp.Serve(&http.Server{
@@ -117,7 +117,7 @@ func (app *App) Start() {
 		Handler:      handler,
 		ReadTimeout:  1 * time.Second,
 		WriteTimeout: app.config.Timeouts.Global,
-	})
+	}, metricsServer)
 
 	if err != nil {
 		log.Fatal("error during gracehttp.Serve()",
@@ -275,7 +275,7 @@ func initGraphite(app *App) {
 	graphite.Register(fmt.Sprintf("%s.pause_ns", pattern), &mstats.PauseNS)
 }
 
-func metricsServer(app *App, logger *zap.Logger) {
+func metricsServer(app *App, logger *zap.Logger) *http.Server {
 	prometheus.MustRegister(app.prometheusMetrics.Requests)
 	prometheus.MustRegister(app.prometheusMetrics.Responses)
 	prometheus.MustRegister(app.prometheusMetrics.FindNotFound)
@@ -303,11 +303,7 @@ func metricsServer(app *App, logger *zap.Logger) {
 		WriteTimeout: writeTimeout,
 	}
 
-	if err := s.ListenAndServe(); err != nil {
-		logger.Fatal("Internal handle server failed",
-			zap.Error(err),
-		)
-	}
+	return s
 }
 
 func publishExpvarz(app *App) {


### PR DESCRIPTION
When trying to restart process using -USR2 new process start would fail
because old process was still listening on prometheus endpoint.

To fix this I added prometheus endpoint to the list of ports handled by
grace.

I also stopped registering prometheus metrics in a separate
routine. From what I tested this didn't seem to cause any issues