### PR TITLE
fix pidfiles:

### DIFF
--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -384,12 +384,12 @@ func setUpConfig(app *App, logger *zap.Logger) {
 
 	if app.config.PidFile != "" {
 		pidfile.SetPidfilePath(app.config.PidFile)
-		err := pidfile.Write()
-		if err != nil {
-			logger.Fatal("error during pidfile.Write()",
-				zap.Error(err),
-			)
-		}
+	}
+	err := pidfile.Write()
+	if err != nil && !pidfile.IsNotConfigured(err) {
+		logger.Fatal("error during pidfile.Write()",
+			zap.Error(err),
+		)
 	}
 
 	helper.ExtrapolatePoints = app.config.ExtrapolateExperiment

--- a/cmd/carbonzipper/main.go
+++ b/cmd/carbonzipper/main.go
@@ -25,15 +25,12 @@ func main() {
 	logger := zapwriter.Logger("main")
 
 	configFile := flag.String("config", "", "config file (yaml)")
-	pidFile := flag.String("pid", "", "pidfile (default: empty, don't create pidfile)")
-	if *pidFile != "" {
-		pidfile.SetPidfilePath(*pidFile)
-		err = pidfile.Write()
-		if err != nil {
-			log.Fatalln("error during pidfile.Write():", err)
-		}
-	}
 	flag.Parse()
+
+	err = pidfile.Write()
+	if err != nil && !pidfile.IsNotConfigured(err) {
+		log.Fatalln("error during pidfile.Write():", err)
+	}
 
 	expvar.NewString("GoVersion").Set(runtime.Version())
 


### PR DESCRIPTION
We had two issues here:
zipper was declaring two flags for -pid:
```
Usage of carbonzipper:
  -config string
        config file (yaml)
  -pid string
        pidfile (default: empty, don't create pidfile)
  -pidfile string
        If specified, write pid to file.
```
It was also using the "pid" flag before parsing the flags.

api was saving the pid only if it was specified in config file, not if it was specified in command line(even if it has the -pidfile argument).