### PR TITLE
auto complete group by node

### DIFF
--- a/expr/functions/averageSeries/function.go
+++ b/expr/functions/averageSeries/function.go
@@ -18,7 +18,7 @@ func GetOrder() interfaces.Order {
 func New(configFile string) []interfaces.FunctionMetadata {
 	f := &averageSeries{}
 	res := make([]interfaces.FunctionMetadata, 0)
-	for _, n := range []string{"avg", "averageSeries"} {
+	for _, n := range []string{"avg", "average", "averageSeries"} {
 		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
 	}
 	return res

--- a/expr/functions/diffSeries/function.go
+++ b/expr/functions/diffSeries/function.go
@@ -21,7 +21,7 @@ func GetOrder() interfaces.Order {
 func New(configFile string) []interfaces.FunctionMetadata {
 	res := make([]interfaces.FunctionMetadata, 0)
 	f := &diffSeries{}
-	functions := []string{"diffSeries"}
+	functions := []string{"diff", "diffSeries"}
 	for _, n := range functions {
 		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
 	}

--- a/expr/functions/stddevSeries/function.go
+++ b/expr/functions/stddevSeries/function.go
@@ -20,7 +20,7 @@ func GetOrder() interfaces.Order {
 func New(configFile string) []interfaces.FunctionMetadata {
 	res := make([]interfaces.FunctionMetadata, 0)
 	f := &stddevSeries{}
-	functions := []string{"stddevSeries"}
+	functions := []string{"stddev", "stddevSeries"}
 	for _, n := range functions {
 		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
 	}


### PR DESCRIPTION
Fix auto-complete suggestions for groupByNode #232

https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.averageSeries states that averageSeries is an alias for aggregate with aggregation average. Therefore "average" method is also added to method list of github.com/bookingcom/carbonapi/expr/averageSeries

Same applied for "diff" and "stddev", which are also alias for "diffSeries" and "stddevSeries" respectively according to graphite documentation.