### PR TITLE
Fix #245: Instrument zipper with per dc/cluster/host performance metrics

### DIFF
--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -203,9 +203,10 @@ func initBackends(config cfg.Zipper, logger *zap.Logger) ([]backend.Backend, err
 	configBackendList := config.GetBackends()
 	backends := make([]backend.Backend, 0, len(configBackendList))
 	for _, host := range configBackendList {
-		cluster, _ := config.ClusterOfBackend(host)
+		dc, cluster, _ := config.InfoOfBackend(host)
 		b, err := bnet.New(bnet.Config{
 			Address:            host,
+			DC:                 dc,
 			Cluster:            cluster,
 			Client:             client,
 			Timeout:            config.Timeouts.AfterStarted,

--- a/app/carbonzipper/metrics.go
+++ b/app/carbonzipper/metrics.go
@@ -139,7 +139,7 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 					config.Monitoring.RenderDurationExp.BucketSize,
 					config.Monitoring.RenderDurationExp.BucketsNum),
 			},
-			[]string{"cluster"},
+			[]string{"dc", "cluster"},
 		),
 		FindDurationExp: prometheus.NewHistogram(
 			prometheus.HistogramOpts{

--- a/cfg/common_test.go
+++ b/cfg/common_test.go
@@ -327,10 +327,225 @@ monitoring:
 		t.Fatalf("Received wrong number of backends: \nExpected %v but returned %v", expectedSize, backendSize)
 	}
 
-	cluster, err := expected.ClusterOfBackend("http://10.190.202.32:8080")
+	_, cluster, err := expected.InfoOfBackend("http://10.190.202.32:8080")
 	expectedCluster := "cluster2"
 	if cluster != expectedCluster {
 		t.Fatalf("Problem in getting cluster of a backend: \nExpected %v but returned %v", expectedCluster, cluster)
+	}
+
+	if !eqCommon(got, expected) {
+		t.Fatalf("Didn't parse expected struct from config\nGot: %v\nExp: %v", got, expected)
+	}
+}
+
+func TestParseCommonDC(t *testing.T) {
+	DEBUG = true
+
+	// TODO (grzkv): Move out to support proper indent with spaces
+	var input = `
+listen: ":8000"
+maxProcs: 32
+concurrencyLimit: 2048
+maxIdleConnsPerHost: 1024
+timeouts:
+    global: "20s"
+    afterStarted: "15s"
+graphite09compat: true
+backendsByDC:
+    - name: "dc1"
+      clusters:
+          - name: "cluster1"
+            backends:
+            - "http://10.190.202.31:8080"
+            - "http://10.190.197.91:8080"
+          - name: "cluster2"
+            backends:
+            - "http://10.190.202.32:8080"
+            - "http://10.190.197.92:8080"
+    - name: "dc2"
+      clusters:
+          - name: "cluster1"
+            backends:
+            - "http://10.290.202.31:8080"
+            - "http://10.290.197.91:8080"
+          - name: "cluster2"
+            backends:
+            - "http://10.290.202.32:8080"
+logger:
+    -
+       logger: ""
+       file: "/var/log/carbonzipper/carbonzipper.log"
+       level: "info"
+       encoding: "json"
+monitoring:
+    timeInQueueExpHistogram:
+        start: 0.3
+        bucketsNum: 30
+        bucketSize: 3
+    timeInQueueLinHistogram:
+        start: 0.0
+        bucketsNum: 33
+        bucketSize: 0.3
+    requestDurationExpHistogram:
+        start: 0.05
+        bucketsNum: 30
+        bucketSize: 3.0
+    requestDurationLinHistogram:
+        start: 0.0
+        bucketsNum: 30
+        bucketSize: 0.03
+    renderDurationExpHistogram:
+        start: 0.03
+        bucketsNum: 30
+        bucketSize: 6
+    findDurationExpHistogram:
+        start: 0.06
+        bucketsNum: 60
+        bucketSize: 3
+    findDurationLinHistogram:
+        start: 0.1
+        bucketsNum: 20
+        bucketSize: 1
+    findDurationSimpleLinHistogram:
+        start: 0.1
+        bucketsNum: 20
+        bucketSize: 1
+    findDurationComplexLinHistogram:
+        start: 0.1
+        bucketsNum: 20
+        bucketSize: 1
+`
+
+	r := strings.NewReader(input)
+	got, err := ParseCommon(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := Common{
+		Listen: ":8000",
+		BackendsByDC: []DC{
+			DC{
+				Name: "dc1",
+				Clusters: []Cluster{
+					Cluster{
+						Name: "cluster1",
+						Backends: []string{
+							"http://10.190.202.31:8080",
+							"http://10.190.197.91:8080",
+						},
+					},
+					Cluster{
+						Name: "cluster2",
+						Backends: []string{
+							"http://10.190.202.32:8080",
+							"http://10.190.197.92:8080",
+						},
+					},
+				},
+			},
+			DC{
+				Name: "dc2",
+				Clusters: []Cluster{
+					Cluster{
+						Name: "cluster1",
+						Backends: []string{
+							"http://10.290.202.31:8080",
+							"http://10.290.197.91:8080",
+						},
+					},
+					Cluster{
+						Name: "cluster2",
+						Backends: []string{
+							"http://10.290.202.32:8080",
+						},
+					},
+				},
+			},
+		},
+		MaxProcs: 32,
+		Timeouts: Timeouts{
+			Global:       20 * time.Second,
+			AfterStarted: 15 * time.Second,
+			Connect:      200 * time.Millisecond,
+		},
+		ConcurrencyLimitPerServer: 2048,
+		KeepAliveInterval:         30 * time.Second,
+		MaxIdleConnsPerHost:       1024,
+
+		ExpireDelaySec:             600,
+		GraphiteWeb09Compatibility: true,
+
+		Buckets: 10,
+		Graphite: GraphiteConfig{
+			Pattern:  "{prefix}.{fqdn}",
+			Host:     "",
+			Interval: 60 * time.Second,
+			Prefix:   "carbon.zipper",
+		},
+		Monitoring: MonitoringConfig{
+			TimeInQueueExpHistogram: HistogramConfig{
+				Start:      0.3,
+				BucketsNum: 30,
+				BucketSize: 3,
+			},
+			TimeInQueueLinHistogram: HistogramConfig{
+				Start:      0.0,
+				BucketsNum: 33,
+				BucketSize: 0.3,
+			},
+			RequestDurationExp: HistogramConfig{
+				Start:      0.05,
+				BucketSize: 3,
+				BucketsNum: 30,
+			},
+			RequestDurationLin: HistogramConfig{
+				Start:      0.0,
+				BucketSize: 0.03,
+				BucketsNum: 30,
+			},
+			RenderDurationExp: HistogramConfig{
+				Start:      0.03,
+				BucketsNum: 30,
+				BucketSize: 6,
+			},
+			FindDurationExp: HistogramConfig{
+				Start:      0.06,
+				BucketsNum: 60,
+				BucketSize: 3,
+			},
+			FindDurationLin: HistogramConfig{
+				Start:      0.1,
+				BucketsNum: 20,
+				BucketSize: 1,
+			},
+			FindDurationLinSimple: HistogramConfig{
+				Start:      0.1,
+				BucketSize: 1,
+				BucketsNum: 20,
+			},
+			FindDurationLinComplex: HistogramConfig{
+				Start:      0.1,
+				BucketSize: 1,
+				BucketsNum: 20,
+			},
+		},
+	}
+
+	backendSize := len(expected.GetBackends())
+	expectedSize := 7
+	if backendSize != expectedSize {
+		t.Fatalf("Received wrong number of backends: \nExpected %v but returned %v", expectedSize, backendSize)
+	}
+
+	dc, cluster, err := expected.InfoOfBackend("http://10.290.202.32:8080")
+	expectedCluster := "cluster2"
+	expectedDC := "dc2"
+	if cluster != expectedCluster {
+		t.Fatalf("Problem in getting cluster of a backend: \nExpected %v but returned %v", expectedCluster, cluster)
+	}
+	if dc != expectedDC {
+		t.Fatalf("Problem in getting dc of a backend: \nExpected %v but returned %v", expectedDC, dc)
 	}
 
 	if !eqCommon(got, expected) {

--- a/config/carbonzipper.yaml
+++ b/config/carbonzipper.yaml
@@ -41,11 +41,18 @@ expireDelaySec: 120
 
 # "http://host:port" array of instances of carbonserver stores
 # This is the *ONLY* config element that MUST be specified.
-backendsByCluster:
-    - name: "sys"
-      backends:
-      - "http://go-carbon:8080"
+backendsByDC:
+    - name: "dc1"
+      clusters:
+          - name: "sys"
+            backends:
+            - "http://go-carbon:8080"
 
+#backendsByCluster:
+#    - name: "sys"
+#      backends:
+#      - "http://go-carbon:8080"
+    
 #backends:
 #    - "http://go-carbon:8080"
 

--- a/pkg/backend/net/net.go
+++ b/pkg/backend/net/net.go
@@ -66,6 +66,7 @@ func ContextCancelCause(err error) string {
 type Backend struct {
 	address        string
 	scheme         string
+	dc             string
 	cluster        string
 	client         *http.Client
 	timeout        time.Duration
@@ -84,6 +85,7 @@ type Config struct {
 	Address string // The backend address.
 
 	// Optional fields
+	DC                 string        // The DC where backend belongs to
 	Cluster            string        // The cluster where backend belongs to
 	Client             *http.Client  // The client to use to communicate with backend. Defaults to http.DefaultClient.
 	Timeout            time.Duration // Set request timeout. Defaults to no timeout.
@@ -114,6 +116,7 @@ func New(cfg Config) (*Backend, error) {
 	b.address = address
 	b.scheme = scheme
 	b.cluster = cfg.Cluster
+	b.dc = cfg.DC
 
 	if cfg.Timeout > 0 {
 		b.timeout = cfg.Timeout
@@ -247,7 +250,7 @@ func (b Backend) do(ctx context.Context, trace types.Trace, req *http.Request) (
 	select {
 	case res := <-ch:
 		trace.AddHTTPCall(t0)
-		trace.ObserveOutDuration(time.Now().Sub(t0), b.cluster)
+		trace.ObserveOutDuration(time.Now().Sub(t0), b.dc, b.cluster)
 
 		var body []byte
 		var bodyErr error
@@ -274,7 +277,7 @@ func (b Backend) do(ctx context.Context, trace types.Trace, req *http.Request) (
 		return res.resp.Header.Get("Content-Type"), body, nil
 
 	case <-ctx.Done():
-		trace.ObserveOutDuration(time.Now().Sub(t0), b.cluster)
+		trace.ObserveOutDuration(time.Now().Sub(t0), b.dc, b.cluster)
 
 		b.logger.Warn("Request context cancelled",
 			zap.String("host", b.address),

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -95,9 +95,9 @@ type Trace struct {
 	OutDuration   *prometheus.HistogramVec
 }
 
-func (t Trace) ObserveOutDuration(ti time.Duration, cluster string) {
+func (t Trace) ObserveOutDuration(ti time.Duration, dc string, cluster string) {
 	if t.OutDuration != nil { // TODO: check when it is nil
-		(*t.OutDuration).With(prometheus.Labels{"cluster": cluster}).Observe(ti.Seconds())
+		(*t.OutDuration).With(prometheus.Labels{"cluster": cluster, "dc": dc}).Observe(ti.Seconds())
 	}
 }
 


### PR DESCRIPTION
This fix enhances the configuration to include dc info to support the structure of "DC > Clusters > Backends", and include the DC of Backend in performance metrics. Previous configurations for "backends" and "backendsByCluster" are still supported. 