### PR TITLE
expr: introduce a new func transformNonNull

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -170,6 +170,7 @@ _When `format=png`_ (default if not specified)
 - timeLagSeriesLists
 - tukeyAbove
 - tukeyBelow
+- transformNonNull
 
 ## Function short docs
 
@@ -297,3 +298,4 @@ _When `format=png`_ (default if not specified)
 | [tukeyAbove](https://en.wikipedia.org/wiki/Tukey%27s_range_test)(seriesList, basis, n, interval=0) |
 | [tukeyBelow](https://en.wikipedia.org/wiki/Tukey%27s_range_test)(seriesList, basis, n, interval=0) |
 | transformNull(seriesList, default=0)                                      |
+| transformNonNull(seriesList, default=1)                                   |

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -603,6 +603,14 @@ func TestEvalExpression(t *testing.T) {
 				[]float64{1, 0, 0, 3, 4, 12}, 1, now32)},
 		},
 		{
+			"transformNonNull(metric1)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("transformNonNull(metric1)",
+				[]float64{1, math.NaN(), math.NaN(), 1, 1, 1}, 1, now32)},
+		},
+		{
 			"reduceSeries(mapSeries(devops.service.*.filter.received.*.count,2), \"asPercent\", 5,\"valid\",\"total\")",
 			map[parser.MetricRequest][]*types.MetricData{
 				{"devops.service.*.filter.received.*.count", 0, 1}: {

--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -88,6 +88,7 @@ import (
 	"github.com/bookingcom/carbonapi/expr/functions/timeLag"
 	"github.com/bookingcom/carbonapi/expr/functions/timeShift"
 	"github.com/bookingcom/carbonapi/expr/functions/timeStack"
+	"github.com/bookingcom/carbonapi/expr/functions/transformNonNull"
 	"github.com/bookingcom/carbonapi/expr/functions/transformNull"
 	"github.com/bookingcom/carbonapi/expr/functions/tukey"
 	"github.com/bookingcom/carbonapi/expr/interfaces"
@@ -272,6 +273,8 @@ func New(configs map[string]string) {
 	funcs = append(funcs, initFunc{name: "timeStack", order: timeStack.GetOrder(), f: timeStack.New})
 
 	funcs = append(funcs, initFunc{name: "transformNull", order: transformNull.GetOrder(), f: transformNull.New})
+
+	funcs = append(funcs, initFunc{name: "transformNonNull", order: transformNonNull.GetOrder(), f: transformNonNull.New})
 
 	funcs = append(funcs, initFunc{name: "tukey", order: tukey.GetOrder(), f: tukey.New})
 

--- a/expr/functions/transformNonNull/function.go
+++ b/expr/functions/transformNonNull/function.go
@@ -1,0 +1,96 @@
+package transformNonNull
+
+import (
+	"fmt"
+
+	"github.com/bookingcom/carbonapi/expr/helper"
+	"github.com/bookingcom/carbonapi/expr/interfaces"
+	"github.com/bookingcom/carbonapi/expr/types"
+	"github.com/bookingcom/carbonapi/pkg/parser"
+)
+
+type transformNonNull struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &transformNonNull{}
+	functions := []string{"transformNonNull"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+// transformNonNull(seriesList, default=0)
+func (f *transformNonNull) Do(e parser.Expr, from, until int32, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
+	arg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
+	if err != nil {
+		return nil, err
+	}
+	defv, err := e.GetFloatNamedOrPosArgDefault("default", 1, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	_, ok := e.NamedArgs()["default"]
+	if !ok {
+		ok = len(e.Args()) > 1
+	}
+
+	var results []*types.MetricData
+	for _, a := range arg {
+		var name string
+		if ok {
+			name = fmt.Sprintf("transformNonNull(%s,%g)", a.Name, defv)
+		} else {
+			name = fmt.Sprintf("transformNonNull(%s)", a.Name)
+		}
+
+		r := *a
+		r.Name = name
+		r.Values = make([]float64, len(a.Values))
+		r.IsAbsent = make([]bool, len(a.Values))
+
+		for i, v := range a.Values {
+			if !a.IsAbsent[i] {
+				v = defv
+			}
+			r.Values[i] = v
+			r.IsAbsent[i] = a.IsAbsent[i]
+		}
+
+		results = append(results, &r)
+	}
+	return results, nil
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *transformNonNull) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"transformNonNull": {
+			Description: "Takes a metric or wildcard seriesList and replaces non-null values with the value\nspecified by `default`.  The value 1 used if not specified.\n\nExample:\n\n.. code-block:: none\n\n  &target=transformNonNull(webapp.pages.*.views, 1)\n\nThis would take any data point with non-null values and replace the value with 1.\nAny other numeric value may be used as well.",
+			Function:    "transformNonNull(seriesList, default=1)",
+			Group:       "Transform",
+			Module:      "graphite.render.functions",
+			Name:        "transformNonNull",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesList",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Default: types.NewSuggestion(1),
+					Name:    "default",
+					Type:    types.Float,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/transformNonNull/function_test.go
+++ b/expr/functions/transformNonNull/function_test.go
@@ -1,0 +1,59 @@
+package transformNonNull
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/bookingcom/carbonapi/expr/helper"
+	"github.com/bookingcom/carbonapi/expr/metadata"
+	"github.com/bookingcom/carbonapi/expr/types"
+	"github.com/bookingcom/carbonapi/pkg/parser"
+	th "github.com/bookingcom/carbonapi/tests"
+)
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestTransformNonNull(t *testing.T) {
+	now32 := int32(time.Now().Unix())
+	cases := []th.EvalTestItem{
+		{
+			"transformNonNull(ns1.ns2.count)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"ns1.ns2.count", 0, 1}: {
+					types.MakeMetricData("ns1.ns2.count", []float64{3, math.NaN(), 3, 3, 3}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData(
+				"transformNonNull(ns1.ns2.count)",
+				[]float64{1, math.NaN(), 1, 1, 1}, 1, now32,
+			)},
+		},
+		{
+			"transformNonNull(ns1.ns2.count, 100)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"ns1.ns2.count", 0, 1}: {
+					types.MakeMetricData("ns1.ns2.count", []float64{3, math.NaN(), 3, 3, 3}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData(
+				"transformNonNull(ns1.ns2.count,100)",
+				[]float64{100, math.NaN(), 100, 100, 100}, 1, now32,
+			)},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Target, func(t *testing.T) {
+			th.TestEvalExpr(t, &c)
+		})
+	}
+}

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -140,7 +140,6 @@ func NearlyEqual(a []float64, absent []bool, b []float64) bool {
 }
 
 func NearlyEqualMetrics(a, b *types.MetricData) bool {
-
 	if len(a.IsAbsent) != len(b.IsAbsent) {
 		return false
 	}


### PR DESCRIPTION
One of the use cause for this func could be used with transformNull to count
changes of metric size:
    sum(transformNull(transformNonNull(ns1.ns2.*.count), 0))

## What issue is this change attempting to solve?

Add a symmetrical new func to transformNull: transformNonNull

## How does this change solve the problem? Why is this the best approach?

There is no alternative function exist in the tool.

## How can we be sure this works as expected?

There are tests and it's has been tried out on my local env against our production servers.

![image](https://user-images.githubusercontent.com/459505/81545909-e32e2700-9379-11ea-94fa-9f07f68de706.png)

