### PR TITLE
Avereha/go1.14

### DIFF
--- a/docker/carbonapi/Dockerfile
+++ b/docker/carbonapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.12
 
 RUN apt-get update
 RUN apt-get install -y libcairo2-dev

--- a/docker/carbonapi/Dockerfile
+++ b/docker/carbonapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12
+FROM golang:1.14
 
 RUN apt-get update
 RUN apt-get install -y libcairo2-dev

--- a/docker/go-carbon/Dockerfile
+++ b/docker/go-carbon/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.12
 
 RUN mkdir -p /data/graphite/whisper/
 COPY ./docker/go-carbon/*.conf /etc/

--- a/docker/go-carbon/Dockerfile
+++ b/docker/go-carbon/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12
+FROM golang:1.14
 
 RUN mkdir -p /data/graphite/whisper/
 COPY ./docker/go-carbon/*.conf /etc/

--- a/docker/nanotube/Dockerfile
+++ b/docker/nanotube/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12
+FROM golang:1.14
 
 RUN go get github.com/bookingcom/nanotube/cmd/nanotube
 RUN go install github.com/bookingcom/nanotube/cmd/nanotube

--- a/docker/zipper/Dockerfile
+++ b/docker/zipper/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12
+FROM golang:1.14
 
 RUN apt-get update
 RUN apt-get install -y libcairo2-dev

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bookingcom/carbonapi
 
-go 1.12
+go 1.14
 
 require (
 	bitbucket.org/tebeka/strftime v0.0.0-20121209190902-af5e0ef38369


### PR DESCRIPTION
## What issue is this change attempting to solve?

Update go version that we are using to build carbonapi/carbonzipper to 1.14

## How does this change solve the problem? Why is this the best approach?

This is the last available version https://golang.org/doc/devel/release.html#go1.14

## How can we be sure this works as expected?

Ran tests.