### PR TITLE
github.com/lomik/go-carbon moved to github.com/go-graphite/go-carbon

### DIFF
--- a/docker/go-carbon/Dockerfile
+++ b/docker/go-carbon/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.14
 RUN mkdir -p /data/graphite/whisper/
 COPY ./docker/go-carbon/*.conf /etc/
 
-RUN go get github.com/lomik/go-carbon
-RUN go install github.com/lomik/go-carbon
+RUN go get github.com/go-graphite/go-carbon
+RUN go install github.com/go-graphite/go-carbon
 
 EXPOSE 2003 2004 7002 7007 2003/udp
 

--- a/docker/go-carbon/go-carbon.conf
+++ b/docker/go-carbon/go-carbon.conf
@@ -84,7 +84,7 @@ buffer-size = 0
 # [receiver.protobuf]
 # protocol = "protobuf"
 # # Same framing protocol as pickle, but message encoded in protobuf format
-# # See https://github.com/lomik/go-carbon/blob/master/helper/carbonpb/carbon.proto
+# # See https://github.com/go-graphite/go-carbon/blob/master/helper/carbonpb/carbon.proto
 # listen = ":2005"
 # # Limit message size for prevent memory overflow
 # max-message-size = 67108864
@@ -132,8 +132,8 @@ enabled = true
 read-timeout = "30s"
 
 # grpc api
-# protocol: https://github.com/lomik/go-carbon/blob/master/helper/carbonpb/carbon.proto
-# samples: https://github.com/lomik/go-carbon/tree/master/api/sample
+# protocol: https://github.com/go-graphite/go-carbon/blob/master/helper/carbonpb/carbon.proto
+# samples: https://github.com/go-graphite/go-carbon/tree/master/api/sample
 [grpc]
 listen = ":7003"
 enabled = true

--- a/intervalset/intervalset.go
+++ b/intervalset/intervalset.go
@@ -1,6 +1,6 @@
 package intervalset
 
-// Copy paste from https://github.com/lomik/go-carbon/blob/master/carbonserver/pickle.go
+// Copy paste from https://github.com/go-graphite/go-carbon/blob/master/carbonserver/pickle.go
 // Original license: MIT
 // Original author: Roman Lomonosov
 


### PR DESCRIPTION
## What issue is this change attempting to solve?

Fix integration tests. Update links to point to the new location.

## How does this change solve the problem? Why is this the best approach?

Related commit:
https://github.com/go-graphite/go-carbon/commit/7337479972c84f22f1bea1f274b4c97e295e0a45

## How can we be sure this works as expected?
https://travis-ci.com/github/bookingcom/carbonapi/jobs/359660398
