### PR TITLE
Router: start using middlewares

### DIFF
--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -31,12 +31,10 @@ import (
 
 	"github.com/facebookgo/grace/gracehttp"
 	"github.com/facebookgo/pidfile"
-	"github.com/gorilla/handlers"
 	"github.com/lomik/zapwriter"
 	"github.com/peterbourgon/g2g"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	muxtrace "go.opentelemetry.io/contrib/instrumentation/gorilla/mux"
 	"go.uber.org/zap"
 )
 
@@ -107,14 +105,6 @@ func (app *App) Start() func() {
 	flush := trace.InitTracer("carbonapi", logger, app.config.Traces)
 
 	handler := initHandlers(app)
-	handler = handlers.CompressHandler(handler)
-	handler = handlers.CORS()(handler)
-	handler = handlers.ProxyHeaders(handler)
-	handler = util.UUIDHandler(handler)
-	handler = recoveryHandler(handler, logger)
-
-	traceMiddleware := muxtrace.Middleware("carbonapi")
-	handler = traceMiddleware(handler)
 
 	prometheusServer := app.registerPrometheusMetrics(logger)
 

--- a/app/carbonapi/routes.go
+++ b/app/carbonapi/routes.go
@@ -43,17 +43,16 @@ func initHandlers(app *App) http.Handler {
 	r.Use(handlers.CORS())
 	r.Use(handlers.ProxyHeaders)
 	r.Use(util.UUIDHandler)
-
-	tracing := muxtrace.Middleware("carbonapi")
+	r.Use(muxtrace.Middleware("carbonapi"))
 
 	r.HandleFunc("/render", httputil.TimeHandler(
-		app.validateRequest(tracing(http.HandlerFunc(app.renderHandler)), "render"), app.bucketRequestTimes))
+		app.validateRequest(http.HandlerFunc(app.renderHandler), "render"), app.bucketRequestTimes))
 
 	r.HandleFunc("/metrics/find", httputil.TimeHandler(
-		app.validateRequest(tracing(http.HandlerFunc(app.findHandler)), "find"), app.bucketRequestTimes))
+		app.validateRequest(http.HandlerFunc(app.findHandler), "find"), app.bucketRequestTimes))
 
 	r.HandleFunc("/info", httputil.TimeHandler(
-		app.validateRequest(tracing(http.HandlerFunc(app.infoHandler)), "info"), app.bucketRequestTimes))
+		app.validateRequest(http.HandlerFunc(app.infoHandler), "info"), app.bucketRequestTimes))
 
 	r.HandleFunc("/lb_check", httputil.TimeHandler(app.lbcheckHandler, app.bucketRequestTimes))
 


### PR DESCRIPTION
#214  What issue is this change attempting to solve?

Now that we have gorilla/mux we can `Use` middlewares.
This should also solve "HTTP GET route not found" from traces title.

## How does this change solve the problem? Why is this the best approach?

Now that we can `Use` middlewares, this should be more readable compared to chaining them by hand.

## How can we be sure this works as expected?

Tested with prod traffic and by hand:
```
 curl -H "Accept-Encoding: gzip" -I localhost:8091/render
...
Content-Encoding: gzip
```
