### PR TITLE
traces: send errors as bool 

### DIFF
--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -102,7 +102,7 @@ func New(config cfg.API, logger *zap.Logger, buildVersion string) (*App, error) 
 func (app *App) Start() func() {
 	logger := zapwriter.Logger("carbonapi")
 
-	flush := trace.InitTracer("carbonapi", logger, app.config.Traces)
+	flush := trace.InitTracer(BuildVersion, "carbonapi", logger, app.config.Traces)
 
 	handler := initHandlers(app)
 

--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -233,11 +233,12 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 	partiallyFailed = partiallyFailed || (totalErrStr != "")
 
 	if totalErrStr != "" {
-		span.SetAttribute("error", totalErrStr)
+		span.SetAttribute("error.message", totalErrStr)
 	}
 
 	if totalErr != nil {
 		toLog.Reason = totalErr.Error()
+		span.SetAttribute("error", true)
 		if _, ok := totalErr.(dataTypes.ErrNotFound); ok {
 			writeError(ctx, r, w, http.StatusNotFound, totalErr.Error(), form)
 			toLog.HttpCode = http.StatusNotFound

--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -67,7 +67,7 @@ func New(config cfg.Zipper, logger *zap.Logger, buildVersion string) (*App, erro
 func (app *App) Start() func() {
 	logger := zapwriter.Logger("zipper")
 
-	flush := trace.InitTracer("carbonzipper", logger, app.config.Traces)
+	flush := trace.InitTracer(BuildVersion, "carbonzipper", logger, app.config.Traces)
 
 	types.SetCorruptionWatcher(app.config.CorruptionThreshold, logger)
 

--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -100,7 +100,8 @@ func (app *App) findHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if err != nil {
-		span.SetAttribute("error", err.Error())
+		span.SetAttribute("error", true)
+		span.SetAttribute("error.message", err.Error())
 
 		if _, ok := errors.Cause(err).(types.ErrNotFound); ok {
 			// graphite-web 0.9.12 needs to get a 200 OK response with an empty
@@ -169,7 +170,8 @@ func (app *App) findHandler(w http.ResponseWriter, req *http.Request) {
 		)
 		Metrics.Errors.Add(1)
 		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusInternalServerError), "find").Inc()
-		span.SetAttribute("error", err.Error())
+		span.SetAttribute("error", true)
+		span.SetAttribute("error.message", err.Error())
 		return
 	}
 
@@ -253,7 +255,8 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request) {
 		)
 		Metrics.Errors.Add(1)
 		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusBadRequest), "render").Inc()
-		span.SetAttribute("error", "from is not a integer")
+		span.SetAttribute("error", true)
+		span.SetAttribute("error.message", "from is not a integer")
 		return
 	}
 
@@ -269,7 +272,8 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request) {
 		)
 		Metrics.Errors.Add(1)
 		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusBadRequest), "render").Inc()
-		span.SetAttribute("error", "until is not a integer")
+		span.SetAttribute("error", true)
+		span.SetAttribute("error.message", "until is not a integer")
 		return
 	}
 
@@ -288,7 +292,8 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request) {
 		)
 		Metrics.Errors.Add(1)
 		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusBadRequest), "render").Inc()
-		span.SetAttribute("error", "empty target")
+		span.SetAttribute("error", true)
+		span.SetAttribute("error.message", "empty target")
 		return
 	}
 
@@ -308,7 +313,8 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request) {
 		app.prometheusMetrics.RequestCancel.WithLabelValues(
 			"find", nt.ContextCancelCause(ctx.Err()),
 		).Inc()
-		span.SetAttribute("error", ctx.Err().Error())
+		span.SetAttribute("error", true)
+		span.SetAttribute("error.message", ctx.Err().Error())
 	}
 
 	if err != nil {
@@ -330,8 +336,8 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request) {
 
 		Metrics.Errors.Add(1)
 		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(code), "render").Inc()
-		span.SetAttribute("error", err.Error())
-
+		span.SetAttribute("error", true)
+		span.SetAttribute("error.message", err.Error())
 		return
 	}
 
@@ -363,7 +369,8 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request) {
 		)
 		Metrics.Errors.Add(1)
 		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusInternalServerError), "render").Inc()
-		span.SetAttribute("error", err.Error())
+		span.SetAttribute("error", true)
+		span.SetAttribute("error.message", err.Error())
 
 		return
 	}

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -21,7 +21,7 @@ import (
 )
 
 // InitTracer creates a new trace provider instance and registers it as global trace provider.
-func InitTracer(serviceName string, logger *zap.Logger, config cfg.Traces) func() {
+func InitTracer(BuildVersion string, serviceName string, logger *zap.Logger, config cfg.Traces) func() {
 
 	endpoint := os.Getenv("JAEGER_ENDPOINT")
 	if endpoint == "" {
@@ -51,6 +51,7 @@ func InitTracer(serviceName string, logger *zap.Logger, config cfg.Traces) func(
 			Tags: []kv.KeyValue{
 				kv.String("exporter", "jaeger"),
 				kv.String("host.hostname", fqdn),
+				kv.String("service.version", BuildVersion),
 			},
 		}),
 		jaeger.RegisterAsGlobal(),


### PR DESCRIPTION
## What issue is this change attempting to solve?

traces: send errors as bool and put the actual error message in error.message
add also service.version tag so we know what version of carbonapi/zipper is generating the trace.

## How does this change solve the problem? Why is this the best approach?

TIL that convention is to set the 'error' field to true for spans with
errors:

https://github.com/opentracing/specification/blob/master/semantic_conventions.md

## How can we be sure this works as expected?

