### PR TITLE
classify ErrWildcardNotAllowed and ErrTooManyArguments as ParseError

### DIFF
--- a/expr/types/types.go
+++ b/expr/types/types.go
@@ -2,12 +2,13 @@ package types
 
 import (
 	"bytes"
-	"errors"
 	"math"
 	"strconv"
 	"time"
 
+	"github.com/bookingcom/carbonapi/pkg/parser"
 	"github.com/bookingcom/carbonapi/pkg/types"
+
 	"github.com/bookingcom/carbonapi/pkg/types/encoding/carbonapi_v2"
 
 	pickle "github.com/lomik/og-rek"
@@ -15,9 +16,9 @@ import (
 
 var (
 	// ErrWildcardNotAllowed is an eval error returned when a wildcard/glob argument is found where a single series is required.
-	ErrWildcardNotAllowed = errors.New("found wildcard where series expected")
+	ErrWildcardNotAllowed = parser.ParseError("found wildcard where series expected")
 	// ErrTooManyArguments is an eval error returned when too many arguments are provided.
-	ErrTooManyArguments = errors.New("too many arguments")
+	ErrTooManyArguments = parser.ParseError("too many arguments")
 )
 
 // MetricData contains necessary data to represent parsed metric (ready to be send out or drawn)


### PR DESCRIPTION
## What issue is this change attempting to solve?

errors: classify ErrWildcardNotAllowed and ErrTooManyArguments as
parsing errors
That way, we will answer with HTTP  400 instead of HTTP 500 when we encouter those errors.

## How does this change solve the problem? Why is this the best approach?

Only reason we have them in this package is because we are doing this
validation during eval and not during parsing

## How can we be sure this works as expected?

make test