### PR TITLE
Avereha/lcm

### DIFF
--- a/expr/functions/divideSeries/function_test.go
+++ b/expr/functions/divideSeries/function_test.go
@@ -82,6 +82,28 @@ func TestDivideSeries(t *testing.T) {
 			[]*types.MetricData{types.MakeMetricData("divideSeries(metric[12])",
 				[]float64{0.5, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 2}, 1, now32)},
 		},
+		{
+			"divideSeries(different_length_metric[12])",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"different_length_metric[12]", 0, 1}: {
+					types.MakeMetricData("different_length_metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 5, 6, 7, 8}, 1, now32),
+					types.MakeMetricData("different_length_metric2", []float64{2, math.NaN(), 3, math.NaN(), 2}, 2, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("divideSeries(different_length_metric[12])",
+				[]float64{0.5, math.NaN(), 1.5, math.NaN(), 4}, 1, now32)},
+		},
+		{
+			"divideSeries(different_length_metric[12])",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"different_length_metric[12]", 0, 1}: {
+					types.MakeMetricData("different_length_metric1", []float64{1, math.NaN(), 2, 3, 4}, 1, now32),
+					types.MakeMetricData("different_length_metric2", []float64{1, math.NaN(), 2}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData("divideSeries(different_length_metric[12])",
+				[]float64{1, math.NaN(), 1, math.NaN(), math.NaN()}, 1, now32)},
+		},
 	}
 
 	for _, tt := range tests {

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -468,3 +468,16 @@ func Poly(x float64, coeffs ...float64) float64 {
 	}
 	return y
 }
+
+// GCD computes the Greatest Common Divisor of two numbers
+func GCD(a, b int32) int32 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+// LCM computes the Least Commong Multiple of two numbers
+func LCM(a, b int32) int32 {
+	return (a * b) / GCD(a, b)
+}


### PR DESCRIPTION
## What issue is this change attempting to solve?

Fix "series %s must have the same length as %s" errors

## How does this change solve the problem? Why is this the best approach?

Implemented the same logic from original graphite: if two different series have different steps, consolidate both at lcm(steps).
If their length is still not equal, pad with Nulls.

I think that if we rewrite the consolidation interface that we have, we would not need to copy input parameters anymore, but this is a change for another time.

## How can we be sure this works as expected?

Existing tests are passing. Added new tests.
Compared graphs with graphite and they are identical. Error is not there anymore.
