### PR TITLE
Avereha/time lag

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -2,6 +2,8 @@ package expr
 
 import (
 	// Import all known functions
+	"fmt"
+
 	_ "github.com/bookingcom/carbonapi/expr/functions"
 	"github.com/bookingcom/carbonapi/expr/helper"
 	"github.com/bookingcom/carbonapi/expr/metadata"
@@ -51,7 +53,7 @@ func EvalExpr(e parser.Expr, from, until int32, values map[parser.MetricRequest]
 		return f.Do(e, from, until, values)
 	}
 
-	return nil, helper.ErrUnknownFunction(e.Target())
+	return nil, fmt.Errorf("%w: %s", helper.ErrUnknownFunction, e.Target())
 }
 
 // RewriteExpr expands targets that use applyByNode into a new list of targets.

--- a/expr/functions/cairo/png/cairo.go
+++ b/expr/functions/cairo/png/cairo.go
@@ -868,7 +868,7 @@ func EvalExprGraph(e parser.Expr, from, until int32, values map[parser.MetricReq
 
 	}
 
-	return nil, helper.ErrUnknownFunction(e.Target())
+	return nil, fmt.Errorf("%w: %s", helper.ErrUnknownFunction, e.Target())
 }
 
 func MarshalSVG(params PictureParams, results []*types.MetricData) []byte {

--- a/expr/functions/seriesList/function.go
+++ b/expr/functions/seriesList/function.go
@@ -39,7 +39,7 @@ func (f *seriesList) Do(e parser.Expr, from, until int32, values map[parser.Metr
 	}
 
 	if len(numerators) != len(denominators) {
-		return nil, fmt.Errorf("both %s arguments must have equal length", e.Target())
+		return nil, fmt.Errorf("%w: %s", parser.ErrDifferentCountMetrics, e.Target())
 	}
 
 	var results []*types.MetricData

--- a/expr/functions/timeLag/function.go
+++ b/expr/functions/timeLag/function.go
@@ -108,7 +108,7 @@ func (f *timeLag) Do(e parser.Expr, from, until int32, values map[parser.MetricR
 			}
 		case "timeLagSeriesLists":
 			if len(producerMetrics) != len(consumerMetrics) {
-				return nil, fmt.Errorf("both %s arguments must have equal length", e.Target())
+				return nil, fmt.Errorf("%w: %s", parser.ErrDifferentCountMetrics, e.Target())
 			}
 		}
 	} else if len(firstArg) == 2 && len(e.Args()) == 1 {

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -22,12 +22,7 @@ var evaluator interfaces.Evaluator
 // Backref is a pre-compiled expression for backref
 var Backref = regexp.MustCompile(`\\(\d+)`)
 
-// ErrUnknownFunction is an error message about unknown function
-type ErrUnknownFunction string
-
-func (e ErrUnknownFunction) Error() string {
-	return fmt.Sprintf("unknown function in evalExpr: %q", string(e))
-}
+var ErrUnknownFunction = parser.ParseError("unknown function")
 
 // SetEvaluator sets evaluator for all helper functions
 func SetEvaluator(e interfaces.Evaluator) {

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -45,6 +45,8 @@ var (
 	ErrSeriesDoesNotExist = ParseError("no timeseries with that name")
 	// ErrUnknownTimeUnits is an eval error returned when a time unit is unknown to system
 	ErrUnknownTimeUnits = ParseError("unknown time units")
+	// ErrBothArgumentsMusthaveSameLenght is an eval error returned when a function that works on pairs of metrics receives arguments having different number of metrics.
+	ErrDifferentCountMetrics = ParseError("both arguments must have the same number of metrics")
 )
 
 // ParseError is a type of errors returned from the parser

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -45,7 +45,7 @@ var (
 	ErrSeriesDoesNotExist = ParseError("no timeseries with that name")
 	// ErrUnknownTimeUnits is an eval error returned when a time unit is unknown to system
 	ErrUnknownTimeUnits = ParseError("unknown time units")
-	// ErrBothArgumentsMusthaveSameLenght is an eval error returned when a function that works on pairs of metrics receives arguments having different number of metrics.
+	// ErrDifferentCountMetrics is an eval error returned when a function that works on pairs of metrics receives arguments having different number of metrics.
 	ErrDifferentCountMetrics = ParseError("both arguments must have the same number of metrics")
 )
 


### PR DESCRIPTION
## What issue is this change attempting to solve?

Fix error classification for:
 - unknown function
 - calls for functions that work on pairs of arguments

## How does this change solve the problem? Why is this the best approach?

That way, we also answer with HTTP 4xx instead of Internal server errors for bad queries.

## How can we be sure this works as expected?

tested by hand.