### PR TITLE
Avereha/consolidate

### DIFF
--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -582,7 +582,7 @@ func (app *App) renderWriteBody(results []*types.MetricData, form renderForm, r 
 	switch form.format {
 	case jsonFormat:
 		if maxDataPoints, _ := strconv.Atoi(r.FormValue("maxDataPoints")); maxDataPoints != 0 {
-			types.ConsolidateJSON(maxDataPoints, results)
+			results = types.ConsolidateJSON(maxDataPoints, results)
 		}
 
 		body = types.MarshalJSON(results)

--- a/expr/types/types.go
+++ b/expr/types/types.go
@@ -42,7 +42,6 @@ func MakeMetricData(name string, values []float64, step, start int32) *MetricDat
 			absent[i] = true
 		}
 	}
-
 	stop := start + int32(len(values))*step
 
 	return &MetricData{Metric: types.Metric{
@@ -257,6 +256,7 @@ func MarshalRaw(results []*MetricData) []byte {
 func (r *MetricData) Consolidate(valuesPerPoint int) *MetricData {
 	ret := *r
 	if valuesPerPoint == 1 || valuesPerPoint == 0 {
+		ret.ValuesPerPoint = 1
 		ret.Values = make([]float64, len(r.Values))
 		ret.IsAbsent = make([]bool, len(r.IsAbsent))
 		copy(ret.Values, r.Values)
@@ -279,6 +279,9 @@ func (r *MetricData) Consolidate(valuesPerPoint int) *MetricData {
 
 	for len(v) >= valuesPerPoint {
 		val, abs := ret.AggregateFunction(v[:valuesPerPoint], absent[:valuesPerPoint])
+		if math.IsNaN(val) {
+			val = 0
+		}
 		aggV = append(aggV, val)
 		aggA = append(aggA, abs)
 		v = v[valuesPerPoint:]
@@ -287,6 +290,9 @@ func (r *MetricData) Consolidate(valuesPerPoint int) *MetricData {
 
 	if len(v) > 0 {
 		val, abs := ret.AggregateFunction(v, absent)
+		if math.IsNaN(val) {
+			val = 0
+		}
 		aggV = append(aggV, val)
 		aggA = append(aggA, abs)
 	}

--- a/expr/types/types_test.go
+++ b/expr/types/types_test.go
@@ -1,10 +1,12 @@
 package types
 
 import (
+	"math"
 	"testing"
 	"time"
 
 	"github.com/bookingcom/carbonapi/pkg/types"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestMarshalCSVInUTC(t *testing.T) {
@@ -53,5 +55,85 @@ func TestMarshalCSVNotInUTC(t *testing.T) {
 
 	if got != exp {
 		t.Errorf("Expected '%s', got '%s'", exp, got)
+	}
+}
+
+func TestConsolidate(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          *MetricData
+		valuesPerPoint int
+		expected       *MetricData
+		expectedEnd    int32
+		aggregation    func([]float64, []bool) (float64, bool)
+	}{
+		{"no consolidation",
+			MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, 0),
+			1,
+			MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, 0),
+			6,
+			nil,
+		},
+		{"valuesPerPoint_2_none_values",
+			MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, 0),
+			2,
+			MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN()}, 2, 0),
+			5,
+			nil,
+		},
+		{"valuesPerPoint_2_some_none_values",
+			MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 1, 2, 3, 4}, 1, 0),
+			2,
+			MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), 1, 2.5, 4}, 2, 0),
+			9,
+			nil,
+		},
+		{"valuesPerPoint_2_average",
+			MakeMetricData("metric1", []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 1, 0),
+			2,
+			MakeMetricData("metric1", []float64{0.5, 2.5, 4.5, 6.5, 8.5, 10}, 2, 0),
+			11,
+			nil,
+		},
+		{"valuesPerPoint_2_max",
+			MakeMetricData("metric1", []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 1, 0),
+			2,
+			MakeMetricData("metric1", []float64{1, 3, 5, 7, 9, 10}, 2, 0),
+			11,
+			AggMax,
+		},
+		{"valuesPerPoint_2_min",
+			MakeMetricData("metric1", []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 1, 0),
+			2,
+			MakeMetricData("metric1", []float64{0, 2, 4, 6, 8, 10}, 2, 0),
+			11,
+			AggMin,
+		},
+	}
+
+	for _, test := range tests {
+		if test.aggregation != nil {
+			test.input.AggregateFunction = test.aggregation
+		}
+		got := test.input.Consolidate(test.valuesPerPoint)
+		if diff := cmp.Diff(test.expected.Values, got.Values); diff != "" {
+			t.Errorf("Consolidation Values for %s (-want +got):\n%s", test.name, diff)
+		}
+		if diff := cmp.Diff(test.expected.IsAbsent, got.IsAbsent); diff != "" {
+			t.Errorf("Consolidation IsAbsent for %s (-want +got):\n%s", test.name, diff)
+		}
+		if test.valuesPerPoint != got.ValuesPerPoint {
+			t.Errorf("Consolidation ValuesPerPoint for %s. Want: %d. Got: %d", test.name, test.valuesPerPoint, got.ValuesPerPoint)
+		}
+		if test.expectedEnd != got.StopTime {
+			t.Errorf("Consolidation StopTime for %s. Want: %d. Got: %d", test.name, test.expectedEnd, got.StopTime)
+		}
+		if test.expected.StepTime != got.StepTime {
+			t.Errorf("Consolidation StepTime for %s. Want: %d. Got: %d", test.name, test.expected.StepTime, got.StepTime)
+		}
+		if test.expected.StartTime != got.StartTime {
+			t.Errorf("Consolidation StartTime for %s. Want: %d. Got: %d", test.name, test.expected.StartTime, got.StartTime)
+		}
+
 	}
 }


### PR DESCRIPTION
## What issue is this change attempting to solve?

https://github.com/bookingcom/carbonapi/issues/278
Do not keep state that we don't use in MetricsData.
Simplify API. 
Add missing tests for consolidation

## How does this change solve the problem? Why is this the best approach?

Instead of keeping state on MetricsData, just return a new MetricsData when we consolidate.

## How can we be sure this works as expected?

Added tests.
make test.
tested by hand.
