### PR TITLE
carbonapi: add new config option `printErrorStackTrace`

### DIFF
--- a/cfg/common.go
+++ b/cfg/common.go
@@ -118,6 +118,7 @@ func DefaultCommonConfig() Common {
 		Traces: Traces{
 			Timeout: 10 * time.Second,
 		},
+		PrintErrorStackTrace: false,
 	}
 }
 
@@ -158,7 +159,8 @@ type Common struct {
 
 	Monitoring MonitoringConfig `yaml:"monitoring"`
 
-	Traces Traces `yaml:"traces"`
+	Traces               Traces `yaml:"traces"`
+	PrintErrorStackTrace bool   `yaml:"printErrorStackTrace"`
 }
 
 // GetBackends returns the list of backends from common configuration


### PR DESCRIPTION
# What issue is this change attempting to solve?

When we get panics during evalExpression, we can see only the error
message, for example:
`index out of range [8] with length 2`
This makes it impossible to debug.

## How does this change solve the problem? Why is this the best approach?

With the new option to print the stack trace, we can see where is the
error coming from

## How can we be sure this works as expected?

Tested on one server.