### PR TITLE
asPercent: return [] if the first argument is not found

### DIFF
--- a/expr/functions/asPercent/function.go
+++ b/expr/functions/asPercent/function.go
@@ -36,6 +36,9 @@ func (f *asPercent) Do(e parser.Expr, from, until int32, values map[parser.Metri
 	if err != nil {
 		return nil, err
 	}
+	if len(arg) == 0 {
+		return arg, nil
+	}
 
 	var getTotal func(i int) float64
 	var formatName func(a, b string) string

--- a/expr/functions/asPercent/function_test.go
+++ b/expr/functions/asPercent/function_test.go
@@ -88,6 +88,17 @@ func TestAliasByNode(t *testing.T) {
 				types.MakeMetricData("asPercent(MISSING,Server3.memory.total)", []float64{math.NaN(), math.NaN(), math.NaN()}, 1, now32),
 			},
 		},
+		{
+			"asPercent(not_found,Server{1,3}.memory.total)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"not_found", 0, 1}: {},
+				{"Server{1,3}.memory.total", 0, 1}: {
+					types.MakeMetricData("Server1.memory.total", []float64{4, 4, 8}, 1, now32),
+					types.MakeMetricData("Server3.memory.total", []float64{4, 16, 2}, 1, now32),
+				},
+			},
+			[]*types.MetricData{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What issue is this change attempting to solve?

For this expression `asPercent(not_found_metric, found_metric)` we
would answer with http 5xx.
Now we answer with 404, Not Found.

## How does this change solve the problem? Why is this the best approach?

I considered two possible solutions:
 a) return empty timeseries array.
 b) return types.ErrMetricsNotFound.

I opted for a) becuase this is what divideSeries is doing if first
argument is not found.

## How can we be sure this works as expected?

graphite python is answering with 5xx too. 
Added test.