### PR TITLE
add # to characters that can be part of a Metric Name

### DIFF
--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -1708,6 +1708,10 @@ func TestExtractMetric(t *testing.T) {
 			"{something}",
 			"{something}",
 		},
+		{
+			"a.b#c.d",
+			"a.b#c.d",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -426,7 +426,7 @@ func IsNameChar(r byte) bool {
 		r == '[' || r == ']' ||
 		r == '^' || r == '$' ||
 		r == '<' || r == '>' ||
-		r == '&'
+		r == '&' || r == '#'
 }
 
 func isDigit(r byte) bool {


### PR DESCRIPTION
## What issue is this change attempting to solve?

add # to characters that can be part of a Name
I noticed this issue as an error when calling groupByNode("a.b#c.d", 1, 'sum').
This happened because ExtractMetricName would extract the name 'c.d' out of it.

## How does this change solve the problem? Why is this the best approach?

It seems that we already have metrics with '#' in their name.

## How can we be sure this works as expected?

Added test.
