### PR TITLE
Avereha/errors

### DIFF
--- a/expr/functions/divideSeries/function.go
+++ b/expr/functions/divideSeries/function.go
@@ -1,7 +1,6 @@
 package divideSeries
 
 import (
-	"errors"
 	"fmt"
 	"math"
 
@@ -67,7 +66,7 @@ func (f *divideSeries) Do(e parser.Expr, from, until int32, values map[parser.Me
 		numerators = append(numerators, firstArg[0])
 		denominator = firstArg[1]
 	} else {
-		return nil, errors.New("must be called with 2 series or a wildcard that matches exactly 2 series")
+		return nil, parser.ParseError("must be called with 2 series or a wildcard that matches exactly 2 series")
 	}
 
 	var results []*types.MetricData

--- a/expr/functions/filterSeries/function.go
+++ b/expr/functions/filterSeries/function.go
@@ -52,7 +52,7 @@ func (f *filterSeries) Do(e parser.Expr, from, until int32, values map[parser.Me
 		callbackFunc = types.AggLast
 	// TODO: this implementation does not support diff, median, multiply, range, stddev
 	default:
-		return nil, fmt.Errorf("unsupported consolidation function %v", callback)
+		return nil, fmt.Errorf("%w: unsupported consolidation function %v", parser.ErrInvalidArgumentValue, callback)
 	}
 
 	var operators = map[string]struct{}{
@@ -71,7 +71,7 @@ func (f *filterSeries) Do(e parser.Expr, from, until int32, values map[parser.Me
 
 	_, ok := operators[operator]
 	if !ok {
-		return nil, fmt.Errorf("unsupported operator %v", operator)
+		return nil, fmt.Errorf("%w: unsupported operator %v", parser.ErrInvalidArgumentValue, operator)
 	}
 
 	threshold, err := e.GetFloatArg(3)

--- a/expr/functions/minMax/function.go
+++ b/expr/functions/minMax/function.go
@@ -61,7 +61,7 @@ func (f *minMax) Do(e parser.Expr, from, until int32, values map[parser.MetricRe
 		})
 	}
 
-	return nil, fmt.Errorf("unsupported target: %v", e.Target())
+	return nil, fmt.Errorf("%w: unsupported target: %v", parser.ErrInvalidArgumentValue, e.Target())
 }
 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web

--- a/expr/functions/nonNegativeDerivative/function.go
+++ b/expr/functions/nonNegativeDerivative/function.go
@@ -1,7 +1,6 @@
 package nonNegativeDerivative
 
 import (
-	"errors"
 	"fmt"
 	"math"
 
@@ -47,7 +46,7 @@ func (f *nonNegativeDerivative) Do(e parser.Expr, from, until int32, values map[
 	hasMin := !math.IsNaN(minValue)
 
 	if hasMax && hasMin && maxValue <= minValue {
-		return nil, errors.New("minValue must be lower than maxValue")
+		return nil, parser.ParseError("minValue must be lower than maxValue")
 	}
 	if hasMax && !hasMin {
 		minValue = 0

--- a/expr/functions/pearsonClosest/function.go
+++ b/expr/functions/pearsonClosest/function.go
@@ -2,7 +2,6 @@ package pearsonClosest
 
 import (
 	"container/heap"
-	"errors"
 	"math"
 
 	"github.com/bookingcom/carbonapi/expr/helper"
@@ -60,7 +59,7 @@ func (f *pearsonClosest) Do(e parser.Expr, from, until int32, values map[parser.
 		return nil, err
 	}
 	if direction != "pos" && direction != "neg" && direction != "abs" {
-		return nil, errors.New("direction must be one of: pos, neg, abs")
+		return nil, parser.ParseError("direction must be one of: pos, neg, abs")
 	}
 
 	// NOTE: if direction == "abs" && len(compare) <= n : we'll still do the work to rank them

--- a/expr/functions/perSecond/function.go
+++ b/expr/functions/perSecond/function.go
@@ -1,7 +1,6 @@
 package perSecond
 
 import (
-	"errors"
 	"fmt"
 	"math"
 
@@ -48,7 +47,7 @@ func (f *perSecond) Do(e parser.Expr, from, until int32, values map[parser.Metri
 	hasMin := !math.IsNaN(minValue)
 
 	if hasMax && hasMin && maxValue <= minValue {
-		return nil, errors.New("minValue must be lower than maxValue")
+		return nil, parser.ParseError("minValue must be lower than maxValue")
 	}
 	if hasMax && !hasMin {
 		minValue = 0

--- a/expr/functions/polyfit/function.go
+++ b/expr/functions/polyfit/function.go
@@ -1,7 +1,6 @@
 package polyfit
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/bookingcom/carbonapi/expr/helper"
@@ -43,7 +42,7 @@ func (f *polyfit) Do(e parser.Expr, from, until int32, values map[parser.MetricR
 	if err != nil {
 		return nil, err
 	} else if degree < 1 {
-		return nil, errors.New("degree must be larger or equal to 1")
+		return nil, parser.ParseError("degree must be larger or equal to 1")
 	}
 
 	offsStr, err := e.GetStringNamedOrPosArgDefault("offset", 2, "0d")

--- a/expr/functions/substr/function.go
+++ b/expr/functions/substr/function.go
@@ -1,7 +1,6 @@
 package substr
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/bookingcom/carbonapi/expr/helper"
@@ -60,7 +59,7 @@ func (f *substr) Do(e parser.Expr, from, until int32, values map[parser.MetricRe
 				}
 			}
 			if realStartField > len(nodes)-1 {
-				return nil, errors.New("start out of range")
+				return nil, parser.ParseError("start out of range")
 			}
 			nodes = nodes[realStartField:]
 		}
@@ -73,7 +72,7 @@ func (f *substr) Do(e parser.Expr, from, until int32, values map[parser.MetricRe
 				}
 			}
 			if realStopField < 0 || realStopField <= realStartField || realStopField-realStartField > len(nodes) {
-				return nil, errors.New("stop out of range")
+				return nil, parser.ParseError("stop out of range")
 			}
 			nodes = nodes[:realStopField-realStartField]
 		}

--- a/expr/functions/timeFunction/function.go
+++ b/expr/functions/timeFunction/function.go
@@ -1,8 +1,6 @@
 package timeFunction
 
 import (
-	"errors"
-
 	"github.com/bookingcom/carbonapi/expr/interfaces"
 	"github.com/bookingcom/carbonapi/expr/types"
 	"github.com/bookingcom/carbonapi/pkg/parser"
@@ -38,7 +36,7 @@ func (f *timeFunction) Do(e parser.Expr, from, until int32, values map[parser.Me
 		return nil, err
 	}
 	if stepInt <= 0 {
-		return nil, errors.New("step can't be less than 0")
+		return nil, parser.ParseError("step can't be less than 0")
 	}
 	step := int32(stepInt)
 

--- a/expr/functions/timeLag/function.go
+++ b/expr/functions/timeLag/function.go
@@ -81,7 +81,7 @@ func (f *timeLag) Do(e parser.Expr, from, until int32, values map[parser.MetricR
 	if len(e.Args()) < 1 {
 		return nil, parser.ErrMissingTimeseries
 	} else if len(e.Args()) < 2 && e.Target() == "timeLagSeriesLists" {
-		return nil, fmt.Errorf("%s must be called with two lists of series", e.Target())
+		return nil, fmt.Errorf("%w: %s must be called with two lists of series", parser.ErrMissingArgument, e.Target())
 	}
 
 	firstArg, err := helper.GetSeriesArg(e.Args()[0], from, until, values)
@@ -115,7 +115,7 @@ func (f *timeLag) Do(e parser.Expr, from, until int32, values map[parser.MetricR
 		consumerMetrics = append(consumerMetrics, firstArg[0])
 		producerMetrics = append(producerMetrics, firstArg[1])
 	} else {
-		return nil, fmt.Errorf("%s must be called with 2 series or a wildcard that matches exactly 2 series", e.Target())
+		return nil, fmt.Errorf("%w: %s must be called with 2 series or a wildcard that matches exactly 2 series", parser.ErrDifferentCountMetrics, e.Target())
 	}
 
 	var results []*types.MetricData

--- a/expr/functions/tukey/function.go
+++ b/expr/functions/tukey/function.go
@@ -2,7 +2,6 @@ package tukey
 
 import (
 	"container/heap"
-	"errors"
 	"sort"
 	"strings"
 
@@ -47,7 +46,7 @@ func (f *tukey) Do(e parser.Expr, from, until int32, values map[parser.MetricReq
 		return nil, err
 	}
 	if n < 1 {
-		return nil, errors.New("n must be larger or equal to 1")
+		return nil, parser.ParseError("n must be larger or equal to 1")
 	}
 
 	var beginInterval int


### PR DESCRIPTION
## What issue is this change attempting to solve?
Mark argument validation errors as ParseErrors.
That way, we are going to answer with http 400 instead of 500.