### PR TITLE
errors: use errors.As for checking if an error is NotFound

### DIFF
--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -430,8 +430,9 @@ func optimistFanIn(errs []error, n int, subj string) (error, string) {
 	allErrorsNotFound := true
 	errStr := ""
 	for _, e := range errs {
+		var notFound dataTypes.ErrNotFound
 		errStr = errStr + e.Error() + ", "
-		if _, ok := e.(dataTypes.ErrNotFound); !ok {
+		if !errors.As(e, &notFound) {
 			allErrorsNotFound = false
 		}
 	}


### PR DESCRIPTION

## What issue is this change attempting to solve?

Sometimes we are wrapping the NotFound errors. If we use errors.As, we
can see that they are the same error type
That way, we answer with http 404 instead of 5xx for NotFound errors.


