### PR TITLE
asPercent: rewrite to support different resolution metrics

### DIFF
--- a/expr/functions/asPercent/function_test.go
+++ b/expr/functions/asPercent/function_test.go
@@ -99,6 +99,63 @@ func TestAliasByNode(t *testing.T) {
 			},
 			[]*types.MetricData{},
 		},
+		{
+			"asPercent(test-db*)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"test-db*", 0, 1}: {
+					types.MakeMetricData("test-db1", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
+					types.MakeMetricData("test-db2", []float64{math.NaN(), 2, math.NaN(), 4, math.NaN(), 6, math.NaN(), 8, math.NaN(), 10, math.NaN(), 12, math.NaN(), 14, math.NaN(), 16, math.NaN(), 18, math.NaN(), 20}, 1, now32),
+					types.MakeMetricData("test-db3", []float64{1, 2, math.NaN(), math.NaN(), math.NaN(), 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, math.NaN(), math.NaN(), math.NaN()}, 1, now32),
+					types.MakeMetricData("test-db4", []float64{1, 2, 3, 4, math.NaN(), 6, math.NaN(), math.NaN(), 9, 10, 11, math.NaN(), 13, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 18, 19, 20}, 1, now32),
+					types.MakeMetricData("test-db5", []float64{1, 2, math.NaN(), math.NaN(), math.NaN(), 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, math.NaN(), math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("asPercent(test-db1,sumSeries(test-db*))", []float64{25.0, 20.0, 50.0, 33.33333333333, 100.0, 20.0, 33.33333333333, 25.0, 25.0, 20.0, 25.0, 25.0, 25.0, 25.0, 33.33333333333, 25.0, 33.33333333333, 25.0, 50.0, 33.33333333333}, 1, now32),
+				types.MakeMetricData("asPercent(test-db2,sumSeries(test-db*))", []float64{math.NaN(), 20.0, math.NaN(), 33.3333333333, math.NaN(), 20.0, math.NaN(), 25.0, math.NaN(), 20.0, math.NaN(), 25.0, math.NaN(), 25.0, math.NaN(), 25.0, math.NaN(), 25.0, math.NaN(), 33.33333333333}, 1, now32),
+				types.MakeMetricData("asPercent(test-db3,sumSeries(test-db*))", []float64{25.0, 20.0, math.NaN(), math.NaN(), math.NaN(), 20.0, 33.33333333333, 25.0, 25.0, 20.0, 25.0, 25.0, 25.0, 25.0, 33.3333333333, 25.0, 33.3333333333, math.NaN(), math.NaN(), math.NaN()}, 1, now32),
+				types.MakeMetricData("asPercent(test-db4,sumSeries(test-db*))", []float64{25.0, 20.0, 50.0, 33.33333333333, math.NaN(), 20.0, math.NaN(), math.NaN(), 25.0, 20.0, 25.0, math.NaN(), 25.0, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 25.0, 50.0, 33.33333333333}, 1, now32),
+				types.MakeMetricData("asPercent(test-db5,sumSeries(test-db*))", []float64{25.0, 20.0, math.NaN(), math.NaN(), math.NaN(), 20.0, 33.33333333333, 25.0, 25.0, 20.0, 25.0, 25.0, 25.0, 25.0, 33.33333333333, 25.0, 33.33333333333, 25.0, math.NaN(), math.NaN()}, 1, now32),
+			}},
+		{
+			"asPercent(test-db*, 10)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"test-db*", 0, 1}: {
+					types.MakeMetricData("test-db1", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
+					types.MakeMetricData("test-db2", []float64{math.NaN(), 2, math.NaN(), 4, math.NaN(), 6, math.NaN(), 8, math.NaN(), 10, math.NaN(), 12, math.NaN(), 14, math.NaN(), 16, math.NaN(), 18, math.NaN(), 20}, 1, now32),
+					types.MakeMetricData("test-db3", []float64{1, 2, math.NaN(), math.NaN(), math.NaN(), 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, math.NaN(), math.NaN(), math.NaN()}, 1, now32),
+					types.MakeMetricData("test-db4", []float64{1, 2, 3, 4, math.NaN(), 6, math.NaN(), math.NaN(), 9, 10, 11, math.NaN(), 13, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 18, 19, 20}, 1, now32),
+					types.MakeMetricData("test-db5", []float64{1, 2, math.NaN(), math.NaN(), math.NaN(), 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, math.NaN(), math.NaN()}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("asPercent(test-db1,10.00)", []float64{10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 110.0, 120.0, 130.0, 140.0, 150.0, 160.0, 170.0, 180.0, 190.0, 200.0}, 1, now32),
+				types.MakeMetricData("asPercent(test-db2,10.00)", []float64{math.NaN(), 20.0, math.NaN(), 40.0, math.NaN(), 60.0, math.NaN(), 80.0, math.NaN(), 100.0, math.NaN(), 120.0, math.NaN(), 140.0, math.NaN(), 160.0, math.NaN(), 180.0, math.NaN(), 200.0}, 1, now32),
+				types.MakeMetricData("asPercent(test-db3,10.00)", []float64{10.0, 20.0, math.NaN(), math.NaN(), math.NaN(), 60.0, 70.0, 80.0, 90.0, 100.0, 110.0, 120.0, 130.0, 140.0, 150.0, 160.0, 170.0, math.NaN(), math.NaN(), math.NaN()}, 1, now32),
+				types.MakeMetricData("asPercent(test-db4,10.00)", []float64{10.0, 20.0, 30.0, 40.0, math.NaN(), 60.0, math.NaN(), math.NaN(), 90.0, 100.0, 110.0, math.NaN(), 130.0, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 180.0, 190.0, 200.0}, 1, now32),
+				types.MakeMetricData("asPercent(test-db5,10.00)", []float64{10.0, 20.0, math.NaN(), math.NaN(), math.NaN(), 60.0, 70.0, 80.0, 90.0, 100.0, 110.0, 120.0, 130.0, 140.0, 150.0, 160.0, 170.0, 180.0, math.NaN(), math.NaN()}, 1, now32),
+			}},
+		{
+			"asPercent(test-db*, single)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"test-db*", 0, 1}: {
+					types.MakeMetricData("test-db1", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
+					types.MakeMetricData("test-db2", []float64{math.NaN(), 2, math.NaN(), 4, math.NaN(), 6, math.NaN(), 8, math.NaN(), 10, math.NaN(), 12, math.NaN(), 14, math.NaN(), 16, math.NaN(), 18, math.NaN(), 20}, 1, now32),
+					types.MakeMetricData("test-db3", []float64{1, 2, math.NaN(), math.NaN(), math.NaN(), 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, math.NaN(), math.NaN(), math.NaN()}, 1, now32),
+					types.MakeMetricData("test-db4", []float64{1, 2, 3, 4, math.NaN(), 6, math.NaN(), math.NaN(), 9, 10, 11, math.NaN(), 13, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 18, 19, 20}, 1, now32),
+					types.MakeMetricData("test-db5", []float64{1, 2, math.NaN(), math.NaN(), math.NaN(), 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, math.NaN(), math.NaN()}, 1, now32),
+				},
+				{"single", 0, 1}: {
+					types.MakeMetricData("test-db1", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
+				},
+			},
+			[]*types.MetricData{
+				types.MakeMetricData("asPercent(test-db1,single)", []float64{100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0}, 1, now32),
+				types.MakeMetricData("asPercent(test-db2,single)", []float64{math.NaN(), 100.0, math.NaN(), 100.0, math.NaN(), 100.0, math.NaN(), 100.0, math.NaN(), 100.0, math.NaN(), 100.0, math.NaN(), 100.0, math.NaN(), 100.0, math.NaN(), 100.0, math.NaN(), 100.0}, 1, now32),
+				types.MakeMetricData("asPercent(test-db3,single)", []float64{100.0, 100.0, math.NaN(), math.NaN(), math.NaN(), 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, math.NaN(), math.NaN(), math.NaN()}, 1, now32),
+				types.MakeMetricData("asPercent(test-db4,single)", []float64{100.0, 100.0, 100.0, 100.0, math.NaN(), 100.0, math.NaN(), math.NaN(), 100.0, 100.0, 100.0, math.NaN(), 100.0, math.NaN(), math.NaN(), math.NaN(), math.NaN(), 100.0, 100.0, 100.0}, 1, now32),
+				types.MakeMetricData("asPercent(test-db5,single)", []float64{100.0, 100.0, math.NaN(), math.NaN(), math.NaN(), 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, math.NaN(), math.NaN()}, 1, now32),
+			}},
 	}
 
 	for _, tt := range tests {

--- a/expr/functions/averageSeries/function.go
+++ b/expr/functions/averageSeries/function.go
@@ -1,6 +1,8 @@
 package averageSeries
 
 import (
+	"fmt"
+
 	"github.com/bookingcom/carbonapi/expr/helper"
 	"github.com/bookingcom/carbonapi/expr/interfaces"
 	"github.com/bookingcom/carbonapi/expr/types"
@@ -32,7 +34,9 @@ func (f *averageSeries) Do(e parser.Expr, from, until int32, values map[parser.M
 	}
 
 	e.SetTarget("averageSeries")
-	return helper.AggregateSeries(e, args, func(values []float64) float64 {
+	name := fmt.Sprintf("averageSeries(%s)", e.RawArgs())
+
+	return helper.AggregateSeries(name, args, func(values []float64) float64 {
 		sum := 0.0
 		for _, value := range values {
 			sum += value

--- a/expr/functions/divideSeries/function.go
+++ b/expr/functions/divideSeries/function.go
@@ -3,7 +3,6 @@ package divideSeries
 import (
 	"errors"
 	"fmt"
-	"math"
 
 	"github.com/bookingcom/carbonapi/expr/helper"
 	"github.com/bookingcom/carbonapi/expr/interfaces"
@@ -29,11 +28,11 @@ func New(configFile string) []interfaces.FunctionMetadata {
 	return res
 }
 
-func divide(a, b float64) float64 {
+func divide(a, b float64) (float64, bool) {
 	if b == 0 {
-		return math.NaN()
+		return 0, true
 	}
-	return a / b
+	return a / b, false
 }
 
 // divideSeries(dividendSeriesList, divisorSeriesList)

--- a/expr/functions/minMax/function.go
+++ b/expr/functions/minMax/function.go
@@ -37,10 +37,11 @@ func (f *minMax) Do(e parser.Expr, from, until int32, values map[parser.MetricRe
 	if err != nil {
 		return nil, err
 	}
+	name := fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
 
 	switch e.Target() {
 	case "maxSeries", "max":
-		return helper.AggregateSeries(e, args, func(values []float64) float64 {
+		return helper.AggregateSeries(name, args, func(values []float64) float64 {
 			max := math.Inf(-1)
 			for _, value := range values {
 				if value > max {
@@ -50,7 +51,7 @@ func (f *minMax) Do(e parser.Expr, from, until int32, values map[parser.MetricRe
 			return max
 		})
 	case "minSeries", "min":
-		return helper.AggregateSeries(e, args, func(values []float64) float64 {
+		return helper.AggregateSeries(name, args, func(values []float64) float64 {
 			min := math.Inf(1)
 			for _, value := range values {
 				if value < min {

--- a/expr/functions/percentileOfSeries/function.go
+++ b/expr/functions/percentileOfSeries/function.go
@@ -1,6 +1,8 @@
 package percentileOfSeries
 
 import (
+	"fmt"
+
 	"github.com/bookingcom/carbonapi/expr/helper"
 	"github.com/bookingcom/carbonapi/expr/interfaces"
 	"github.com/bookingcom/carbonapi/expr/types"
@@ -43,7 +45,8 @@ func (f *percentileOfSeries) Do(e parser.Expr, from, until int32, values map[par
 		return nil, err
 	}
 
-	return helper.AggregateSeries(e, args, func(values []float64) float64 {
+	name := fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
+	return helper.AggregateSeries(name, args, func(values []float64) float64 {
 		return helper.Percentile(values, percent, interpolate)
 	})
 }

--- a/expr/functions/seriesList/function.go
+++ b/expr/functions/seriesList/function.go
@@ -45,22 +45,22 @@ func (f *seriesList) Do(e parser.Expr, from, until int32, values map[parser.Metr
 	var results []*types.MetricData
 	functionName := e.Target()[:len(e.Target())-len("Lists")]
 
-	var compute func(l, r float64) float64
+	var compute func(l, r float64) (float64, bool)
 
 	switch e.Target() {
 	case "divideSeriesLists":
-		compute = func(l, r float64) float64 {
+		compute = func(l, r float64) (float64, bool) {
 			if r == 0 {
-				return math.NaN()
+				return 0, true
 			}
-			return l / r
+			return l / r, false
 		}
 	case "multiplySeriesLists":
-		compute = func(l, r float64) float64 { return l * r }
+		compute = func(l, r float64) (float64, bool) { return l * r, false }
 	case "diffSeriesLists":
-		compute = func(l, r float64) float64 { return l - r }
+		compute = func(l, r float64) (float64, bool) { return l - r, false }
 	case "powSeriesLists":
-		compute = func(l, r float64) float64 { return math.Pow(l, r) }
+		compute = func(l, r float64) (float64, bool) { return math.Pow(l, r), false }
 	}
 	for i, numerator := range numerators {
 		denominator := denominators[i]

--- a/expr/functions/stddevSeries/function.go
+++ b/expr/functions/stddevSeries/function.go
@@ -1,6 +1,7 @@
 package stddevSeries
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/bookingcom/carbonapi/expr/helper"
@@ -35,7 +36,8 @@ func (f *stddevSeries) Do(e parser.Expr, from, until int32, values map[parser.Me
 	}
 
 	e.SetTarget("stddevSeries")
-	return helper.AggregateSeries(e, args, func(values []float64) float64 {
+	name := fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
+	return helper.AggregateSeries(name, args, func(values []float64) float64 {
 		sum := 0.0
 		diffSqr := 0.0
 		for _, value := range values {

--- a/expr/functions/sum/function.go
+++ b/expr/functions/sum/function.go
@@ -1,6 +1,8 @@
 package sum
 
 import (
+	"fmt"
+
 	"github.com/bookingcom/carbonapi/expr/helper"
 	"github.com/bookingcom/carbonapi/expr/interfaces"
 	"github.com/bookingcom/carbonapi/expr/types"
@@ -25,6 +27,15 @@ func New(configFile string) []interfaces.FunctionMetadata {
 	return res
 }
 
+// SumAggregation
+func SumAggregation(values []float64) float64 {
+	sum := 0.0
+	for _, value := range values {
+		sum += value
+	}
+	return sum
+}
+
 // sumSeries(*seriesLists)
 func (f *sum) Do(e parser.Expr, from, until int32, values map[parser.MetricRequest][]*types.MetricData) ([]*types.MetricData, error) {
 	// TODO(dgryski): make sure the arrays are all the same 'size'
@@ -34,13 +45,8 @@ func (f *sum) Do(e parser.Expr, from, until int32, values map[parser.MetricReque
 	}
 
 	e.SetTarget("sumSeries")
-	return helper.AggregateSeries(e, args, func(values []float64) float64 {
-		sum := 0.0
-		for _, value := range values {
-			sum += value
-		}
-		return sum
-	})
+	name := fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
+	return helper.AggregateSeries(name, args, SumAggregation)
 }
 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -112,14 +112,13 @@ func ForEachSeriesDo(e parser.Expr, from, until int32, values map[parser.MetricR
 type AggregateFunc func([]float64) float64
 
 // AggregateSeries aggregates series
-func AggregateSeries(e parser.Expr, args []*types.MetricData, function AggregateFunc) ([]*types.MetricData, error) {
 
+func AggregateSeries(name string, args []*types.MetricData, function AggregateFunc) ([]*types.MetricData, error) {
 	seriesList, start, end, step, err := Normalize(args)
 	if err != nil {
 		return nil, err
 	}
 	length := int((end - start) / step)
-	name := fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
 	result := make([]float64, length)
 
 	for i := 0; i < length; i++ {

--- a/expr/types/types.go
+++ b/expr/types/types.go
@@ -31,6 +31,20 @@ type MetricData struct {
 	AggregateFunction func([]float64, []bool) (float64, bool)
 }
 
+// New creates new MetricData with given metric timeseries. values have math.NaN() for absent
+func New(name string, values []float64, isAbsent []bool, step, start int32) *MetricData {
+	stop := start + int32(len(values))*step
+
+	return &MetricData{Metric: types.Metric{
+		Name:      name,
+		Values:    values,
+		IsAbsent:  isAbsent,
+		StartTime: start,
+		StepTime:  step,
+		StopTime:  stop,
+	}}
+}
+
 // MakeMetricData creates new metrics data with given metric timeseries. values have math.NaN() for absent
 func MakeMetricData(name string, values []float64, step, start int32) *MetricData {
 

--- a/expr/types/types.go
+++ b/expr/types/types.go
@@ -31,7 +31,7 @@ type MetricData struct {
 	AggregateFunction func([]float64, []bool) (float64, bool)
 }
 
-// New creates new MetricData with given metric timeseries. values have math.NaN() for absent
+// New creates new MetricData with given metric timeseries values and isAbsent
 func New(name string, values []float64, isAbsent []bool, step, start int32) *MetricData {
 	stop := start + int32(len(values))*step
 


### PR DESCRIPTION
# What issue is this change attempting to solve?

Rewrite asPercent to support metrics with different resolutions.

## How does this change solve the problem? Why is this the best approach?

Part of this change:
 - update signature of CombineSeries callback to return both (value,
   isAbsent).
 - added constructor for MetricData.
 - updated AggregateSeries signature to received the name of the
 resulting metric. 

## How can we be sure this works as expected?
Added new tests(imported from original graphite test suite).

