### PR TITLE
AggregateSeries: update callback function to return (value, isAbsent)

### DIFF
--- a/expr/functions/averageSeries/function.go
+++ b/expr/functions/averageSeries/function.go
@@ -34,14 +34,13 @@ func (f *averageSeries) Do(e parser.Expr, from, until int32, values map[parser.M
 	}
 
 	e.SetTarget("averageSeries")
-	name := fmt.Sprintf("averageSeries(%s)", e.RawArgs())
-
-	return helper.AggregateSeries(name, args, func(values []float64) float64 {
+	name := fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
+	return helper.AggregateSeries(name, args, func(values []float64) (float64, bool) {
 		sum := 0.0
 		for _, value := range values {
 			sum += value
 		}
-		return sum / float64(len(values))
+		return sum / float64(len(values)), false
 	})
 }
 

--- a/expr/functions/legendValue/function.go
+++ b/expr/functions/legendValue/function.go
@@ -49,7 +49,7 @@ func (f *legendValue) Do(e parser.Expr, from, until int32, values map[parser.Met
 	for _, a := range arg {
 		r := *a
 		for _, method := range methods {
-			summary := helper.SummarizeValues(method, a.Values)
+			summary, _ := helper.SummarizeValues(method, a.Values)
 			r.Name = fmt.Sprintf("%s (%s: %f)", r.Name, method, summary)
 		}
 

--- a/expr/functions/minMax/function.go
+++ b/expr/functions/minMax/function.go
@@ -41,24 +41,24 @@ func (f *minMax) Do(e parser.Expr, from, until int32, values map[parser.MetricRe
 
 	switch e.Target() {
 	case "maxSeries", "max":
-		return helper.AggregateSeries(name, args, func(values []float64) float64 {
+		return helper.AggregateSeries(name, args, func(values []float64) (float64, bool) {
 			max := math.Inf(-1)
 			for _, value := range values {
 				if value > max {
 					max = value
 				}
 			}
-			return max
+			return max, false
 		})
 	case "minSeries", "min":
-		return helper.AggregateSeries(name, args, func(values []float64) float64 {
+		return helper.AggregateSeries(name, args, func(values []float64) (float64, bool) {
 			min := math.Inf(1)
 			for _, value := range values {
 				if value < min {
 					min = value
 				}
 			}
-			return min
+			return min, false
 		})
 	}
 

--- a/expr/functions/nPercentile/function.go
+++ b/expr/functions/nPercentile/function.go
@@ -52,9 +52,10 @@ func (f *nPercentile) Do(e parser.Expr, from, until int32, values map[parser.Met
 			}
 		}
 
-		value := helper.Percentile(values, percent, true)
+		value, absent := helper.Percentile(values, percent, true)
 		for i := range r.Values {
 			r.Values[i] = value
+			r.IsAbsent[i] = absent
 		}
 
 		results = append(results, &r)

--- a/expr/functions/percentileOfSeries/function.go
+++ b/expr/functions/percentileOfSeries/function.go
@@ -46,7 +46,7 @@ func (f *percentileOfSeries) Do(e parser.Expr, from, until int32, values map[par
 	}
 
 	name := fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
-	return helper.AggregateSeries(name, args, func(values []float64) float64 {
+	return helper.AggregateSeries(name, args, func(values []float64) (float64, bool) {
 		return helper.Percentile(values, percent, interpolate)
 	})
 }

--- a/expr/functions/removeBelowSeries/function.go
+++ b/expr/functions/removeBelowSeries/function.go
@@ -63,7 +63,7 @@ func (f *removeBelowSeries) Do(e parser.Expr, from, until int32, values map[pars
 				}
 			}
 
-			threshold = helper.Percentile(values, number, true)
+			threshold, _ = helper.Percentile(values, number, true)
 		}
 
 		r := *a

--- a/expr/functions/sortBy/function.go
+++ b/expr/functions/sortBy/function.go
@@ -41,11 +41,12 @@ func (f *sortBy) Do(e parser.Expr, from, until int32, values map[parser.MetricRe
 	for i, a := range arg {
 		switch e.Target() {
 		case "sortByTotal":
-			vals[i] = helper.SummarizeValues("sum", a.Values)
+			vals[i], _ = helper.SummarizeValues("sum", a.Values)
 		case "sortByMaxima":
-			vals[i] = helper.SummarizeValues("max", a.Values)
+			vals[i], _ = helper.SummarizeValues("max", a.Values)
 		case "sortByMinima":
-			vals[i] = 1 / helper.SummarizeValues("min", a.Values)
+			min, _ := helper.SummarizeValues("min", a.Values)
+			vals[i] = 1 / min
 		}
 	}
 

--- a/expr/functions/stddevSeries/function.go
+++ b/expr/functions/stddevSeries/function.go
@@ -37,7 +37,7 @@ func (f *stddevSeries) Do(e parser.Expr, from, until int32, values map[parser.Me
 
 	e.SetTarget("stddevSeries")
 	name := fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
-	return helper.AggregateSeries(name, args, func(values []float64) float64 {
+	return helper.AggregateSeries(name, args, func(values []float64) (float64, bool) {
 		sum := 0.0
 		diffSqr := 0.0
 		for _, value := range values {
@@ -47,7 +47,7 @@ func (f *stddevSeries) Do(e parser.Expr, from, until int32, values map[parser.Me
 		for _, value := range values {
 			diffSqr += (value - average) * (value - average)
 		}
-		return math.Sqrt(diffSqr / float64(len(values)))
+		return math.Sqrt(diffSqr / float64(len(values))), false
 	})
 }
 

--- a/expr/functions/sum/function.go
+++ b/expr/functions/sum/function.go
@@ -28,12 +28,12 @@ func New(configFile string) []interfaces.FunctionMetadata {
 }
 
 // SumAggregation
-func SumAggregation(values []float64) float64 {
+func SumAggregation(values []float64) (float64, bool) {
 	sum := 0.0
 	for _, value := range values {
 		sum += value
 	}
-	return sum
+	return sum, false
 }
 
 // sumSeries(*seriesLists)

--- a/expr/functions/summarize/function.go
+++ b/expr/functions/summarize/function.go
@@ -2,7 +2,6 @@ package summarize
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/bookingcom/carbonapi/expr/helper"
 	"github.com/bookingcom/carbonapi/expr/interfaces"
@@ -132,13 +131,8 @@ func (f *summarize) Do(e parser.Expr, from, until int32, values map[parser.Metri
 			}
 
 			if t >= bucketEnd {
-				rv := helper.SummarizeValues(summarizeFunction, values)
+				r.Values[ridx], r.IsAbsent[ridx] = helper.SummarizeValues(summarizeFunction, values)
 
-				if math.IsNaN(rv) {
-					r.IsAbsent[ridx] = true
-				}
-
-				r.Values[ridx] = rv
 				ridx++
 				bucketEnd += bucketSize
 				bucketItems = 0
@@ -148,14 +142,7 @@ func (f *summarize) Do(e parser.Expr, from, until int32, values map[parser.Metri
 
 		// last partial bucket
 		if bucketItems > 0 {
-			rv := helper.SummarizeValues(summarizeFunction, values)
-			if math.IsNaN(rv) {
-				r.Values[ridx] = 0
-				r.IsAbsent[ridx] = true
-			} else {
-				r.Values[ridx] = rv
-				r.IsAbsent[ridx] = false
-			}
+			r.Values[ridx], r.IsAbsent[ridx] = helper.SummarizeValues(summarizeFunction, values)
 		}
 
 		results = append(results, &r)

--- a/expr/helper/helper_test.go
+++ b/expr/helper/helper_test.go
@@ -11,15 +11,19 @@ func TestPercentile(t *testing.T) {
 		percent     float64
 		interpolate bool
 		expected    float64
+		absent      bool
 	}{
-		{"simple", []float64{1, 2, 3}, 50, false, 2},
-		{"80", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 80, false, 9},
+		{"simple", []float64{1, 2, 3}, 50, false, 2, false},
+		{"80", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 80, false, 9, false},
 	}
 
 	for _, test := range input {
-		got := Percentile(test.data, test.percent, test.interpolate)
+		got, absent := Percentile(test.data, test.percent, test.interpolate)
 		if got != test.expected {
 			t.Errorf("Expected: %f. Got: %f. Test: %+v", test.expected, got, test)
+		}
+		if absent != test.absent {
+			t.Errorf("Expected absent: %t. Got: %t. Test: %+v", test.absent, absent, test)
 		}
 	}
 }

--- a/expr/helper/normalize.go
+++ b/expr/helper/normalize.go
@@ -2,12 +2,11 @@ package helper
 
 import (
 	"github.com/bookingcom/carbonapi/expr/types"
-	allTheTypes "github.com/bookingcom/carbonapi/pkg/types"
 )
 
 func Normalize(args []*types.MetricData) ([]*types.MetricData, int32, int32, int32, error) {
 	if len(args) == 0 {
-		return []*types.MetricData{}, 0, 0, 0, allTheTypes.ErrMetricsNotFound
+		return []*types.MetricData{}, 0, 0, 0, nil
 	}
 	if len(args) == 1 {
 		return args, args[0].StartTime, args[0].StopTime, args[0].StepTime, nil


### PR DESCRIPTION
## What issue is this change attempting to solve?

AggregateSeries: update callback function to return (value, isAbsent)
That way, it will be consistent with the rest of the API.

## How does this change solve the problem? Why is this the best approach?

And now that we have a contructor for TimeSeries, we can use in
AggregateSeries()

## How can we be sure this works as expected?

make test