### PR TITLE
Avereha/diff series

### DIFF
--- a/expr/functions/asPercent/function.go
+++ b/expr/functions/asPercent/function.go
@@ -64,7 +64,7 @@ func asPercentWithNodes(e parser.Expr, from, until int32, values map[parser.Metr
 			totalSeries[key] = tmpTotalSeries[key][0]
 		} else {
 			name := fmt.Sprintf("sumSeries(%s)", e.Args()[1].Target())
-			aggregated, err := helper.AggregateSeries(name, seriesList, sum.SumAggregation)
+			aggregated, err := helper.AggregateSeries(name, seriesList, false, sum.SumAggregation)
 			if err != nil {
 				return nil, err
 			}
@@ -152,7 +152,7 @@ func asPercentWithoutNodes(e parser.Expr, from, until int32, values map[parser.M
 	switch {
 	case len(e.Args()) == 1:
 		name := fmt.Sprintf("sumSeries(%s)", e.Args()[0].Target())
-		aggregated, err := helper.AggregateSeries(name, seriesList, sum.SumAggregation)
+		aggregated, err := helper.AggregateSeries(name, seriesList, false, sum.SumAggregation)
 		if err != nil {
 			return nil, err
 		}

--- a/expr/functions/averageSeries/function.go
+++ b/expr/functions/averageSeries/function.go
@@ -35,7 +35,7 @@ func (f *averageSeries) Do(e parser.Expr, from, until int32, values map[parser.M
 
 	e.SetTarget("averageSeries")
 	name := fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
-	return helper.AggregateSeries(name, args, func(values []float64) (float64, bool) {
+	return helper.AggregateSeries(name, args, false, func(values []float64) (float64, bool) {
 		sum := 0.0
 		for _, value := range values {
 			sum += value

--- a/expr/functions/diffSeries/function_test.go
+++ b/expr/functions/diffSeries/function_test.go
@@ -76,7 +76,7 @@ func TestDiffSeries(t *testing.T) {
 				},
 			},
 			[]*types.MetricData{types.MakeMetricData("diffSeries(metric*)",
-				[]float64{-4, -3, math.NaN(), 3, -2, math.NaN()}, 1, now32)},
+				[]float64{-3.5, 3, -2}, 1, now32)},
 		},
 	}
 

--- a/expr/functions/minMax/function.go
+++ b/expr/functions/minMax/function.go
@@ -41,7 +41,7 @@ func (f *minMax) Do(e parser.Expr, from, until int32, values map[parser.MetricRe
 
 	switch e.Target() {
 	case "maxSeries", "max":
-		return helper.AggregateSeries(name, args, func(values []float64) (float64, bool) {
+		return helper.AggregateSeries(name, args, false, func(values []float64) (float64, bool) {
 			max := math.Inf(-1)
 			for _, value := range values {
 				if value > max {
@@ -51,7 +51,7 @@ func (f *minMax) Do(e parser.Expr, from, until int32, values map[parser.MetricRe
 			return max, false
 		})
 	case "minSeries", "min":
-		return helper.AggregateSeries(name, args, func(values []float64) (float64, bool) {
+		return helper.AggregateSeries(name, args, false, func(values []float64) (float64, bool) {
 			min := math.Inf(1)
 			for _, value := range values {
 				if value < min {

--- a/expr/functions/percentileOfSeries/function.go
+++ b/expr/functions/percentileOfSeries/function.go
@@ -46,7 +46,7 @@ func (f *percentileOfSeries) Do(e parser.Expr, from, until int32, values map[par
 	}
 
 	name := fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
-	return helper.AggregateSeries(name, args, func(values []float64) (float64, bool) {
+	return helper.AggregateSeries(name, args, false, func(values []float64) (float64, bool) {
 		return helper.Percentile(values, percent, interpolate)
 	})
 }

--- a/expr/functions/stddevSeries/function.go
+++ b/expr/functions/stddevSeries/function.go
@@ -37,7 +37,7 @@ func (f *stddevSeries) Do(e parser.Expr, from, until int32, values map[parser.Me
 
 	e.SetTarget("stddevSeries")
 	name := fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
-	return helper.AggregateSeries(name, args, func(values []float64) (float64, bool) {
+	return helper.AggregateSeries(name, args, false, func(values []float64) (float64, bool) {
 		sum := 0.0
 		diffSqr := 0.0
 		for _, value := range values {

--- a/expr/functions/sum/function.go
+++ b/expr/functions/sum/function.go
@@ -46,7 +46,7 @@ func (f *sum) Do(e parser.Expr, from, until int32, values map[parser.MetricReque
 
 	e.SetTarget("sumSeries")
 	name := fmt.Sprintf("%s(%s)", e.Target(), e.RawArgs())
-	return helper.AggregateSeries(name, args, SumAggregation)
+	return helper.AggregateSeries(name, args, false, SumAggregation)
 }
 
 // Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web

--- a/expr/helper/helper.go
+++ b/expr/helper/helper.go
@@ -112,8 +112,7 @@ func ForEachSeriesDo(e parser.Expr, from, until int32, values map[parser.MetricR
 type AggregateFunc func([]float64) (float64, bool)
 
 // AggregateSeries aggregates series
-
-func AggregateSeries(name string, args []*types.MetricData, function AggregateFunc) ([]*types.MetricData, error) {
+func AggregateSeries(name string, args []*types.MetricData, absent_if_first_series_absent bool, function AggregateFunc) ([]*types.MetricData, error) {
 	seriesList, start, end, step, err := Normalize(args)
 	if err != nil {
 		return nil, err
@@ -131,7 +130,7 @@ func AggregateSeries(name string, args []*types.MetricData, function AggregateFu
 		}
 		result[i] = 0
 		isAbsent[i] = true
-		if len(values) > 0 {
+		if len(values) > 0 && !(absent_if_first_series_absent && seriesList[0].IsAbsent[i]) {
 			result[i], isAbsent[i] = function(values)
 		}
 	}


### PR DESCRIPTION
## What issue is this change attempting to solve?

diffSeries: add support for different resolution metrics. 

## How does this change solve the problem? Why is this the best approach?

Part of this change, I updated AggregateSeries signature to support
`absent_if_first_series_is_absent`.
For diffSeries, it makes more sense to have absent value in the result
when the first series is absent.
This is probably different from original graphite implementation.

## How can we be sure this works as expected?

make test