### PR TITLE
render: stop answering with HTTP 404

### DIFF
--- a/app/carbonapi/app_test.go
+++ b/app/carbonapi/app_test.go
@@ -271,8 +271,8 @@ func renderHandlerNotFoundErrs(t *testing.T) {
 
 	testRouter.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusNotFound {
-		t.Errorf("Expected status code %d, got %d", http.StatusNotFound, rr.Code)
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, rr.Code)
 	}
 }
 

--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -265,16 +265,12 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request) {
 	if totalErr != nil {
 		toLog.Reason = totalErr.Error()
 		span.SetAttribute("error", true)
-		if _, ok := totalErr.(dataTypes.ErrNotFound); ok {
-			writeError(ctx, r, w, http.StatusNotFound, totalErr.Error(), form)
-			toLog.HttpCode = http.StatusNotFound
-			logAsError = true
-		} else {
+		if _, ok := totalErr.(dataTypes.ErrNotFound); !ok {
 			writeError(ctx, r, w, http.StatusInternalServerError, totalErr.Error(), form)
 			toLog.HttpCode = http.StatusInternalServerError
 			logAsError = true
+			return
 		}
-		return
 	}
 
 	body, err := app.renderWriteBody(results, form, r, logger)


### PR DESCRIPTION
## What issue is this change attempting to solve?

grafana alerting has a special option on what to do "if data not found".
For this condition to be true, we have to answer with http 200 and [].
If we answer with http 404, this will be considered an error.

## How does this change solve the problem? Why is this the best approach?

This is what graphite python answers on 'not found'.

