### PR TITLE
renderHandler: check if context.Done()

### DIFF
--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -386,6 +386,13 @@ func (app *App) getTargetData(ctx context.Context, target string, exp parser.Exp
 		}
 		close(rch)
 
+		// We have to check it here because we don't want to return before closing rch
+		select {
+		case <-ctx.Done():
+			return ctx.Err(), 0
+		default:
+		}
+
 		metricErr, metricErrStr := optimistFanIn(errs, len(renderRequests), "requests")
 		*partFail = (*partFail) || (metricErrStr != "")
 		if metricErr != nil {


### PR DESCRIPTION
# What issue is this change attempting to solve?
During http request, we check if ctx.Done() and return with Err when
this happens.

But then when we collect results(and errors) we handle those context
deadline errors as regular errors.
For a complex request with 200k metrics,this is what happens:
 - ~120k metrics are retrieved with sucess
 - for the rest 80k metrics we received 'context deadline' errors
 When merging those errors, we just drop the 'context deadline' errors
 and continue operations with the remaining 120k metrics as if nothing
 happened.

## How does this change solve the problem? Why is this the best approach?

With this check, we just return ctx.Err() on ctx.Done()

## How can we be sure this works as expected?

tested with slow request.