### PR TITLE
bnet: remove context cancel logs

### DIFF
--- a/pkg/backend/net/net.go
+++ b/pkg/backend/net/net.go
@@ -182,11 +182,6 @@ func (b Backend) enter(ctx context.Context) error {
 
 	select {
 	case <-ctx.Done():
-		b.logger.Warn("Request context cancelled",
-			zap.String("host", b.address),
-			zap.String("uuid", util.GetUUID(ctx)),
-			zap.Error(ctx.Err()),
-		)
 		return ctx.Err()
 
 	case b.limiter <- struct{}{}:
@@ -280,12 +275,6 @@ func (b Backend) do(ctx context.Context, trace types.Trace, req *http.Request) (
 
 	case <-ctx.Done():
 		trace.ObserveOutDuration(time.Now().Sub(t0), b.dc, b.cluster)
-
-		b.logger.Warn("Request context cancelled",
-			zap.String("host", b.address),
-			zap.String("uuid", util.GetUUID(ctx)),
-			zap.Error(ctx.Err()),
-		)
 		return "", nil, ctx.Err()
 	}
 }


### PR DESCRIPTION
# What issue is this change attempting to solve?
Fixes #239 

during one complex render request we can issue other 100k render
requests to the zipper.
After a while, they start reaching main context deadline.
When this happens, logs get poluted with tens of tousands of log lines.

## How does this change solve the problem? Why is this the best approach?

I just removed the log lines.

## How can we be sure this works as expected?
Tested with slow request.