### PR TITLE
WriteTimeout & ctx.Deadline race condition

### DIFF
--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -113,7 +113,7 @@ func (app *App) Start() func() {
 		Addr:         app.config.Listen,
 		Handler:      handler,
 		ReadTimeout:  1 * time.Second,
-		WriteTimeout: app.config.Timeouts.Global * 2,
+		WriteTimeout: app.config.Timeouts.Global * 2, // It has to be greater than Timeout.Global because we use that value as per-request context timeout
 	}, prometheusServer)
 	if err != nil {
 		logger.Fatal("gracehttp failed",

--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -113,7 +113,7 @@ func (app *App) Start() func() {
 		Addr:         app.config.Listen,
 		Handler:      handler,
 		ReadTimeout:  1 * time.Second,
-		WriteTimeout: app.config.Timeouts.Global,
+		WriteTimeout: app.config.Timeouts.Global * 2,
 	}, prometheusServer)
 	if err != nil {
 		logger.Fatal("gracehttp failed",

--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -116,7 +116,7 @@ func (app *App) Start() func() {
 		Addr:         app.config.Listen,
 		Handler:      handler,
 		ReadTimeout:  1 * time.Second,
-		WriteTimeout: app.config.Timeouts.Global * 2,
+		WriteTimeout: app.config.Timeouts.Global * 2, // It has to be greater than Timeout.Global because we use that value as per-request context timeout
 	}, metricsServer)
 
 	if err != nil {

--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -116,7 +116,7 @@ func (app *App) Start() func() {
 		Addr:         app.config.Listen,
 		Handler:      handler,
 		ReadTimeout:  1 * time.Second,
-		WriteTimeout: app.config.Timeouts.Global,
+		WriteTimeout: app.config.Timeouts.Global * 2,
 	}, metricsServer)
 
 	if err != nil {


### PR DESCRIPTION
#What issue is this change attempting to solve?
When processing a request, we use a ctx with a timeout that was
Timeout.Global value.

At the same time, we set the same Timeout as WriteTimeout when creating
the httpServer.

What happens it that after `Timeout.Global` seconds:
 - we check if ctx.Done() and return from functions with errors.
 - the http server is closing the connection because we reached
   WriteTimeout

So when we try to answer with an error because we reached ctx.Deadline the connection will be closed.

## How does this change solve the problem? Why is this the best approach?

I'm not 100% sure that 2*Timeout.Global is the right value here.
Idea is that WriteTimeout has to be greater than ctx.Deadline, so I though to use the double of that number.

## How can we be sure this works as expected?

Tested with very slow request that times out.