### PR TITLE
constantLine: add one more datapoint

### DIFF
--- a/expr/functions/constantLine/function.go
+++ b/expr/functions/constantLine/function.go
@@ -39,9 +39,9 @@ func (f *constantLine) Do(ctx context.Context, e parser.Expr, from, until int32,
 			Name:      fmt.Sprintf("%g", value),
 			StartTime: from,
 			StopTime:  until,
-			StepTime:  until - from,
-			Values:    []float64{value, value},
-			IsAbsent:  []bool{false, false},
+			StepTime:  (until - from) / 2,
+			Values:    []float64{value, value, value},
+			IsAbsent:  []bool{false, false, false},
 		},
 	}
 

--- a/expr/functions/constantLine/function_test.go
+++ b/expr/functions/constantLine/function_test.go
@@ -31,7 +31,7 @@ func TestConstantLine(t *testing.T) {
 				{"42.42", 0, 1}: {types.MakeMetricData("constantLine", []float64{12.3, 12.3}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("42.42",
-				[]float64{42.42, 42.42}, 1, now32)},
+				[]float64{42.42, 42.42, 42.42}, 1, now32)},
 		},
 	}
 

--- a/expr/functions/constantLine/function_test.go
+++ b/expr/functions/constantLine/function_test.go
@@ -1,6 +1,7 @@
 package constantLine
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -37,9 +38,38 @@ func TestConstantLine(t *testing.T) {
 
 	for _, tt := range tests {
 		testName := tt.Target
-		t.Run(testName, func(t *testing.T) {
-			th.TestEvalExpr(t, &tt)
-		})
-	}
+		evaluator := metadata.GetEvaluator()
+		originalMetrics := th.DeepClone(tt.M)
+		exp, _, err := parser.ParseExpr(tt.Target)
+		ctx := context.Background()
+		g, err := evaluator.EvalExpr(ctx, exp, 1, now32, tt.M, th.NoopGetTargetData)
 
+		if err != nil {
+			t.Errorf("failed to eval %s: %+v", testName, err)
+			return
+		}
+		if len(g) != len(tt.Want) {
+			t.Errorf("%s returned a different number of metrics, actual %v, Want %v", testName, len(g), len(tt.Want))
+			return
+		}
+		th.DeepEqual(t, testName, originalMetrics, tt.M)
+
+		for i, want := range tt.Want {
+			actual := g[i]
+			if actual == nil {
+				t.Errorf("returned no value %v", tt.Target)
+				return
+			}
+			if actual.StepTime == 0 {
+				t.Errorf("missing Step for %+v", g)
+			}
+			if actual.Name != want.Name {
+				t.Errorf("bad Name for %s metric %d: got %s, Want %s", testName, i, actual.Name, want.Name)
+			}
+			if !th.NearlyEqualMetrics(actual, want) {
+				t.Errorf("different values for %s metric %s: got %v, Want %v", testName, actual.Name, actual.Values, want.Values)
+				return
+			}
+		}
+	}
 }

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -194,7 +194,7 @@ func InitTestSummarize() (int32, int32, int32) {
 	return tenThirtyTwo, tenFiftyNine, tenThirty
 }
 
-func noopGetTargetData(ctx context.Context, exp parser.Expr, from, until int32, metricMap map[parser.MetricRequest][]*types.MetricData) (error, int) {
+func NoopGetTargetData(ctx context.Context, exp parser.Expr, from, until int32, metricMap map[parser.MetricRequest][]*types.MetricData) (error, int) {
 	return nil, 0
 }
 
@@ -206,7 +206,7 @@ func TestSummarizeEvalExpr(t *testing.T, tt *SummarizeEvalTestItem) {
 		exp, _, _ := parser.ParseExpr(tt.Target)
 
 		ctx := context.Background()
-		g, err := evaluator.EvalExpr(ctx, exp, 0, 1, tt.M, noopGetTargetData)
+		g, err := evaluator.EvalExpr(ctx, exp, 0, 1, tt.M, NoopGetTargetData)
 		if err != nil {
 			t.Errorf("failed to eval %v: %+v", tt.Name, err)
 			return
@@ -248,7 +248,7 @@ func TestMultiReturnEvalExpr(t *testing.T, tt *MultiReturnEvalTestItem) {
 		return
 	}
 	ctx := context.Background()
-	g, err := evaluator.EvalExpr(ctx, exp, 0, 1, tt.M, noopGetTargetData)
+	g, err := evaluator.EvalExpr(ctx, exp, 0, 1, tt.M, NoopGetTargetData)
 	if err != nil {
 		t.Errorf("failed to eval %v: %+v", tt.Name, err)
 		return
@@ -299,7 +299,7 @@ func TestEvalExpr(t *testing.T, tt *EvalTestItem) {
 	testName := tt.Target
 	exp, _, err := parser.ParseExpr(tt.Target)
 	ctx := context.Background()
-	g, err := evaluator.EvalExpr(ctx, exp, 0, 1, tt.M, noopGetTargetData)
+	g, err := evaluator.EvalExpr(ctx, exp, 0, 1, tt.M, NoopGetTargetData)
 
 	if err != nil {
 		t.Errorf("failed to eval %s: %+v", testName, err)


### PR DESCRIPTION
# What issue is this change attempting to solve?

I was checking graphite-python and there constantLine has 3 datapoints.
This helps when we use functions with constantLine(). That way, the
result with have 2 datapoints(instead of one)

