### PR TITLE
find: answer with http 422 for requests that are too complex

### DIFF
--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/bookingcom/carbonapi/pkg/backend"
-	nt "github.com/bookingcom/carbonapi/pkg/backend/net"
 	"github.com/bookingcom/carbonapi/pkg/types"
 	"github.com/bookingcom/carbonapi/pkg/types/encoding/carbonapi_v2"
 	"github.com/bookingcom/carbonapi/pkg/types/encoding/json"
@@ -95,7 +94,7 @@ func (app *App) findHandler(w http.ResponseWriter, req *http.Request) {
 	if ctx.Err() != nil {
 		// context was cancelled even if some of the requests succeeded
 		app.prometheusMetrics.RequestCancel.WithLabelValues(
-			"find", nt.ContextCancelCause(ctx.Err()),
+			"find", ctx.Err().Error(),
 		).Inc()
 	}
 
@@ -311,7 +310,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request) {
 	if ctx.Err() != nil {
 		// context was cancelled even if some of the requests succeeded
 		app.prometheusMetrics.RequestCancel.WithLabelValues(
-			"find", nt.ContextCancelCause(ctx.Err()),
+			"find", ctx.Err().Error(),
 		).Inc()
 		span.SetAttribute("error", true)
 		span.SetAttribute("error.message", ctx.Err().Error())

--- a/pkg/backend/net/net.go
+++ b/pkg/backend/net/net.go
@@ -39,30 +39,6 @@ func (e ErrHTTPCode) Error() string {
 	}
 }
 
-// ErrContextCancel signifies context cancellation manual or via timeout
-type ErrContextCancel struct {
-	Err error
-}
-
-func (err ErrContextCancel) Error() string {
-	return err.Err.Error()
-}
-
-// ContextCancelCause tells why the context was cancelled
-func ContextCancelCause(err error) string {
-	var cause string
-	switch err {
-	case context.DeadlineExceeded:
-		cause = "deadline"
-	case context.Canceled:
-		cause = "canceled"
-	default:
-		cause = "unknown"
-	}
-
-	return cause
-}
-
 // Backend represents a host that accepts requests for metrics over HTTP.
 type Backend struct {
 	address        string
@@ -345,10 +321,6 @@ func (b Backend) Render(ctx context.Context, request types.RenderRequest) ([]typ
 
 	contentType, resp, err := b.call(ctx, request.Trace, u, body)
 	if err != nil {
-		if ctx.Err() != nil {
-			return nil, ErrContextCancel{Err: ctx.Err()}
-		}
-
 		if code, ok := err.(ErrHTTPCode); ok && code == http.StatusNotFound {
 			return nil, types.ErrMetricsNotFound
 		}
@@ -472,10 +444,6 @@ func (b Backend) Find(ctx context.Context, request types.FindRequest) (types.Mat
 
 	contentType, resp, err := b.call(ctx, request.Trace, u, body)
 	if err != nil {
-		if ctx.Err() != nil {
-			return types.Matches{}, ErrContextCancel{Err: ctx.Err()}
-		}
-
 		if code, ok := err.(ErrHTTPCode); ok && code == http.StatusNotFound {
 			return types.Matches{}, types.ErrMatchesNotFound
 		}


### PR DESCRIPTION
## What issue is this change attempting to solve?

find: answer with http 422 for requests that are too complex

## How does this change solve the problem? Why is this the best approach?

Removed ErrContextCancel type because it was not used and it made
errors.Is() checks to fail

## How can we be sure this works as expected?
Tested with very small timeout.
