### PR TITLE
pprof: fix routing

### DIFF
--- a/app/carbonapi/routes.go
+++ b/app/carbonapi/routes.go
@@ -24,12 +24,7 @@ func initHandlersInternal(app *App) http.Handler {
 	r.HandleFunc("/debug/version", app.debugVersionHandler)
 
 	r.Handle("/debug/vars", expvar.Handler())
-	r.HandleFunc("/debug/pprof", pprof.Index)
-	s := r.PathPrefix("/debug/pprof").Subrouter()
-	s.HandleFunc("/cmdline", pprof.Cmdline)
-	s.HandleFunc("/profile", pprof.Profile)
-	s.HandleFunc("/symbol", pprof.Symbol)
-	s.HandleFunc("/trace", pprof.Trace)
+	r.PathPrefix("/debug/pprof").HandlerFunc(pprof.Index)
 
 	r.Handle("/metrics", promhttp.Handler())
 

--- a/app/carbonzipper/routes.go
+++ b/app/carbonzipper/routes.go
@@ -32,11 +32,7 @@ func initMetricHandlers(app *App) http.Handler {
 	r.Handle("/metrics", promhttp.Handler())
 
 	r.Handle("/debug/vars", expvar.Handler())
-	r.HandleFunc("/debug/pprof/", pprof.Index)
-	r.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	r.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	r.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	r.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	r.PathPrefix("/debug/pprof").HandlerFunc(pprof.Index)
 
 	return r
 }


### PR DESCRIPTION
## What issue is this change attempting to solve?

When trying to request /debug/pprof/heap I would get 404.

## How does this change solve the problem? Why is this the best approach?

Since I used PathPrefix, we don't need the other paths individually.

## How can we be sure this works as expected?

Request to /debug/pprof/heap works now.