### PR TITLE
traces: add two new options:  jaegerBufferMaxCount and jaegerBatchMaxCount

### DIFF
--- a/cfg/common.go
+++ b/cfg/common.go
@@ -120,6 +120,9 @@ func DefaultCommonConfig() Common {
 		Traces: Traces{
 			Timeout: 10 * time.Second,
 			Tags:    Tags{},
+			JaegerBufferMaxCount: 500000, // If size of one span is 3k, we will hold max ~1.5g in memory
+			JaegerBatchMaxCount: 500, // If size of one span is 3k, total request size will be ~1.5m
+
 		},
 		PrintErrorStackTrace: false,
 	}
@@ -267,7 +270,9 @@ type DC struct {
 
 // Traces holds configuration related to tracing
 type Traces struct {
-	JaegerEndpoint string        `yaml:"jaegerEndpoint"`
-	Timeout        time.Duration `yaml:"timeout"`
-	Tags           Tags          `yaml:"tags"`
+	JaegerEndpoint       string        `yaml:"jaegerEndpoint"`
+	Timeout              time.Duration `yaml:"timeout"`
+	Tags                 Tags          `yaml:"tags"`
+	JaegerBufferMaxCount int           `yaml:"jaegerBufferMaxCount"`
+	JaegerBatchMaxCount  int           `yaml:"jaegerBatchMaxCount"`
 }

--- a/config/carbonapi.yaml
+++ b/config/carbonapi.yaml
@@ -154,4 +154,7 @@ traces:
     # If empty, no traces will be generated
     jaegerEndpoint: ""
     timeout: 10s
-
+    # Max number of spans that are stored in memory
+    jaegerBufferMaxCount: 500000
+    # Max number of spans sent in one batch
+    jaegerBatchMaxCount: 500

--- a/config/carbonzipper.yaml
+++ b/config/carbonzipper.yaml
@@ -125,4 +125,7 @@ traces:
     # If empty, no traces will be generated
     jaegerEndpoint: ""
     timeout: 10s
-
+    # Max number of spans that are stored in memory
+    jaegerBufferMaxCount: 500000
+    # Max number of spans sent in one batch
+    jaegerBatchMaxCount: 500

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -60,6 +60,8 @@ func InitTracer(BuildVersion string, serviceName string, logger *zap.Logger, con
 		}),
 		jaeger.RegisterAsGlobal(),
 		jaeger.WithSDK(&sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
+		jaeger.WithBufferMaxCount(config.JaegerBufferMaxCount),
+		jaeger.WithBatchMaxCount(config.JaegerBatchMaxCount),
 	)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## What issue is this change attempting to solve?

I noticed that `carbonzipper` was running out of memory and getting OOM killed. 
A big chuck of memory was used by spans.

There are two options that control how many spans can get acumulated in memory:
 `BatchMaxCount`(default 10) : maximum number of spans that get sent in a request.
 `BufferMaxCount`(default 1 billion!) : maximum number of spans that can be stored in memory if sending is low.
Becuase of small `BatchMaxCount` spans would get send slow. Because of bug `BufferMaxCount`, the process would run out memory.
See also comment:
https://github.com/open-telemetry/opentelemetry-go/blob/master/exporters/trace/jaeger/jaeger.go#L136

## How does this change solve the problem? Why is this the best approach?

I added two new options:  jaegerBufferMaxCount and jaegerBatchMax.
That way, we can configure max number of spans stored in memory and number of spans that get sent in a request.
Default values are for a span size of ~3k.

## How can we be sure this works as expected?

make test. 
Tested with prod traffic.