### PR TITLE
return 404 instead of 500 when info-ing a non-existing metric

### DIFF
--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -951,7 +951,8 @@ func (app *App) infoHandler(w http.ResponseWriter, r *http.Request) {
 	request.IncCall()
 	infos, err := app.backend.Info(ctx, request)
 	if err != nil {
-		if _, ok := err.(dataTypes.ErrNotFound); ok {
+		var notFound dataTypes.ErrNotFound
+		if errors.As(err, &notFound) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			toLog.HttpCode = http.StatusNotFound
 			toLog.Reason = "info not found"

--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -951,6 +951,13 @@ func (app *App) infoHandler(w http.ResponseWriter, r *http.Request) {
 	request.IncCall()
 	infos, err := app.backend.Info(ctx, request)
 	if err != nil {
+		if _, ok := err.(dataTypes.ErrNotFound); ok {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			toLog.HttpCode = http.StatusNotFound
+			toLog.Reason = "info not found"
+			logAsError = true
+			return
+		}
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		toLog.HttpCode = http.StatusInternalServerError
 		toLog.Reason = err.Error()

--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -457,7 +457,8 @@ func (app *App) infoHandler(w http.ResponseWriter, req *http.Request) {
 	err = errorsFanIn(ctx, errs, len(bs))
 	if err != nil {
 
-		if _, ok := err.(types.ErrNotFound); ok {
+		var notFound types.ErrNotFound
+		if errors.As(err, &notFound) {
 			accessLogger.Error("info not found",
 				zap.Int("http_code", http.StatusNotFound),
 				zap.Error(err),

--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -456,6 +456,17 @@ func (app *App) infoHandler(w http.ResponseWriter, req *http.Request) {
 	infos, errs := backend.Infos(ctx, bs, request)
 	err = errorsFanIn(ctx, errs, len(bs))
 	if err != nil {
+
+		if _, ok := err.(types.ErrNotFound); ok {
+			accessLogger.Error("info not found",
+				zap.Int("http_code", http.StatusNotFound),
+				zap.Error(err),
+				zap.Duration("runtime_seconds", time.Since(t0)),
+			)
+			http.Error(w, "info: not found", http.StatusNotFound)
+			return
+		}
+
 		accessLogger.Error("info failed",
 			zap.Int("http_code", http.StatusInternalServerError),
 			zap.Error(err),

--- a/pkg/backend/net/net.go
+++ b/pkg/backend/net/net.go
@@ -392,6 +392,11 @@ func (b Backend) Info(ctx context.Context, request types.InfoRequest) ([]types.I
 	request.Trace.AddMarshal(t0)
 
 	_, resp, err := b.call(ctx, request.Trace, u, body)
+
+	if code, ok := err.(ErrHTTPCode); ok && code == http.StatusNotFound {
+		return nil, types.ErrInfoNotFound
+	}
+
 	if err != nil {
 		return nil, errors.Wrap(err, "HTTP call failed")
 	}


### PR DESCRIPTION

## What issue is this change attempting to solve?

## How does this change solve the problem? Why is this the best approach?

## How can we be sure this works as expected?

