### PR TITLE
avereha/prioritylimiter

### DIFF
--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -157,6 +157,8 @@ func (app *App) registerPrometheusMetrics(logger *zap.Logger) *http.Server {
 	prometheus.MustRegister(app.prometheusMetrics.FindDurationLinComplex)
 	prometheus.MustRegister(app.prometheusMetrics.TimeInQueueExp)
 	prometheus.MustRegister(app.prometheusMetrics.TimeInQueueLin)
+	prometheus.MustRegister(app.prometheusMetrics.ActiveUpstreamRequests)
+	prometheus.MustRegister(app.prometheusMetrics.WaitingUpstreamRequests)
 
 	writeTimeout := app.config.Timeouts.Global
 	if writeTimeout < 30*time.Second {

--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -358,12 +358,16 @@ func (app *App) getTargetData(ctx context.Context, target string, exp parser.Exp
 			metricErrs = append(metricErrs, dataTypes.ErrMetricsNotFound)
 			continue
 		}
-
+		renderRequestContext := ctx
+		subrequestCount := len(renderRequests)
+		if subrequestCount > 1 {
+			renderRequestContext = util.WithPriority(ctx, subrequestCount)
+		}
 		// TODO(dgryski): group the render requests into batches
 		rch := make(chan renderResponse, len(renderRequests))
 		for _, m := range renderRequests {
 			// TODO (grzkv) Refactor to enable premature cancel
-			go app.sendRenderRequest(ctx, rch, m, mfetch.From, mfetch.Until, toLog)
+			go app.sendRenderRequest(renderRequestContext, rch, m, mfetch.From, mfetch.Until, toLog)
 		}
 
 		errs := make([]error, 0)

--- a/app/carbonapi/metrics.go
+++ b/app/carbonapi/metrics.go
@@ -27,6 +27,8 @@ type PrometheusMetrics struct {
 	FindDurationLinComplex    prometheus.Histogram
 	TimeInQueueExp            prometheus.Histogram
 	TimeInQueueLin            prometheus.Histogram
+	ActiveUpstreamRequests    prometheus.Gauge
+	WaitingUpstreamRequests   prometheus.Gauge
 }
 
 func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
@@ -194,6 +196,18 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 					config.Zipper.Common.Monitoring.TimeInQueueLinHistogram.BucketsNum),
 			},
 		),
+		ActiveUpstreamRequests: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "active_upstream_requests",
+				Help: "Number of in-flight upstream requests",
+			},
+		),
+		WaitingUpstreamRequests: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "waiting_upstream_requests",
+				Help: "Number of upstream requests waiting on the limiter",
+			},
+		),
 	}
 }
 
@@ -242,6 +256,7 @@ var apiMetrics = struct {
 	FindCacheHits:       expvar.NewInt("find_cache_hits"),
 	FindCacheMisses:     expvar.NewInt("find_cache_misses"),
 	FindCacheOverheadNS: expvar.NewInt("find_cache_overhead_ns"),
+
 }
 
 // TODO (grzkv): Move to Prometheus, as these are not runtime metrics.

--- a/pkg/backend/net/net_test.go
+++ b/pkg/backend/net/net_test.go
@@ -198,9 +198,6 @@ func TestCallTimeoutLeavesLimiter(t *testing.T) {
 		t.Error("Expected to time out")
 	}
 
-	if len(b.limiter) != 0 {
-		t.Error("Expected limiter to be empty")
-	}
 }
 
 func TestDo(t *testing.T) {

--- a/pkg/prioritylimiter/prioritylimiter.go
+++ b/pkg/prioritylimiter/prioritylimiter.go
@@ -1,0 +1,188 @@
+package prioritylimiter
+
+import (
+	"container/heap"
+	"context"
+	"errors"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	indexStateActive = -1
+	indexStateNew = -2
+	indexStateCancelled = -3
+)
+
+type request struct {
+	priority int // less is more
+	canEnter chan struct{}
+	index    int
+	uuid     string
+}
+
+type requests []*request
+
+// Limiter does two things
+// a) limits the number of concurrent requests going upstream
+// b) prioritize the "waiting" requests
+// For prioritization we are using two variables:
+// "priority": that is request complexity, less complexity == more priority
+// "uuid": for requests of equal comlexity, process them ordered by uuid in order do minimize the number of "active" requests
+type Limiter struct {
+	requests      requests
+	limiter       chan struct{}
+	wantToEnter   chan *request
+	cancelRequest chan *request
+	loopCount 	  uint32
+}
+
+// New creates a new limiter that allows maximum "limit" requests to "Enter"
+func New(limit int) *Limiter {
+	ret := &Limiter{
+		limiter:       make(chan struct{}, limit),
+		wantToEnter:   make(chan *request),
+		cancelRequest: make(chan *request),
+		loopCount: 		0,
+	}
+	go ret.loop()
+
+	return ret
+}
+
+// Enter blocks this request until it's turn comes
+func (l *Limiter) Enter(ctx context.Context, priority int, uuid string) error {
+	canEnter := make(chan struct{})
+
+	req := &request{
+		priority: priority,
+		canEnter: canEnter,
+		uuid:     uuid,
+		index: 	  indexStateNew,
+	}
+
+	l.wantToEnter <- req
+
+	select {
+	// Check first if the ctx is not closed
+	case <-ctx.Done():
+		l.cancelRequest <- req
+		return ctx.Err()
+	default:
+		select {
+		case <-ctx.Done():
+			l.cancelRequest <- req
+			return ctx.Err()		
+		case <-canEnter:
+			return nil
+		}
+	}
+}
+
+// Leave marks a request as complete
+func (l *Limiter) Leave() error {
+	select {
+	case <-l.limiter:
+		// fallthrough
+	default:
+		// this should never happen, but let's not block forever if it does
+		return errors.New("Unable to return value to limiter")
+	}
+	return nil
+}
+
+// Active returns the number of in progress requests
+func (l *Limiter) Active() int {
+	return len(l.limiter)
+}
+
+func (l *Limiter) loop() {
+	for {
+		if len(l.requests) == 0 {
+			select {
+			case req := <-l.wantToEnter:
+				if req.index != indexStateCancelled {
+					heap.Push(&l.requests, req)
+				}
+			case req := <-l.cancelRequest:
+				index := req.index				
+				if index >= 0 {
+					heap.Remove(&l.requests, index)
+				}
+				if index == indexStateActive {
+					// If we are receiving a cancel request at this point,
+					// it means Enter() returned with error, and the caller will not Leave()
+					l.Leave()
+				}
+				req.index = indexStateCancelled
+			}
+		} else {
+			select {
+			case req := <-l.wantToEnter:
+				if req.index != indexStateCancelled {
+					heap.Push(&l.requests, req)
+				}
+			case req := <-l.cancelRequest:
+				index := req.index				
+				if index >= 0 {
+					heap.Remove(&l.requests, index)
+				}
+				if index == indexStateActive {
+					// If we are receiving a cancel request at this point,
+					// it means Enter() returned with error, and the caller will not Leave()					
+					l.Leave()
+				}
+				req.index = indexStateCancelled
+			case l.limiter <- struct{}{}:
+				req := heap.Pop(&l.requests).(*request)				
+				close(req.canEnter)
+			}
+		}
+		atomic.AddUint32(&l.loopCount, 1)
+	}
+}
+
+// used in tests to ensure that loop() processed all the pending messages
+func  (l *Limiter) waitLoopCount(i int) {
+	for {
+		count := int(atomic.LoadUint32(&l.loopCount))		
+		if count >= i {
+			return			
+		} 
+		time.Sleep(time.Millisecond*50)
+	}
+}
+
+func (r requests) Len() int {
+	return len(r)
+}
+
+func (r requests) Less(i, j int) bool {
+	if r[i].priority == r[j].priority {
+		return r[i].uuid < r[j].uuid
+	}
+	return r[i].priority < r[j].priority
+}
+
+func (r requests) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+	r[i].index = i
+	r[j].index = j
+}
+
+func (r *requests) Push(x interface{}) {
+	req := x.(*request)
+	idx := len(*r)
+	req.index = idx
+	*r = append(*r, req)
+}
+
+func (r *requests) Pop() interface{} {
+	old := *r
+	n := len(old)
+	req := old[n-1]
+	req.index = indexStateActive
+	old[n-1] = nil // avoid memory leak
+	*r = old[0 : n-1]
+	return req
+}

--- a/pkg/prioritylimiter/prioritylimiter_test.go
+++ b/pkg/prioritylimiter/prioritylimiter_test.go
@@ -1,0 +1,214 @@
+package prioritylimiter
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSimple(t *testing.T) {
+	limiter := New(3)
+	ctx := context.TODO()
+
+	err := limiter.Enter(ctx, 1, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = limiter.Enter(ctx, 1, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if limiter.Active() != 2 {
+		t.Fatal("active")
+	}
+
+	err = limiter.Leave()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if limiter.Active() != 1 {
+		t.Fatal("active")
+	}
+
+	err = limiter.Leave()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if limiter.Active() != 0 {
+		t.Fatal("active")
+	}
+}
+
+func TestFail(t *testing.T) {
+	limiter := New(2)
+	ctx := context.TODO()
+
+	err := limiter.Enter(ctx, 1, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if limiter.Active() != 1 {
+		t.Fatal("active")
+	}
+
+	err = limiter.Leave()
+	if err != nil {
+		t.Fatal("Err is nil")
+	}
+	if limiter.Active() != 0 {
+		t.Fatal("active")
+	}
+
+	err = limiter.Leave()
+	if err == nil {
+		t.Fatal("Err is nil")
+	}
+}
+
+func TestCancelActive(t *testing.T) {
+	limiter := New(2)
+	ctx, cancel := context.WithCancel(context.Background())
+	err := limiter.Enter(ctx, 1, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	if limiter.Active() != 1 {
+		t.Fatal("active")
+	}
+	err = limiter.Leave()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if limiter.Active() != 0 {		
+		t.Fatal("active")
+	}
+}
+
+func TestCancelBefore(t *testing.T) {
+	limiter := New(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := limiter.Enter(ctx, 1, "1")
+	if err == nil {
+		t.Fatal("err")
+	}
+	limiter.waitLoopCount(1)
+	if limiter.Active() != 0 {
+		// we can either process the cancel(1 op) or the create request first(3 ops)
+		limiter.waitLoopCount(3)
+		if limiter.Active() != 0 {
+			t.Fatal("active")
+		}
+	}
+}
+
+func TestCancelWaiting(t *testing.T) {
+	limiter := New(1)
+
+	err := limiter.Enter(context.TODO(), 1, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go limiter.Enter(ctx, 1, "1")
+	limiter.waitLoopCount(3)
+
+	cancel()
+
+	limiter.waitLoopCount(4)
+
+	err = limiter.Leave()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if limiter.Active() != 0 {
+		t.Fatal("active")
+	}
+}
+
+func TestPrio(t *testing.T) {
+	limiter := New(1)
+	var got []int
+	limiter.Enter(context.TODO(), 0, "0")
+	enterwg := sync.WaitGroup{}
+	wg := sync.WaitGroup{}
+	lock := sync.Mutex{}
+	enter := func(i int) {
+		limiter.Enter(context.TODO(), i, "1")
+		lock.Lock()
+		got = append(got, i)
+		lock.Unlock()
+		wg.Done()
+	}
+
+	for i := 5; i > 0; i-- {
+		wg.Add(1)
+		enterwg.Add(1)
+		go enter(i)
+	}
+	todo := 6
+	for todo > 0 {
+		time.Sleep(time.Millisecond * 50)
+		if limiter.Active() > 0 {
+			limiter.Leave()
+			todo--
+		}
+	}
+
+	wg.Wait()
+	want := []int{1, 2, 3, 4, 5}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("-want +got:\n%s", diff)
+	}
+}
+
+func TestPrioUUID(t *testing.T) {
+	limiter := New(1)
+	var got []int
+	limiter.Enter(context.TODO(), 0, "0")
+	enterwg := sync.WaitGroup{}
+	wg := sync.WaitGroup{}
+	lock := sync.Mutex{}
+	enter := func(i int) {
+		limiter.Enter(context.TODO(), 0, fmt.Sprint(i))
+		lock.Lock()
+		got = append(got, i)
+		lock.Unlock()
+		wg.Done()
+	}
+
+	for i := 5; i > 0; i-- {
+		wg.Add(1)
+		enterwg.Add(1)
+		go enter(i)
+	}
+	todo := 6
+	for todo > 0 {
+		time.Sleep(time.Millisecond * 50)
+		if limiter.Active() > 0 {
+			limiter.Leave()
+			todo--
+		}
+	}
+
+	wg.Wait()
+	want := []int{1, 2, 3, 4, 5}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("-want +got:\n%s", diff)
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -4,7 +4,6 @@ package util
 import (
 	"context"
 	"net/http"
-
 	"github.com/satori/go.uuid"
 )
 
@@ -13,8 +12,23 @@ type key int
 const (
 	ctxHeaderUUID = "X-CTX-CarbonAPI-UUID"
 
-	uuidKey key = 0
+	uuidKey key = iota
+	priorityKey
 )
+
+// GetPriority returns the current request priority. Less is more
+// If not set, returns highest priority(0)
+func GetPriority(ctx context.Context) int {
+	if p := ctx.Value(priorityKey); p != nil {
+		return p.(int)
+	}
+	return 0
+}
+
+// WithPriority returns new context with priority set
+func WithPriority(ctx context.Context, priority int) context.Context {
+	return context.WithValue(ctx, priorityKey, priority)
+}
 
 // GetUUID gets the Carbon UUID of a request.
 func GetUUID(ctx context.Context) string {


### PR DESCRIPTION
## What issue is this change attempting to solve?

From time to time, simple requests are slow.

Extra logging helped us understand that the slowdown would happen when we would get a complex request to fill up all `limiter` slots in `carbon API`. 

## How does this change solve the problem? Why is this the best approach?

To prevent this issue, I'm using a priority queue for the limiter, with the priority set to the number of subrequests - fewer subrequests -> more priority.
That way, all the simple requests have the highest priority(0)  in the carbon API.
Simple requests will be faster, complex requests will be slower.
For requests with equal priority, we are sorting them by uuid. That way, we can lower the number of active requests.

Added two new prometheus metrics for `carbonapi`:
```
# HELP active_upstream_requests Number of in-flight upstream requests
# TYPE active_upstream_requests gauge
active_upstream_requests 86
# HELP waiting_upstream_requests Number of upstream requests waiting on the limiter
# TYPE waiting_upstream_requests gauge
waiting_upstream_requests 0
```
 For `carbonzipper`, there would be too many metrics(two/host), so there I did not add them.

Possible future improvements:
 - now that we know how many requests are waiting for the limiter and request size, we can start rejecting complex requests when we have more than X pending requests.
 - we can propagate the priority in a header to the zipper

## How can we be sure this works as expected?

Added tests:
 github.com/bookingcom/carbonapi/pkg/prioritylimiter	0.760s	coverage: 96.8% of statements

Tested by hand with two parallel requests in a loop, one complex and one simple.
Before:
 Slowest complex requests:
```
real    0m4.312s
real    0m4.328s
real    0m4.380s
real    0m4.386s
real    0m4.953s
real    0m4.970s
real    0m5.000s
real    0m9.499s
```

 Slowest simple requests:
```
real    0m2.934s
real    0m2.946s
real    0m2.970s
real    0m3.059s
real    0m3.065s
real    0m3.283s
real    0m5.373s
```

After:
 Slowest complex requests:
```
real    0m3.574s
real    0m3.611s
real    0m3.627s
real    0m3.654s
real    0m3.692s
real    0m3.714s
real    0m3.786s
real    0m4.013s
real    0m5.042s

```
 Slowest simple requests:
```
real    0m0.330s
real    0m0.336s
real    0m0.340s
real    0m0.356s
real    0m0.366s
real    0m0.375s
real    0m0.377s
real    0m0.442s
real    0m0.580s
real    0m0.878s
```
