### PR TITLE
parser: return errors if there are syntax bugs in metric names wrapped by a function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.30
+          version: v1.40.1
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -149,6 +149,8 @@ linters:
   disable:
     - maligned
     - prealloc
+    - makezero # Disable due to panic bug in makezero (golangci-lint@1.40.1)
+    - errorlint # Disable temporarily, more could be found in: https://github.com/bookingcom/carbonapi/issues/333
   disable-all: false
   presets:
     - bugs

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -44,5 +44,6 @@ Slawomir Skowron
 Stefan Boronea
 Vladimir Smirnov
 Vsevolod Polyakov
+Xiaofan Hu
 Zachary Dykstra
 Zhang Cheng

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -35,6 +35,22 @@ var (
 	ErrMissingQuote = ParseError("missing quote")
 	// ErrUnexpectedCharacter is a parse error returned when an expression contains an unexpected character.
 	ErrUnexpectedCharacter = ParseError("unexpected character")
+	// ErrMissinggBracket is a parse error returned when an expression is missing an opening or closing bracket.
+	ErrMissinggBracket = ParseError("missing opening or closing bracket []")
+	// ErrMissinggBrace is a parse error returned when an expression is missing an opening or closing brace.
+	ErrMissinggBrace = ParseError("missing opening or closing brace {}")
+	// ErrCommaInBrackets is a parse error returned when an expression has comma within brackets.
+	ErrCommaInBrackets = ParseError("comma within brackets")
+	// ErrSpacesInMetricName is a parse error returned when an expression has space in metric name.
+	ErrSpacesInMetricName = ParseError("space in metric name")
+	// ErrSpacesInBraces is a parse error returned when an expression has space in braces.
+	ErrSpacesInBraces = ParseError("space in braces")
+	// ErrSpacesInBrackets is a parse error returned when an expression has space in brackets.
+	ErrSpacesInBrackets = ParseError("space in brackets")
+	// ErrBraceInBrackets is a parse error returned when an expression has brace within brackets.
+	ErrBraceInBrackets = ParseError("brace within brackets")
+	// ErrNestedBrackets is a parse error returned when an expression has nested brackets.
+	ErrNestedBrackets = ParseError("nested brackets")
 	// ErrBadType is an eval error returned when a argument has wrong type.
 	ErrBadType = ParseError("bad type")
 	// ErrMissingArgument is an eval error returned when a argument is missing.

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -35,10 +35,10 @@ var (
 	ErrMissingQuote = ParseError("missing quote")
 	// ErrUnexpectedCharacter is a parse error returned when an expression contains an unexpected character.
 	ErrUnexpectedCharacter = ParseError("unexpected character")
-	// ErrMissinggBracket is a parse error returned when an expression is missing an opening or closing bracket.
-	ErrMissinggBracket = ParseError("missing opening or closing bracket []")
-	// ErrMissinggBrace is a parse error returned when an expression is missing an opening or closing brace.
-	ErrMissinggBrace = ParseError("missing opening or closing brace {}")
+	// ErrMissingBracket is a parse error returned when an expression is missing an opening or closing bracket.
+	ErrMissingBracket = ParseError("missing opening or closing bracket []")
+	// ErrMissingBrace is a parse error returned when an expression is missing an opening or closing brace.
+	ErrMissingBrace = ParseError("missing opening or closing brace {}")
 	// ErrCommaInBrackets is a parse error returned when an expression has comma within brackets.
 	ErrCommaInBrackets = ParseError("comma within brackets")
 	// ErrSpacesInMetricName is a parse error returned when an expression has space in metric name.

--- a/pkg/parser/internal.go
+++ b/pkg/parser/internal.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"fmt"
-
 	"runtime/debug"
 )
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -582,7 +582,7 @@ FOR:
 		// Graphite render spec: https://graphite.readthedocs.io/en/latest/render_api.html#graphing-metrics
 		switch s[i] {
 		case '{':
-			// No way escape { in metric names, thus supporting it
+			// No way escape { in metric names, thus using it
 			// in the range brackets should be an error.
 			if brackets > 0 {
 				return s, "", ErrBraceInBrackets
@@ -590,12 +590,12 @@ FOR:
 
 			braces++
 		case '}':
-			// No way escape } in metric names, thus supporting it
+			// No way escape } in metric names, thus using it
 			// in the range brackets should be an error.
 			if brackets > 0 {
 				return s, "", ErrBraceInBrackets
 			} else if braces == 0 {
-				return s, "", ErrMissinggBrace
+				return s, "", ErrMissingBrace
 			}
 
 			braces--
@@ -616,7 +616,7 @@ FOR:
 			// No way to escape braces {} and brackets [] in
 			// graphite query, thus missing open [ means it's a query bug.
 			if brackets == 0 {
-				return s, "", ErrMissinggBracket
+				return s, "", ErrMissingBracket
 			}
 
 			brackets--
@@ -662,10 +662,10 @@ FOR:
 	// No way to escape braces {} and brackets [] in graphite query, thus
 	// missing closed }/] means it's a query bug.
 	if braces > 0 {
-		return s, "", ErrMissinggBrace
+		return s, "", ErrMissingBrace
 	}
 	if brackets > 0 {
-		return s, "", ErrMissinggBracket
+		return s, "", ErrMissingBracket
 	}
 
 	if i == len(s) {


### PR DESCRIPTION
## What issue is this change attempting to solve?

In the current implementation, carbonapi returns `400` errors for queries like ns1.ns2.foo-[a b] or ns1.ns2.foo-{a, b}.
However, if these types of queries happened to be wrapped around within a function, like sumSeries, that accepts
metrics list, no errors are returned. As they are treated as individual metrics and sent to storage, storage would
returns 400 as well.

## How does this change solve the problem? Why is this the best approach?

This commit fixes the issue, by generating a parser error if spaces and comma appears inappropriately within []/{}.
At the same time, nested range list (like [[]]) and unclosed ([/{) or unopened (]/}) ranges or value list are also
reported as errors, instead of treating them as proper query and forwarding them to storages.

As consequence of this change, some of the requests that are originally returning 200 would be returned with 400
status codes.

## How can we be sure this works as expected?

Original tests still pass and new test cases are added.