### PR TITLE
carbonapi/render: EvalExpr should return series no exist as error

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -40,7 +40,12 @@ func EvalExpr(ctx context.Context, e parser.Expr, from, until int32, values map[
 	}
 
 	if e.IsName() {
-		return values[parser.MetricRequest{Metric: e.Target(), From: from, Until: until}], nil
+		val := values[parser.MetricRequest{Metric: e.Target(), From: from, Until: until}]
+		if val == nil {
+			return nil, parser.ErrSeriesDoesNotExist
+		}
+
+		return val, nil
 	} else if e.IsConst() {
 		p := types.MetricData{
 			Metric: dataTypes.Metric{


### PR DESCRIPTION
## What issue is this change attempting to solve?

This fixes a regression caused by commit f74343ceb74500b9b4997470604cea6f135054eb.

## How does this change solve the problem? Why is this the best approach?

Returns an error rather than a nil would be helpful for graphite functions to notice
that data does not exist and can return 4xx or 2xx, rather than panics and return
5xx.

## How can we be sure this works as expected?

500s are reduced.
