### PR TITLE
carbonzipper: introduce deterministicBackend option

### DIFF
--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -211,6 +211,7 @@ func initBackends(config cfg.Zipper, logger *zap.Logger) ([]backend.Backend, err
 			Limit:              config.ConcurrencyLimitPerServer,
 			PathCacheExpirySec: uint32(config.ExpireDelaySec),
 			Logger:             logger,
+			Deterministic:      config.DeterministicBackend,
 		})
 
 		if err != nil {

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestMergeInfos(t *testing.T) {
 	infos := [][]Info{
-		[]Info{Info{}},
+		{Info{}},
 		[]Info{Info{}},
 	}
 
@@ -408,6 +408,44 @@ func TestMergeMetricsDifferingStepTimes6(t *testing.T) {
 		Name:     "metric",
 		Values:   []float64{1, 1},
 		IsAbsent: []bool{false, false},
+		StepTime: 1,
+	}
+
+	doTest(t, input, expected)
+}
+
+func TestMergeMetricsDifferingStepTimes7(t *testing.T) {
+	input := []Metric{
+		Metric{
+			Name:          "metric",
+			Values:        []float64{2, 0, 2},
+			IsAbsent:      []bool{false, true, false},
+			StepTime:      1,
+			backendAddr:   "10.0.0.1",
+			backendWeight: 2,
+		},
+		Metric{
+			Name:          "metric",
+			Values:        []float64{1, 0, 0},
+			IsAbsent:      []bool{false, true, true},
+			StepTime:      1,
+			backendAddr:   "10.0.0.2",
+			backendWeight: 1,
+		},
+		Metric{
+			Name:          "metric",
+			Values:        []float64{3, 3, 3},
+			IsAbsent:      []bool{false, false, false},
+			StepTime:      1,
+			backendAddr:   "10.0.0.3",
+			backendWeight: 3,
+		},
+	}
+
+	expected := Metric{
+		Name:     "metric",
+		Values:   []float64{1, 3, 2},
+		IsAbsent: []bool{false, false, false},
 		StepTime: 1,
 	}
 


### PR DESCRIPTION
## What issue is this change attempting to solve?

In graphite storage (go-carbon) installations where consistency can not be guaranteed,
by always prefer to return metrics from the same set of backends would make the query
result less confusing, no more flapping results.

This commit essentially make graphite render result more consistent, both and right
and wrong.

## How does this change solve the problem? Why is this the best approach?

DeterministicBackend sets a backend weight for each metrics in render
request and carbonzipper would favor metrics from a specific node.
As storage backends like go-carbon does not have strong consistency
guarantee, this means that the same metric persisted in different
replicas might have different values. Without DeterministicBackend
option, carbonzipper would just favor metrics returned first from
any backend. This might result in confusing query result in
carbonapi that are reading multiple metrics in one query.

An example like bellow:

```
asPercent(
    integral(sumSeries(http.app.latencies.{0_5_1,1_5,5_10,10_25,25_50,50_100,100_250}.count)),
    integral(sumSeries(http.app.latencies.*.count))
)
```

Without DeterministicBackend option, the example query above might
return result 100.1%. With DeterministicBackend option, it is
guaranteed that the query result would always "seems" meaningful,
but not necessarily correct.

## How can we be sure this works as expected?

Check TestMergeMetricsDifferingStepTimes7. Also confirm with production data that returning results are always consistent now.

