### PR TITLE
Emadolsky/weighted average

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -141,7 +141,6 @@ _When `format=png`_ (default if not specified)
 - unique
 - useSeriesAbove
 - verticalLine
-- weightedAverage
 - xFilesFactor
 
 ### Functions *present in carbonapi but absent in graphite-web*
@@ -297,3 +296,4 @@ _When `format=png`_ (default if not specified)
 | [tukeyAbove](https://en.wikipedia.org/wiki/Tukey%27s_range_test)(seriesList, basis, n, interval=0) |
 | [tukeyBelow](https://en.wikipedia.org/wiki/Tukey%27s_range_test)(seriesList, basis, n, interval=0) |
 | transformNull(seriesList, default=0)                                      |
+| weightedAverage(seriesListAvg, seriesListWeight, *nodes)                  |

--- a/expr/functions/glue.go
+++ b/expr/functions/glue.go
@@ -92,6 +92,7 @@ import (
 	"github.com/bookingcom/carbonapi/expr/functions/timeStack"
 	"github.com/bookingcom/carbonapi/expr/functions/transformNull"
 	"github.com/bookingcom/carbonapi/expr/functions/tukey"
+	"github.com/bookingcom/carbonapi/expr/functions/weightedAverage"
 	"github.com/bookingcom/carbonapi/expr/interfaces"
 	"github.com/bookingcom/carbonapi/expr/metadata"
 )
@@ -280,6 +281,8 @@ func New(configs map[string]string) {
 	funcs = append(funcs, initFunc{name: "transformNull", order: transformNull.GetOrder(), f: transformNull.New})
 
 	funcs = append(funcs, initFunc{name: "tukey", order: tukey.GetOrder(), f: tukey.New})
+
+	funcs = append(funcs, initFunc{name: "weightedAverage", order: weightedAverage.GetOrder(), f: weightedAverage.New})
 
 	sort.Slice(funcs, func(i, j int) bool {
 		if funcs[i].order == interfaces.Any && funcs[j].order == interfaces.Last {

--- a/expr/functions/weightedAverage/function.go
+++ b/expr/functions/weightedAverage/function.go
@@ -65,11 +65,14 @@ func (f *weightedAverage) Do(ctx context.Context, e parser.Expr, from, until int
 
 	var productMetrics []*types.MetricData
 	for _, key := range keys {
-		for i, _ := range avgGrouped[key] {
-			productMetricName := fmt.Sprintf("product(%s, %s)", weightGrouped[key][i].Name, avgGrouped[key][i].Name)
-			productMetric := helper.CombineSeries(avgGrouped[key][i], weightGrouped[key][i], productMetricName, productOperator)
-			productMetrics = append(productMetrics, productMetric)
+		if len(avgGrouped[key]) == 0 || len(weightGrouped[key]) == 0 {
+			continue
 		}
+		weight := weightGrouped[key][len(weightGrouped[key])-1]
+		avg := avgGrouped[key][len(avgGrouped[key])-1]
+		productMetricName := fmt.Sprintf("product(%s, %s)", weight.Name, avg.Name)
+		productMetric := helper.CombineSeries(avg, weight, productMetricName, productOperator)
+		productMetrics = append(productMetrics, productMetric)
 	}
 	if len(productMetrics) == 0 {
 		return []*types.MetricData{}, nil

--- a/expr/functions/weightedAverage/function.go
+++ b/expr/functions/weightedAverage/function.go
@@ -1,0 +1,160 @@
+package weightedAverage
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/bookingcom/carbonapi/expr/functions/sum"
+	"github.com/bookingcom/carbonapi/expr/helper"
+	"github.com/bookingcom/carbonapi/expr/interfaces"
+	"github.com/bookingcom/carbonapi/expr/types"
+	"github.com/bookingcom/carbonapi/pkg/parser"
+)
+
+type weightedAverage struct {
+	interfaces.FunctionBase
+}
+
+func GetOrder() interfaces.Order {
+	return interfaces.Any
+}
+
+func New(configFile string) []interfaces.FunctionMetadata {
+	res := make([]interfaces.FunctionMetadata, 0)
+	f := &weightedAverage{}
+	functions := []string{"weightedAverage"}
+	for _, n := range functions {
+		res = append(res, interfaces.FunctionMetadata{Name: n, F: f})
+	}
+	return res
+}
+
+// exclude(seriesList, pattern)
+func (f *weightedAverage) Do(ctx context.Context, e parser.Expr, from, until int32, values map[parser.MetricRequest][]*types.MetricData, getTargetData interfaces.GetTargetData) ([]*types.MetricData, error) {
+	avgArg, err := helper.GetSeriesArg(ctx, e.Args()[0], from, until, values, getTargetData)
+	if err != nil {
+		return nil, err
+	}
+	weightArg, err := helper.GetSeriesArg(ctx, e.Args()[1], from, until, values, getTargetData)
+	if err != nil {
+		return nil, err
+	}
+	nodes, err := e.GetIntArgs(2)
+	if err != nil {
+		return nil, err
+	}
+
+	avgGrouped, avgNodeKeys, err := helper.GroupByNodes(nodes, avgArg)
+	if err != nil {
+		return nil, err
+	}
+	weightGrouped, weightNodeKeys, err := helper.GroupByNodes(nodes, weightArg)
+	if err != nil {
+		return nil, err
+	}
+
+	var keys []string
+	for avgKey := range avgNodeKeys {
+		if _, found := weightNodeKeys[avgKey]; found {
+			keys = append(keys, avgKey)
+		}
+	}
+
+	var productMetrics []*types.MetricData
+	for _, key := range keys {
+		for i, _ := range avgGrouped[key] {
+			productMetricName := fmt.Sprintf("product(%s, %s)", weightGrouped[key][i].Name, avgGrouped[key][i].Name)
+			productMetric := helper.CombineSeries(avgGrouped[key][i], weightGrouped[key][i], productMetricName, productOperator)
+			productMetrics = append(productMetrics, productMetric)
+		}
+	}
+	if len(productMetrics) == 0 {
+		return []*types.MetricData{}, nil
+	}
+
+	sumOfProductMetricName := "sumOfProducts"
+	sumOfProductsMetrics, err := helper.AggregateSeries(sumOfProductMetricName, productMetrics, false, false, sum.SumAggregation)
+	if err != nil {
+		return nil, err
+	}
+	sumOfWeightsMetricName := "sumOfWeights"
+	sumOfWeightsMetrics, err := helper.AggregateSeries(sumOfWeightsMetricName, weightArg, false, false, sum.SumAggregation)
+	if err != nil {
+		return nil, err
+	}
+	weightedAverageMetricName := getWeightedAverageMetricName(avgArg, weightArg, nodes)
+	weightedAverageMetric := helper.CombineSeries(sumOfProductsMetrics[0], sumOfWeightsMetrics[0], weightedAverageMetricName, divOperator)
+
+	results := make([]*types.MetricData, 1)
+	results[0] = weightedAverageMetric
+
+	return results, nil
+}
+
+func productOperator(a, b float64) (float64, bool) {
+	return a * b, false
+}
+
+func divOperator(a, b float64) (float64, bool) {
+	if b == 0 {
+		return 0, true
+	}
+	return (a / b), false
+}
+
+func getWeightedAverageMetricName(avgSeriesList, weightSeriesList []*types.MetricData, nodes []int) string {
+	avgsName := getAggregatedMetricName(avgSeriesList)
+	weightsName := getAggregatedMetricName(weightSeriesList)
+	nodesStrList := make([]string, len(nodes))
+	for i, node := range nodes {
+		nodesStrList[i] = strconv.Itoa(node)
+	}
+	nodesName := strings.Join(nodesStrList, ",")
+	return fmt.Sprintf("weightedAverage(%s, %s, %s)", avgsName, weightsName, nodesName)
+}
+
+func getAggregatedMetricName(seriesList []*types.MetricData) string {
+	seriesSet := make(map[string]bool)
+	for _, series := range seriesList {
+		seriesSet[series.Name] = true
+	}
+	seriesUniqueList := make([]string, 0, len(seriesSet))
+	for seriesName := range seriesSet {
+		seriesUniqueList = append(seriesUniqueList, seriesName)
+	}
+	sort.Strings(seriesUniqueList)
+	return strings.Join(seriesUniqueList, ",")
+}
+
+// Description is auto-generated description, based on output of https://github.com/graphite-project/graphite-web
+func (f *weightedAverage) Description() map[string]types.FunctionDescription {
+	return map[string]types.FunctionDescription{
+		"weightedAverage": {
+			Description: "Takes a series of average values and a series of weights and produces a weighted average for all values. The corresponding values should share one or more zero-indexed nodes and/or tags.",
+			Function:    "weightedAverage(seriesListAvg, seriesListWeight, *nodes)",
+			Group:       "Combine",
+			Module:      "graphite.render.functions",
+			Name:        "weightedAverage",
+			Params: []types.FunctionParam{
+				{
+					Name:     "seriesListAvg",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Name:     "seriesListWeight",
+					Required: true,
+					Type:     types.SeriesList,
+				},
+				{
+					Name:     "nodes",
+					Multiple: true,
+					Type:     types.NodeOrTag,
+				},
+			},
+		},
+	}
+}

--- a/expr/functions/weightedAverage/function_test.go
+++ b/expr/functions/weightedAverage/function_test.go
@@ -1,0 +1,92 @@
+package weightedAverage
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/bookingcom/carbonapi/expr/helper"
+	"github.com/bookingcom/carbonapi/expr/metadata"
+	"github.com/bookingcom/carbonapi/expr/types"
+	"github.com/bookingcom/carbonapi/pkg/parser"
+	th "github.com/bookingcom/carbonapi/tests"
+)
+
+var None = math.NaN()
+
+func init() {
+	md := New("")
+	evaluator := th.EvaluatorFromFunc(md[0].F)
+	metadata.SetEvaluator(evaluator)
+	helper.SetEvaluator(evaluator)
+	for _, m := range md {
+		metadata.RegisterFunction(m.Name, m.F)
+	}
+}
+
+func TestWeightedAverage(t *testing.T) {
+	now32 := int32(time.Now().Unix())
+
+	tests := []th.EvalTestItem{
+		{
+			"weightedAverage(metric*, metric*, 0)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
+					types.MakeMetricData("metric2", []float64{None, 2, None, 4, None, 6, None, 8, None, 10, None, 12, None, 14, None, 16, None, 18, None, 20}, 1, now32),
+					types.MakeMetricData("metric3", []float64{1, 2, None, None, None, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, None, None, None}, 1, now32),
+					types.MakeMetricData("metric4", []float64{1, 2, 3, 4, None, 6, None, None, 9, 10, 11, None, 13, None, None, None, None, 18, 19, 20}, 1, now32),
+					types.MakeMetricData("metric5", []float64{1, 2, None, None, None, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, None, None}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData(
+				"weightedAverage(metric1,metric2,metric3,metric4,metric5, metric1,metric2,metric3,metric4,metric5, 0)",
+				[]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32,
+			),
+			},
+		},
+		{
+			"weightedAverage(metric*.dividend, metric*.divisor, 0)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*.dividend", 0, 1}: {
+					types.MakeMetricData("metric1.dividend", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
+					types.MakeMetricData("metric2.dividend", []float64{None, 2, None, 4, None, 6, None, 8, None, 10, None, 12, None, 14, None, 16, None, 18, None, 20}, 1, now32),
+					types.MakeMetricData("metric3.dividend", []float64{1, 2, None, None, None, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, None, None, None}, 1, now32),
+					types.MakeMetricData("metric5.dividend", []float64{1, 2, None, None, None, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, None, None}, 1, now32),
+				},
+				{"metric*.divisor", 0, 1}: {
+					types.MakeMetricData("metric1.divisor", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
+					types.MakeMetricData("metric3.divisor", []float64{1, 2, None, None, None, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, None, None, None}, 1, now32),
+					types.MakeMetricData("metric4.divisor", []float64{1, 2, 3, 4, None, 6, None, None, 9, 10, 11, None, 13, None, None, None, None, 18, 19, 20}, 1, now32),
+					types.MakeMetricData("metric5.divisor", []float64{1, 2, None, None, None, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, None, None}, 1, now32),
+				},
+			},
+			[]*types.MetricData{types.MakeMetricData(
+				"weightedAverage(metric1.dividend,metric2.dividend,metric3.dividend,metric5.dividend, metric1.divisor,metric3.divisor,metric4.divisor,metric5.divisor, 0)",
+				[]float64{0.75, 1.5, 1.5, 2.0, 5.0, 4.5, 7.0, 8.0, 6.75, 7.5, 8.25, 12.0, 9.75, 14.0, 15.0, 16.0, 17.0, 12.0, 9.5, 10.0}, 1, now32,
+			),
+			},
+		},
+		{
+			"weightedAverage(metric*.dividend, metric*.divisor, 0)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric*.dividend", 0, 1}: {
+					types.MakeMetricData("metric1.dividend", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
+				},
+				{"metric*.divisor", 0, 1}: {
+					types.MakeMetricData("metric2.divisor", []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1, now32),
+				},
+			},
+			[]*types.MetricData{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		testName := tt.Target
+		t.Run(testName, func(t *testing.T) {
+			th.TestEvalExpr(t, &tt)
+		})
+	}
+
+}


### PR DESCRIPTION
## What issue is this change attempting to solve?

Currently, carbonapi does not support weightedAverage function.

## How does this change solve the problem? Why is this the best approach?

This PR adds weightedAverage function to carbonapi.

## How can we be sure this works as expected?

Tests are included. Tests are copied and used from https://github.com/go-graphite/carbonapi/blob/main/expr/functions/weightedAverage/function_test.go.