### PR TITLE
Support all whitespaces in carbonapi parser

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -369,6 +369,8 @@ func parseExprWithoutPipe(e string) (Expr, string, error) {
 		return nil, e, ErrMissingArgument
 	}
 
+	e = strings.TrimLeftFunc(e, unicode.IsSpace)
+
 	if e != "" && e[0] == '(' {
 		var err error
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -334,7 +334,7 @@ func (e *expr) insertFirstArg(exp *expr) error {
 
 func parseExprWithoutPipe(e string) (Expr, string, error) {
 	// skip whitespace
-	for len(e) > 1 && e[0] == ' ' {
+	for len(e) > 1 && unicode.IsSpace(rune(e[0])) {
 		e = e[1:]
 	}
 
@@ -391,7 +391,7 @@ func ParseExpr(e string) (Expr, string, error) {
 }
 
 func pipe(exp *expr, e string) (*expr, string, error) {
-	for len(e) > 1 && e[0] == ' ' {
+	for len(e) > 1 && unicode.IsSpace(rune(e[0])) {
 		e = e[1:]
 	}
 
@@ -450,7 +450,7 @@ func parseArgList(e string) (string, []*expr, map[string]*expr, string, error) {
 	e = e[1:]
 
 	// check for empty args
-	t := strings.TrimLeft(e, " ")
+	t := strings.TrimLeftFunc(e, unicode.IsSpace)
 	if t != "" && t[0] == ')' {
 		return "", posArgs, namedArgs, t[1:], nil
 	}
@@ -517,9 +517,7 @@ func parseArgList(e string) (string, []*expr, map[string]*expr, string, error) {
 		}
 
 		// after the argument, trim any trailing spaces
-		for len(e) > 0 && e[0] == ' ' {
-			e = e[1:]
-		}
+		e = strings.TrimLeftFunc(e, unicode.IsSpace)
 
 		// We've consumed the entire buffer but the argument list isn't complete.
 		if len(e) == 0 {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -396,6 +396,18 @@ func TestParseExpr(t *testing.T) {
 			s:   `func(foo.[[abc]].qux)`,
 			err: ErrNestedBrackets,
 		},
+		{
+			s: "  \nfunc2(\rfoo.b[09].qux  ,   \ns\t)",
+			e: &expr{
+				target: "func2",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "foo.b[09].qux"},
+					{target: "s"},
+				},
+				argString: "\rfoo.b[09].qux  ,   \ns\t",
+			},
+		},
 	}
 
 	for _, ttr := range tests {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -397,7 +397,7 @@ func TestParseExpr(t *testing.T) {
 			err: ErrNestedBrackets,
 		},
 		{
-			s: "  \nfunc2(\rfoo.b[09].qux  ,   \ns\t)",
+			s: "  \nfunc2\t  (  \rfoo.b[09].qux  ,   \ns\t)    ",
 			e: &expr{
 				target: "func2",
 				etype:  EtFunc,
@@ -405,7 +405,27 @@ func TestParseExpr(t *testing.T) {
 					{target: "foo.b[09].qux"},
 					{target: "s"},
 				},
-				argString: "\rfoo.b[09].qux  ,   \ns\t",
+				argString: "  \rfoo.b[09].qux  ,   \ns\t",
+			},
+		},
+		{
+			s: "  \nfunc2\t  (  \rfunc \n (\ng\r)  ,   \ns\t)    ",
+			e: &expr{
+				target: "func2",
+				etype:  EtFunc,
+				args: []*expr{
+					{
+						target: "func",
+						etype:  EtFunc,
+						args: []*expr{
+							{target: "g"},
+						},
+						argString: "\ng\r",
+					},
+					{target: "s"},
+				},
+				// The reason that func is without any whitespaces is that we behave argString of funcs exceptionally.
+				argString: "func(\ng\r),   \ns\t",
 			},
 		},
 	}


### PR DESCRIPTION
This commit supports ignoring all whitespaces instead of only
ignoring spaces. The feature is beneficial because interfaces like
grafana allow multi-line queries.

The current proposed change uses `unicode.isSpace` instead of checking with space character. We could also re-implement it to be faster, but I do not believe it is a big deal.