### PR TITLE
Add render majority read feature

### DIFF
--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -279,6 +279,7 @@ func metricsServer(app *App) *http.Server {
 	prometheus.MustRegister(app.prometheusMetrics.Responses)
 	prometheus.MustRegister(app.prometheusMetrics.Renders)
 	prometheus.MustRegister(app.prometheusMetrics.RenderMismatches)
+	prometheus.MustRegister(app.prometheusMetrics.RenderFixedMismatches)
 	prometheus.MustRegister(app.prometheusMetrics.FindNotFound)
 	prometheus.MustRegister(app.prometheusMetrics.RequestCancel)
 	prometheus.MustRegister(app.prometheusMetrics.DurationExp)

--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -309,10 +309,11 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request) {
 	request.Trace.OutDuration = app.prometheusMetrics.RenderOutDurationExp
 	bs := app.filterBackendByTopLevelDomain(request.Targets)
 	bs = backend.Filter(bs, request.Targets)
-	metrics, points, mismatches, errs := backend.Renders(ctx, bs, request,
+	metrics, points, mismatches, fixedMismatches, errs := backend.Renders(ctx, bs, request,
 		app.config.RenderReplicaMatchMode, app.config.RenderMismatchMetricReportLimit)
 	app.prometheusMetrics.Renders.Add(float64(points))
 	app.prometheusMetrics.RenderMismatches.Add(float64(mismatches))
+	app.prometheusMetrics.RenderFixedMismatches.Add(float64(fixedMismatches))
 	err = errorsFanIn(errs, len(bs))
 	span.SetAttribute("graphite.metrics", len(metrics))
 	// time in queue is converted to ms

--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -310,7 +310,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request) {
 	bs := app.filterBackendByTopLevelDomain(request.Targets)
 	bs = backend.Filter(bs, request.Targets)
 	metrics, points, mismatches, errs := backend.Renders(ctx, bs, request,
-		app.config.RenderMismatchCheck, app.config.RenderMismatchMetricReportLimit)
+		app.config.RenderReplicaMatchMode, app.config.RenderMismatchMetricReportLimit)
 	app.prometheusMetrics.Renders.Add(float64(points))
 	app.prometheusMetrics.RenderMismatches.Add(float64(mismatches))
 	err = errorsFanIn(errs, len(bs))

--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -309,11 +309,11 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request) {
 	request.Trace.OutDuration = app.prometheusMetrics.RenderOutDurationExp
 	bs := app.filterBackendByTopLevelDomain(request.Targets)
 	bs = backend.Filter(bs, request.Targets)
-	metrics, points, mismatches, fixedMismatches, errs := backend.Renders(ctx, bs, request,
-		app.config.RenderReplicaMatchMode, app.config.RenderMismatchMetricReportLimit)
-	app.prometheusMetrics.Renders.Add(float64(points))
-	app.prometheusMetrics.RenderMismatches.Add(float64(mismatches))
-	app.prometheusMetrics.RenderFixedMismatches.Add(float64(fixedMismatches))
+	metrics, stats, errs := backend.Renders(ctx, bs, request, app.config.RenderReplicaMatchMode,
+		app.config.RenderMismatchMetricReportLimit)
+	app.prometheusMetrics.Renders.Add(float64(stats.DataPointCount))
+	app.prometheusMetrics.RenderMismatches.Add(float64(stats.MismatchCount))
+	app.prometheusMetrics.RenderFixedMismatches.Add(float64(stats.FixedMismatchCount))
 	err = errorsFanIn(errs, len(bs))
 	span.SetAttribute("graphite.metrics", len(metrics))
 	// time in queue is converted to ms

--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -310,7 +310,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request) {
 	bs := app.filterBackendByTopLevelDomain(request.Targets)
 	bs = backend.Filter(bs, request.Targets)
 	metrics, stats, errs := backend.Renders(ctx, bs, request, app.config.RenderReplicaMatchMode,
-		app.config.RenderMismatchMetricReportLimit)
+		app.config.RenderReplicaMismatchReportLimit)
 	app.prometheusMetrics.Renders.Add(float64(stats.DataPointCount))
 	app.prometheusMetrics.RenderMismatches.Add(float64(stats.MismatchCount))
 	app.prometheusMetrics.RenderFixedMismatches.Add(float64(stats.FixedMismatchCount))

--- a/app/carbonzipper/metrics.go
+++ b/app/carbonzipper/metrics.go
@@ -55,20 +55,21 @@ var Metrics = struct {
 
 // PrometheusMetrics keeps all the metrics exposed on /metrics endpoint
 type PrometheusMetrics struct {
-	Requests             prometheus.Counter
-	Responses            *prometheus.CounterVec
-	RenderMismatches     prometheus.Counter
-	Renders              prometheus.Counter
-	FindNotFound         prometheus.Counter
-	RequestCancel        *prometheus.CounterVec
-	DurationExp          prometheus.Histogram
-	DurationLin          prometheus.Histogram
-	RenderDurationExp    prometheus.Histogram
-	RenderOutDurationExp *prometheus.HistogramVec
-	FindDurationExp      prometheus.Histogram
-	FindDurationLin      prometheus.Histogram
-	TimeInQueueExp       prometheus.Histogram
-	TimeInQueueLin       prometheus.Histogram
+	Requests              prometheus.Counter
+	Responses             *prometheus.CounterVec
+	RenderMismatches      prometheus.Counter
+	RenderFixedMismatches prometheus.Counter
+	Renders               prometheus.Counter
+	FindNotFound          prometheus.Counter
+	RequestCancel         *prometheus.CounterVec
+	DurationExp           prometheus.Histogram
+	DurationLin           prometheus.Histogram
+	RenderDurationExp     prometheus.Histogram
+	RenderOutDurationExp  *prometheus.HistogramVec
+	FindDurationExp       prometheus.Histogram
+	FindDurationLin       prometheus.Histogram
+	TimeInQueueExp        prometheus.Histogram
+	TimeInQueueLin        prometheus.Histogram
 }
 
 // NewPrometheusMetrics creates a set of default Prom metrics
@@ -86,6 +87,12 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 				Help: "Count of HTTP responses, partitioned by return code and handler",
 			},
 			[]string{"code", "handler"},
+		),
+		RenderFixedMismatches: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "render_fixed_mismatches_total",
+				Help: "Count of fixed mismatched rendered data points",
+			},
 		),
 		RenderMismatches: prometheus.NewCounter(
 			prometheus.CounterOpts{

--- a/cfg/common.go
+++ b/cfg/common.go
@@ -126,8 +126,8 @@ func DefaultCommonConfig() Common {
 		},
 		PrintErrorStackTrace: false,
 
-		RenderReplicaMatchMode:          ReplicaMatchModeNormal,
-		RenderMismatchMetricReportLimit: 10,
+		RenderReplicaMatchMode:           ReplicaMatchModeNormal,
+		RenderReplicaMismatchReportLimit: 10,
 	}
 }
 
@@ -172,12 +172,18 @@ type Common struct {
 	PrintErrorStackTrace bool   `yaml:"printErrorStackTrace"`
 
 	// RenderReplicaMatchMode indicates how carbonzipper merges the metrics from replica backends.
-	// Possible values are `normal`(default), `check`, and `majority`
-	// `normal` ignores the mismatches and only heals null points.
-	// `check` looks for mismatches, and exposes metrics.
-	// `majority` chooses the values of majority of backends in addition to exposing metrics.
-	RenderReplicaMatchMode          ReplicaMatchMode `yaml:"renderReplicaMatchMode"`
-	RenderMismatchMetricReportLimit int              `yaml:"renderMismatchMetricReportLimit"`
+	// Possible values are:
+	//
+	// * `normal` - ignore the mismatches and only heal null points (default)
+	//
+	// * `check` - look for mismatches, and expose metrics
+	//
+	// * `majority` - choose the values of majority of backends in addition to exposing metrics
+	RenderReplicaMatchMode ReplicaMatchMode `yaml:"renderReplicaMatchMode"`
+
+	// RenderReplicaMismatchReportLimit limits the number of mismatched metrics to be logged
+	// for a single render request.
+	RenderReplicaMismatchReportLimit int `yaml:"renderReplicaMismatchReportLimit"`
 }
 
 // GetBackends returns the list of backends from common configuration

--- a/cfg/common.go
+++ b/cfg/common.go
@@ -126,7 +126,7 @@ func DefaultCommonConfig() Common {
 		},
 		PrintErrorStackTrace: false,
 
-		RenderMismatchCheck:             false,
+		RenderReplicaMatchMode:          ReplicaMatchModeNormal,
 		RenderMismatchMetricReportLimit: 10,
 	}
 }
@@ -171,8 +171,13 @@ type Common struct {
 	Traces               Traces `yaml:"traces"`
 	PrintErrorStackTrace bool   `yaml:"printErrorStackTrace"`
 
-	RenderMismatchCheck             bool `yaml:"renderMismatchCheck"`
-	RenderMismatchMetricReportLimit int  `yaml:"renderMismatchMetricReportLimit"`
+	// RenderReplicaMatchMode indicates how carbonzipper merges the metrics from replica backends.
+	// Possible values are `normal`(default), `check`, and `majority`
+	// `normal` ignores the mismatches and only heals null points.
+	// `check` looks for mismatches, and exposes metrics.
+	// `majority` chooses the values of majority of backends in addition to exposing metrics.
+	RenderReplicaMatchMode          ReplicaMatchMode `yaml:"renderReplicaMatchMode"`
+	RenderMismatchMetricReportLimit int              `yaml:"renderMismatchMetricReportLimit"`
 }
 
 // GetBackends returns the list of backends from common configuration
@@ -281,4 +286,28 @@ type Traces struct {
 	Tags                 Tags          `yaml:"tags"`
 	JaegerBufferMaxCount int           `yaml:"jaegerBufferMaxCount"`
 	JaegerBatchMaxCount  int           `yaml:"jaegerBatchMaxCount"`
+}
+
+type ReplicaMatchMode string
+
+const (
+	ReplicaMatchModeNormal   ReplicaMatchMode = "normal"
+	ReplicaMatchModeCheck    ReplicaMatchMode = "check"
+	ReplicaMatchModeMajority ReplicaMatchMode = "majority"
+)
+
+func (cm *ReplicaMatchMode) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	switch s {
+	case string(ReplicaMatchModeCheck):
+		*cm = ReplicaMatchModeCheck
+	case string(ReplicaMatchModeMajority):
+		*cm = ReplicaMatchModeMajority
+	default:
+		*cm = ReplicaMatchModeNormal
+	}
+	return nil
 }

--- a/docker/zipper/Dockerfile
+++ b/docker/zipper/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get install -y libcairo2-dev
 
 WORKDIR /go/src/github.com/bookingcom/carbonapi
 COPY . .
+COPY ./config/carbonzipper.yaml /etc/carbonzipper.yaml
 
 RUN make build
 

--- a/pkg/backend/benchmark_test.go
+++ b/pkg/backend/benchmark_test.go
@@ -136,7 +136,7 @@ func BenchmarkRendersStorm(b *testing.B) {
 					wg.Add(1)
 					go func() {
 						defer wg.Done()
-						_, _, _, _, err := Renders(ctx, backends, types.NewRenderRequest(nil, 0, 0), cc, 10)
+						_, _, err := Renders(ctx, backends, types.NewRenderRequest(nil, 0, 0), cc, 10)
 						errs <- err
 					}()
 				}

--- a/pkg/backend/benchmark_test.go
+++ b/pkg/backend/benchmark_test.go
@@ -136,7 +136,7 @@ func BenchmarkRendersStorm(b *testing.B) {
 					wg.Add(1)
 					go func() {
 						defer wg.Done()
-						_, _, _, err := Renders(ctx, backends, types.NewRenderRequest(nil, 0, 0), cc, 10)
+						_, _, _, _, err := Renders(ctx, backends, types.NewRenderRequest(nil, 0, 0), cc, 10)
 						errs <- err
 					}()
 				}

--- a/pkg/backend/benchmark_test.go
+++ b/pkg/backend/benchmark_test.go
@@ -3,10 +3,10 @@ package backend
 import (
 	"context"
 	"fmt"
+	"github.com/bookingcom/carbonapi/cfg"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -64,10 +64,10 @@ func BenchmarkRenders(b *testing.B) {
 	}
 
 	ctx := context.Background()
-	mismatchChecks := []bool{false, true}
-	for _, mismatchCheck := range mismatchChecks {
-		cc := mismatchCheck
-		b.Run(fmt.Sprintf("BenchmarkRenders/RenderMismatchCheck%s", strconv.FormatBool(cc)), func(b *testing.B) {
+	renderReplicaMatchModes := []cfg.ReplicaMatchMode{cfg.ReplicaMatchModeNormal, cfg.ReplicaMatchModeCheck, cfg.ReplicaMatchModeMajority}
+	for _, replicaMatchMode := range renderReplicaMatchModes {
+		cc := replicaMatchMode
+		b.Run(fmt.Sprintf("BenchmarkRenders/ReplicaMatchMode%s", string(cc)), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				Renders(ctx, backends, types.NewRenderRequest(nil, 0, 0), cc, 10)
 			}
@@ -127,10 +127,10 @@ func BenchmarkRendersStorm(b *testing.B) {
 	n := 50
 	errs := make(chan []error, n)
 
-	mismatchChecks := []bool{false, true}
-	for _, mismatchCheck := range mismatchChecks {
-		cc := mismatchCheck
-		b.Run(fmt.Sprintf("BenchmarkRendersStorm/RenderMismatchCheck%s", strconv.FormatBool(cc)), func(b *testing.B) {
+	renderReplicaMatchModes := []cfg.ReplicaMatchMode{cfg.ReplicaMatchModeNormal, cfg.ReplicaMatchModeCheck, cfg.ReplicaMatchModeMajority}
+	for _, replicaMatchMode := range renderReplicaMatchModes {
+		cc := replicaMatchMode
+		b.Run(fmt.Sprintf("BenchmarkRendersStorm/ReplicaMatchMode%s", string(cc)), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				for j := 0; j < n; j++ {
 					wg.Add(1)

--- a/pkg/backend/rpc.go
+++ b/pkg/backend/rpc.go
@@ -45,9 +45,9 @@ type Backend interface {
 // replicaMatchMode indicates how data points of the metrics fetched from replicas
 // will be checked and applied on the final metrics. mismatchMetricReportLimit limits
 // the number of metrics reported in log for each render request.
-func Renders(ctx context.Context, backends []Backend, request types.RenderRequest, replicaMatchMode cfg.ReplicaMatchMode, mismatchMetricReportLimit int) ([]types.Metric, int, int, int, []error) {
+func Renders(ctx context.Context, backends []Backend, request types.RenderRequest, replicaMatchMode cfg.ReplicaMatchMode, mismatchMetricReportLimit int) ([]types.Metric, types.MetricRenderStats, []error) {
 	if len(backends) == 0 {
-		return nil, 0, 0, 0, nil
+		return nil, types.MetricRenderStats{}, nil
 	}
 
 	msgCh := make(chan []types.Metric, len(backends))
@@ -75,8 +75,8 @@ func Renders(ctx context.Context, backends []Backend, request types.RenderReques
 		}
 	}
 
-	metrics, points, mismatches, fixedMismatches := types.MergeMetrics(msgs, replicaMatchMode, mismatchMetricReportLimit)
-	return metrics, points, mismatches, fixedMismatches, errs
+	metrics, stats := types.MergeMetrics(msgs, replicaMatchMode, mismatchMetricReportLimit)
+	return metrics, stats, errs
 }
 
 // Infos makes Info calls to multiple backends.

--- a/pkg/backend/rpc.go
+++ b/pkg/backend/rpc.go
@@ -17,6 +17,7 @@ package backend
 
 import (
 	"context"
+	"github.com/bookingcom/carbonapi/cfg"
 
 	"github.com/bookingcom/carbonapi/pkg/types"
 
@@ -41,10 +42,10 @@ type Backend interface {
 // worrying about those levels of performance in the first place.
 
 // Renders makes Render calls to multiple backends.
-// mismatchCheck indicates whether data points of the metrics fetched from replicas
-// will be checked for reporting consistency or not. mismatchMetricReportLimit limits
+// replicaMatchMode indicates how data points of the metrics fetched from replicas
+// will be checked and applied on the final metrics. mismatchMetricReportLimit limits
 // the number of metrics reported in log for each render request.
-func Renders(ctx context.Context, backends []Backend, request types.RenderRequest, mismatchCheck bool, mismatchMetricReportLimit int) ([]types.Metric, int, int, []error) {
+func Renders(ctx context.Context, backends []Backend, request types.RenderRequest, replicaMatchMode cfg.ReplicaMatchMode, mismatchMetricReportLimit int) ([]types.Metric, int, int, []error) {
 	if len(backends) == 0 {
 		return nil, 0, 0, nil
 	}
@@ -74,7 +75,7 @@ func Renders(ctx context.Context, backends []Backend, request types.RenderReques
 		}
 	}
 
-	metrics, points, mismatches := types.MergeMetrics(msgs, mismatchCheck, mismatchMetricReportLimit)
+	metrics, points, mismatches := types.MergeMetrics(msgs, replicaMatchMode, mismatchMetricReportLimit)
 	return metrics, points, mismatches, errs
 }
 

--- a/pkg/backend/rpc.go
+++ b/pkg/backend/rpc.go
@@ -43,9 +43,9 @@ type Backend interface {
 
 // Renders makes Render calls to multiple backends.
 // replicaMatchMode indicates how data points of the metrics fetched from replicas
-// will be checked and applied on the final metrics. mismatchMetricReportLimit limits
-// the number of metrics reported in log for each render request.
-func Renders(ctx context.Context, backends []Backend, request types.RenderRequest, replicaMatchMode cfg.ReplicaMatchMode, mismatchMetricReportLimit int) ([]types.Metric, types.MetricRenderStats, []error) {
+// will be checked and applied on the final metrics. replicaMismatchReportLimit limits
+// the number of mismatched metrics reported in log for each render request.
+func Renders(ctx context.Context, backends []Backend, request types.RenderRequest, replicaMatchMode cfg.ReplicaMatchMode, replicaMismatchReportLimit int) ([]types.Metric, types.MetricRenderStats, []error) {
 	if len(backends) == 0 {
 		return nil, types.MetricRenderStats{}, nil
 	}
@@ -75,7 +75,7 @@ func Renders(ctx context.Context, backends []Backend, request types.RenderReques
 		}
 	}
 
-	metrics, stats := types.MergeMetrics(msgs, replicaMatchMode, mismatchMetricReportLimit)
+	metrics, stats := types.MergeMetrics(msgs, replicaMatchMode, replicaMismatchReportLimit)
 	return metrics, stats, errs
 }
 

--- a/pkg/backend/rpc.go
+++ b/pkg/backend/rpc.go
@@ -45,9 +45,9 @@ type Backend interface {
 // replicaMatchMode indicates how data points of the metrics fetched from replicas
 // will be checked and applied on the final metrics. mismatchMetricReportLimit limits
 // the number of metrics reported in log for each render request.
-func Renders(ctx context.Context, backends []Backend, request types.RenderRequest, replicaMatchMode cfg.ReplicaMatchMode, mismatchMetricReportLimit int) ([]types.Metric, int, int, []error) {
+func Renders(ctx context.Context, backends []Backend, request types.RenderRequest, replicaMatchMode cfg.ReplicaMatchMode, mismatchMetricReportLimit int) ([]types.Metric, int, int, int, []error) {
 	if len(backends) == 0 {
-		return nil, 0, 0, nil
+		return nil, 0, 0, 0, nil
 	}
 
 	msgCh := make(chan []types.Metric, len(backends))
@@ -75,8 +75,8 @@ func Renders(ctx context.Context, backends []Backend, request types.RenderReques
 		}
 	}
 
-	metrics, points, mismatches := types.MergeMetrics(msgs, replicaMatchMode, mismatchMetricReportLimit)
-	return metrics, points, mismatches, errs
+	metrics, points, mismatches, fixedMismatches := types.MergeMetrics(msgs, replicaMatchMode, mismatchMetricReportLimit)
+	return metrics, points, mismatches, fixedMismatches, errs
 }
 
 // Infos makes Info calls to multiple backends.

--- a/pkg/backend/rpc_test.go
+++ b/pkg/backend/rpc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/bookingcom/carbonapi/cfg"
 	"testing"
 
 	"github.com/bookingcom/carbonapi/pkg/backend/mock"
@@ -64,7 +65,7 @@ func TestCarbonapiv2FindsEmpty(t *testing.T) {
 }
 
 func TestCarbonapiv2RendersEmpty(t *testing.T) {
-	got, _, _, err := Renders(context.Background(), []Backend{}, types.NewRenderRequest(nil, 0, 1), false, 10)
+	got, _, _, err := Renders(context.Background(), []Backend{}, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeNormal, 10)
 	if err != nil {
 		t.Error(err)
 		return
@@ -95,7 +96,7 @@ func TestCarbonapiv2Renders(t *testing.T) {
 		backends = append(backends, b)
 	}
 
-	got, ps, ins, errs := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), true, 10)
+	got, ps, ins, errs := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeMajority, 10)
 	if len(errs) != 0 {
 		t.Error(errs[0])
 		return
@@ -124,7 +125,7 @@ func TestCarbonapiv2RendersError(t *testing.T) {
 
 	backends := []Backend{mock.New(mock.Config{Render: render})}
 
-	_, _, _, err := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), false, 10)
+	_, _, _, err := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeNormal, 10)
 	if err == nil {
 		t.Error("Expected error")
 	}

--- a/pkg/backend/rpc_test.go
+++ b/pkg/backend/rpc_test.go
@@ -65,7 +65,7 @@ func TestCarbonapiv2FindsEmpty(t *testing.T) {
 }
 
 func TestCarbonapiv2RendersEmpty(t *testing.T) {
-	got, _, _, err := Renders(context.Background(), []Backend{}, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeNormal, 10)
+	got, _, _, _, err := Renders(context.Background(), []Backend{}, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeNormal, 10)
 	if err != nil {
 		t.Error(err)
 		return
@@ -96,7 +96,7 @@ func TestCarbonapiv2Renders(t *testing.T) {
 		backends = append(backends, b)
 	}
 
-	got, ps, ins, errs := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeMajority, 10)
+	got, ps, ins, fixed, errs := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeMajority, 10)
 	if len(errs) != 0 {
 		t.Error(errs[0])
 		return
@@ -108,12 +108,17 @@ func TestCarbonapiv2Renders(t *testing.T) {
 	}
 
 	if ps != 6 {
-		t.Errorf("Expected %d ok responses, got %d", 6, ps)
+		t.Errorf("Expected %d points, got %d", 6, ps)
 		return
 	}
 
 	if ins != 0 {
-		t.Errorf("Expected %d ok responses, got %d", 0, ins)
+		t.Errorf("Expected %d mismatches, got %d", 0, ins)
+		return
+	}
+
+	if fixed != 0 {
+		t.Errorf("Expected %d fixed mismatches, got %d", 0, fixed)
 		return
 	}
 }
@@ -125,7 +130,7 @@ func TestCarbonapiv2RendersError(t *testing.T) {
 
 	backends := []Backend{mock.New(mock.Config{Render: render})}
 
-	_, _, _, err := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeNormal, 10)
+	_, _, _, _, err := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeNormal, 10)
 	if err == nil {
 		t.Error("Expected error")
 	}

--- a/pkg/backend/rpc_test.go
+++ b/pkg/backend/rpc_test.go
@@ -65,7 +65,7 @@ func TestCarbonapiv2FindsEmpty(t *testing.T) {
 }
 
 func TestCarbonapiv2RendersEmpty(t *testing.T) {
-	got, _, _, _, err := Renders(context.Background(), []Backend{}, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeNormal, 10)
+	got, _, err := Renders(context.Background(), []Backend{}, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeNormal, 10)
 	if err != nil {
 		t.Error(err)
 		return
@@ -96,7 +96,7 @@ func TestCarbonapiv2Renders(t *testing.T) {
 		backends = append(backends, b)
 	}
 
-	got, ps, ins, fixed, errs := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeMajority, 10)
+	got, stats, errs := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeMajority, 10)
 	if len(errs) != 0 {
 		t.Error(errs[0])
 		return
@@ -107,18 +107,18 @@ func TestCarbonapiv2Renders(t *testing.T) {
 		return
 	}
 
-	if ps != 6 {
-		t.Errorf("Expected %d points, got %d", 6, ps)
+	if stats.DataPointCount != 6 {
+		t.Errorf("Expected %d points, got %d", 6, stats.DataPointCount)
 		return
 	}
 
-	if ins != 0 {
-		t.Errorf("Expected %d mismatches, got %d", 0, ins)
+	if stats.MismatchCount != 0 {
+		t.Errorf("Expected %d mismatches, got %d", 0, stats.MismatchCount)
 		return
 	}
 
-	if fixed != 0 {
-		t.Errorf("Expected %d fixed mismatches, got %d", 0, fixed)
+	if stats.FixedMismatchCount != 0 {
+		t.Errorf("Expected %d fixed mismatches, got %d", 0, stats.FixedMismatchCount)
 		return
 	}
 }
@@ -130,7 +130,7 @@ func TestCarbonapiv2RendersError(t *testing.T) {
 
 	backends := []Backend{mock.New(mock.Config{Render: render})}
 
-	_, _, _, _, err := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeNormal, 10)
+	_, _, err := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeNormal, 10)
 	if err == nil {
 		t.Error("Expected error")
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -209,7 +209,7 @@ type MetricRenderStats struct {
 // MergeMetrics merges metrics by name.
 // It returns merged metrics, number of rendered data points for the returned metrics,
 // and number of mismatched data points seen (if mismatchCheck is true).
-func MergeMetrics(metrics [][]Metric, replicaMatchMode cfg.ReplicaMatchMode, mismatchMetricReportLimit int) ([]Metric, MetricRenderStats) {
+func MergeMetrics(metrics [][]Metric, replicaMatchMode cfg.ReplicaMatchMode, replicaMismatchReportLimit int) ([]Metric, MetricRenderStats) {
 	if len(metrics) == 0 {
 		return nil, MetricRenderStats{}
 	}
@@ -245,7 +245,7 @@ func MergeMetrics(metrics [][]Metric, replicaMatchMode cfg.ReplicaMatchMode, mis
 	var mismatchedMetricReports []metricReport
 	for _, ms := range metricByNames {
 		m, stats := mergeMetrics(ms, replicaMatchMode)
-		if stats.MismatchCount > 0 && len(mismatchedMetricReports) < mismatchMetricReportLimit {
+		if stats.MismatchCount > 0 && len(mismatchedMetricReports) < replicaMismatchReportLimit {
 			mismatchedMetricReports = append(mismatchedMetricReports, metricReport{
 				MetricName:       m.Name,
 				Start:            m.StartTime,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -9,7 +9,7 @@ package types
 // TODO (grzkv): Name of this module makes 0 sense
 
 import (
-	"fmt"
+	"errors"
 	"github.com/bookingcom/carbonapi/cfg"
 	"math"
 	"sort"
@@ -308,7 +308,7 @@ func areFloatsEqual(a, b float64) bool {
 func getPointMajorityValue(values []float64) (majorityValue float64, majorityCount int, err error) {
 	valuesCount := len(values)
 	if valuesCount == 0 {
-		return math.NaN(), 0, fmt.Errorf("no value for majority voting")
+		return 0, 0, errors.New("no value for majority voting")
 	}
 
 	sort.Slice(values, func(i, j int) bool {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -385,7 +385,7 @@ func mergeMetrics(metrics []Metric, replicaMatchMode cfg.ReplicaMatchMode) (metr
 				pointExists = true
 			}
 
-			if metric.Values[i] != m.Values[i] {
+			if !areFloatsEqual(metric.Values[i], m.Values[i]) {
 				mismatchObserved = true
 				if replicaMatchMode == cfg.ReplicaMatchModeCheck {
 					// mismatch exists, enough for check mode

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -99,7 +99,7 @@ func TestMergeManyMetricsWithNormal(t *testing.T) {
 		IsAbsent: []bool{false},
 	}
 
-	got, _, _ := MergeMetrics(input, cfg.ReplicaMatchModeNormal, 0)
+	got, _, _, _ := MergeMetrics(input, cfg.ReplicaMatchModeNormal, 0)
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -133,7 +133,7 @@ func TestMergeManyMismatchedMetricsWithCheck(t *testing.T) {
 		IsAbsent: []bool{false, false},
 	}
 
-	got, ps, ins := MergeMetrics(input, cfg.ReplicaMatchModeCheck, 10)
+	got, ps, ins, fixed := MergeMetrics(input, cfg.ReplicaMatchModeCheck, 10)
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -148,6 +148,10 @@ func TestMergeManyMismatchedMetricsWithCheck(t *testing.T) {
 
 	if ins != 1 {
 		t.Errorf("Expected 1 mismatched points , got %d", ins)
+	}
+
+	if fixed != 0 {
+		t.Errorf("Expected 0 fixed mismatch point , got %d", fixed)
 	}
 }
 
@@ -175,7 +179,7 @@ func TestMergeManyMismatchedMetricsWithMajority(t *testing.T) {
 		IsAbsent: []bool{false, false},
 	}
 
-	got, ps, ins := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
+	got, ps, ins, fixed := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -190,6 +194,10 @@ func TestMergeManyMismatchedMetricsWithMajority(t *testing.T) {
 
 	if ins != 1 {
 		t.Errorf("Expected 1 mismatched point , got %d", ins)
+	}
+
+	if fixed != 0 {
+		t.Errorf("Expected 0 fixed mismatch point , got %d", fixed)
 	}
 }
 
@@ -224,7 +232,7 @@ func TestMergeManyMinorityMismatchedMetricsWithCheck(t *testing.T) {
 		IsAbsent: []bool{false, false},
 	}
 
-	got, ps, ins := MergeMetrics(input, cfg.ReplicaMatchModeCheck, 10)
+	got, ps, ins, fixed := MergeMetrics(input, cfg.ReplicaMatchModeCheck, 10)
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -238,6 +246,10 @@ func TestMergeManyMinorityMismatchedMetricsWithCheck(t *testing.T) {
 	}
 	if ins != 1 {
 		t.Errorf("Expected 1 mismatched point, got %d", ins)
+	}
+
+	if fixed != 0 {
+		t.Errorf("Expected 0 fixed mismatch point , got %d", fixed)
 	}
 }
 
@@ -272,7 +284,7 @@ func TestMergeManyMinorityMismatchedMetricsWithMajority(t *testing.T) {
 		IsAbsent: []bool{false, false},
 	}
 
-	got, ps, ins := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
+	got, ps, ins, fixed := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -284,8 +296,13 @@ func TestMergeManyMinorityMismatchedMetricsWithMajority(t *testing.T) {
 	if ps != 2 {
 		t.Errorf("Expected 2 metric points, got %d", ps)
 	}
+
 	if ins != 1 {
 		t.Errorf("Expected 1 mismatched points, got %d", ins)
+	}
+
+	if fixed != 1 {
+		t.Errorf("Expected 1 fixed mismatch point , got %d", fixed)
 	}
 }
 
@@ -320,7 +337,7 @@ func TestMergeManyRiskyAndMismatchedMetricsWithCheck(t *testing.T) {
 		IsAbsent: []bool{false, false, false},
 	}
 
-	got, ps, ins := MergeMetrics(input, cfg.ReplicaMatchModeCheck, 10)
+	got, ps, ins, fixed := MergeMetrics(input, cfg.ReplicaMatchModeCheck, 10)
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -332,8 +349,13 @@ func TestMergeManyRiskyAndMismatchedMetricsWithCheck(t *testing.T) {
 	if ps != 3 {
 		t.Errorf("Expected 2 metric points, got %d", ps)
 	}
+
 	if ins != 2 {
 		t.Errorf("Expected 2 mismatched points, got %d", ins)
+	}
+
+	if fixed != 0 {
+		t.Errorf("Expected 0 fixed mismatch point , got %d", fixed)
 	}
 }
 
@@ -368,7 +390,7 @@ func TestMergeManyRiskyAndMismatchedMetricsWithMajority(t *testing.T) {
 		IsAbsent: []bool{false, false, false},
 	}
 
-	got, ps, ins := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
+	got, ps, ins, fixed := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -383,6 +405,10 @@ func TestMergeManyRiskyAndMismatchedMetricsWithMajority(t *testing.T) {
 
 	if ins != 2 {
 		t.Errorf("Expected 2 mismatched points, got %d", ins)
+	}
+
+	if fixed != 1 {
+		t.Errorf("Expected 1 fixed mismatch point , got %d", fixed)
 	}
 }
 
@@ -404,7 +430,7 @@ func TestMergeManyMetricsDifferent(t *testing.T) {
 		},
 	}
 
-	got, _, _ := MergeMetrics(input, cfg.ReplicaMatchModeNormal, 0)
+	got, _, _, _ := MergeMetrics(input, cfg.ReplicaMatchModeNormal, 0)
 	if len(got) != 2 {
 		t.Errorf("Expected 2 metrics, got %d", len(got))
 	}
@@ -693,7 +719,7 @@ func TestMergeMetricsDifferingStepTimes6(t *testing.T) {
 }
 
 func doTest(t *testing.T, input []Metric, expected Metric) {
-	got, _ := mergeMetrics(input, cfg.ReplicaMatchModeNormal)
+	got, _, _ := mergeMetrics(input, cfg.ReplicaMatchModeNormal)
 
 	if !MetricsEqual(got, expected) {
 		t.Errorf("Merge failed\nExp: %+v\nGot: %+v\n", expected, got)

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -100,7 +100,7 @@ func TestMergeManyMetricsWithNormal(t *testing.T) {
 		IsAbsent: []bool{false},
 	}
 
-	got, _, _, _ := MergeMetrics(input, cfg.ReplicaMatchModeNormal, 0)
+	got, _ := MergeMetrics(input, cfg.ReplicaMatchModeNormal, 0)
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -134,7 +134,7 @@ func TestMergeManyMismatchedMetricsWithCheck(t *testing.T) {
 		IsAbsent: []bool{false, false},
 	}
 
-	got, ps, ins, fixed := MergeMetrics(input, cfg.ReplicaMatchModeCheck, 10)
+	got, stats := MergeMetrics(input, cfg.ReplicaMatchModeCheck, 10)
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -143,16 +143,16 @@ func TestMergeManyMismatchedMetricsWithCheck(t *testing.T) {
 		t.Errorf("Merge failed\nExp: %+v\nGot: %+v\n", expected, got[0])
 	}
 
-	if ps != 2 {
-		t.Errorf("Expected 2 points , got %d", ps)
+	if stats.DataPointCount != 2 {
+		t.Errorf("Expected 2 points , got %d", stats.DataPointCount)
 	}
 
-	if ins != 1 {
-		t.Errorf("Expected 1 mismatched points , got %d", ins)
+	if stats.MismatchCount != 1 {
+		t.Errorf("Expected 1 mismatched points , got %d", stats.MismatchCount)
 	}
 
-	if fixed != 0 {
-		t.Errorf("Expected 0 fixed mismatch point , got %d", fixed)
+	if stats.FixedMismatchCount != 0 {
+		t.Errorf("Expected 0 fixed mismatch point , got %d", stats.FixedMismatchCount)
 	}
 }
 
@@ -180,7 +180,7 @@ func TestMergeManyMismatchedMetricsWithMajority(t *testing.T) {
 		IsAbsent: []bool{false, false},
 	}
 
-	got, ps, ins, fixed := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
+	got, stats := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -189,16 +189,16 @@ func TestMergeManyMismatchedMetricsWithMajority(t *testing.T) {
 		t.Errorf("Merge failed\nExp: %+v\nGot: %+v\n", expected, got[0])
 	}
 
-	if ps != 2 {
-		t.Errorf("Expected 2 points , got %d", ps)
+	if stats.DataPointCount != 2 {
+		t.Errorf("Expected 2 points , got %d", stats.DataPointCount)
 	}
 
-	if ins != 1 {
-		t.Errorf("Expected 1 mismatched point , got %d", ins)
+	if stats.MismatchCount != 1 {
+		t.Errorf("Expected 1 mismatched point , got %d", stats.MismatchCount)
 	}
 
-	if fixed != 0 {
-		t.Errorf("Expected 0 fixed mismatch point , got %d", fixed)
+	if stats.FixedMismatchCount != 0 {
+		t.Errorf("Expected 0 fixed mismatch point , got %d", stats.FixedMismatchCount)
 	}
 }
 
@@ -233,7 +233,7 @@ func TestMergeManyMinorityMismatchedMetricsWithCheck(t *testing.T) {
 		IsAbsent: []bool{false, false},
 	}
 
-	got, ps, ins, fixed := MergeMetrics(input, cfg.ReplicaMatchModeCheck, 10)
+	got, stats := MergeMetrics(input, cfg.ReplicaMatchModeCheck, 10)
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -242,15 +242,15 @@ func TestMergeManyMinorityMismatchedMetricsWithCheck(t *testing.T) {
 		t.Errorf("Merge failed\nExp: %+v\nGot: %+v\n", expected, got[0])
 	}
 
-	if ps != 2 {
-		t.Errorf("Expected 2 metric points, got %d", ps)
+	if stats.DataPointCount != 2 {
+		t.Errorf("Expected 2 metric points, got %d", stats.DataPointCount)
 	}
-	if ins != 1 {
-		t.Errorf("Expected 1 mismatched point, got %d", ins)
+	if stats.MismatchCount != 1 {
+		t.Errorf("Expected 1 mismatched point, got %d", stats.MismatchCount)
 	}
 
-	if fixed != 0 {
-		t.Errorf("Expected 0 fixed mismatch point , got %d", fixed)
+	if stats.FixedMismatchCount != 0 {
+		t.Errorf("Expected 0 fixed mismatch point , got %d", stats.FixedMismatchCount)
 	}
 }
 
@@ -285,7 +285,7 @@ func TestMergeManyMinorityMismatchedMetricsWithMajority(t *testing.T) {
 		IsAbsent: []bool{false, false},
 	}
 
-	got, ps, ins, fixed := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
+	got, stats := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -294,16 +294,16 @@ func TestMergeManyMinorityMismatchedMetricsWithMajority(t *testing.T) {
 		t.Errorf("Merge failed\nExp: %+v\nGot: %+v\n", expected, got[0])
 	}
 
-	if ps != 2 {
-		t.Errorf("Expected 2 metric points, got %d", ps)
+	if stats.DataPointCount != 2 {
+		t.Errorf("Expected 2 metric points, got %d", stats.DataPointCount)
 	}
 
-	if ins != 1 {
-		t.Errorf("Expected 1 mismatched points, got %d", ins)
+	if stats.MismatchCount != 1 {
+		t.Errorf("Expected 1 mismatched points, got %d", stats.MismatchCount)
 	}
 
-	if fixed != 1 {
-		t.Errorf("Expected 1 fixed mismatch point , got %d", fixed)
+	if stats.FixedMismatchCount != 1 {
+		t.Errorf("Expected 1 fixed mismatch point , got %d", stats.FixedMismatchCount)
 	}
 }
 
@@ -338,7 +338,7 @@ func TestMergeManyRiskyAndMismatchedMetricsWithCheck(t *testing.T) {
 		IsAbsent: []bool{false, false, false},
 	}
 
-	got, ps, ins, fixed := MergeMetrics(input, cfg.ReplicaMatchModeCheck, 10)
+	got, stats := MergeMetrics(input, cfg.ReplicaMatchModeCheck, 10)
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -347,16 +347,16 @@ func TestMergeManyRiskyAndMismatchedMetricsWithCheck(t *testing.T) {
 		t.Errorf("Merge failed\nExp: %+v\nGot: %+v\n", expected, got[0])
 	}
 
-	if ps != 3 {
-		t.Errorf("Expected 2 metric points, got %d", ps)
+	if stats.DataPointCount != 3 {
+		t.Errorf("Expected 2 metric points, got %d", stats.DataPointCount)
 	}
 
-	if ins != 2 {
-		t.Errorf("Expected 2 mismatched points, got %d", ins)
+	if stats.MismatchCount != 2 {
+		t.Errorf("Expected 2 mismatched points, got %d", stats.MismatchCount)
 	}
 
-	if fixed != 0 {
-		t.Errorf("Expected 0 fixed mismatch point , got %d", fixed)
+	if stats.FixedMismatchCount != 0 {
+		t.Errorf("Expected 0 fixed mismatch point , got %d", stats.FixedMismatchCount)
 	}
 }
 
@@ -391,7 +391,7 @@ func TestMergeManyRiskyAndMismatchedMetricsWithMajority(t *testing.T) {
 		IsAbsent: []bool{false, false, false},
 	}
 
-	got, ps, ins, fixed := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
+	got, stats := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -400,16 +400,16 @@ func TestMergeManyRiskyAndMismatchedMetricsWithMajority(t *testing.T) {
 		t.Errorf("Merge failed\nExp: %+v\nGot: %+v\n", expected, got[0])
 	}
 
-	if ps != 3 {
-		t.Errorf("Expected 3 metric points, got %d", ps)
+	if stats.DataPointCount != 3 {
+		t.Errorf("Expected 3 metric points, got %d", stats.DataPointCount)
 	}
 
-	if ins != 2 {
-		t.Errorf("Expected 2 mismatched points, got %d", ins)
+	if stats.MismatchCount != 2 {
+		t.Errorf("Expected 2 mismatched points, got %d", stats.MismatchCount)
 	}
 
-	if fixed != 1 {
-		t.Errorf("Expected 1 fixed mismatch point , got %d", fixed)
+	if stats.FixedMismatchCount != 1 {
+		t.Errorf("Expected 1 fixed mismatch point , got %d", stats.FixedMismatchCount)
 	}
 }
 
@@ -448,7 +448,7 @@ func TestMergeManyRiskyAndMismatchedMetricsWithMajorityBadFloat(t *testing.T) {
 		IsAbsent: []bool{false, false, false},
 	}
 
-	got, ps, ins, fixed := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
+	got, stats := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -457,16 +457,16 @@ func TestMergeManyRiskyAndMismatchedMetricsWithMajorityBadFloat(t *testing.T) {
 		t.Errorf("Merge failed\nExp: %+v\nGot: %+v\n", expected, got[0])
 	}
 
-	if ps != 3 {
-		t.Errorf("Expected 3 metric points, got %d", ps)
+	if stats.DataPointCount != 3 {
+		t.Errorf("Expected 3 metric points, got %d", stats.DataPointCount)
 	}
 
-	if ins != 2 {
-		t.Errorf("Expected 2 mismatched points, got %d", ins)
+	if stats.MismatchCount != 2 {
+		t.Errorf("Expected 2 mismatched points, got %d", stats.MismatchCount)
 	}
 
-	if fixed != 1 {
-		t.Errorf("Expected 1 fixed mismatch point , got %d", fixed)
+	if stats.FixedMismatchCount != 1 {
+		t.Errorf("Expected 1 fixed mismatch point , got %d", stats.FixedMismatchCount)
 	}
 }
 
@@ -488,7 +488,7 @@ func TestMergeManyMetricsDifferent(t *testing.T) {
 		},
 	}
 
-	got, _, _, _ := MergeMetrics(input, cfg.ReplicaMatchModeNormal, 0)
+	got, _ := MergeMetrics(input, cfg.ReplicaMatchModeNormal, 0)
 	if len(got) != 2 {
 		t.Errorf("Expected 2 metrics, got %d", len(got))
 	}
@@ -777,7 +777,7 @@ func TestMergeMetricsDifferingStepTimes6(t *testing.T) {
 }
 
 func doTest(t *testing.T, input []Metric, expected Metric) {
-	got, _, _ := mergeMetrics(input, cfg.ReplicaMatchModeNormal)
+	got, _ := mergeMetrics(input, cfg.ReplicaMatchModeNormal)
 
 	if !MetricsEqual(got, expected) {
 		t.Errorf("Merge failed\nExp: %+v\nGot: %+v\n", expected, got)


### PR DESCRIPTION
## What issue is this change attempting to solve?

It is possible that metrics in different backends have different values for points (replica mismatches). These are mainly caused by aggregating metrics with null points. The null points on backends are also caused by backends being temporarily unavailable. 

## How does this change solve the problem? Why is this the best approach?

`renderReplicaMatchMode` is introduced to configure carbonzipper on how it should behave on merging metrics retrieved from backends.
With `majority` implementation, for each of the data points in a render request result, the values stored in the majority of backends will be returned.
If there is no majority in the values, this code returns ~one of the most voted values~ the first value like normal mode (To be discussed).

Also, one counter is added for monitoring number of fixed mismatches. it is increased whenever a data-point has a majority value in `majority` mode.

Possible next steps:
- Configuration on what to do when there is no majority (either null or different).
- take the number of replicas for each metric into account.
  - Pro: eliminate further checks if the majority condition is already met.
  - Con: we should find a way to inject the data to zipper
- take the exact replicas of a metric into account.
  -  Pro: get rid of old or not related backends for a metric. only check the related backends.
  -  Con: implementation can be complex.

## How can we be sure this works as expected?
Tests are developed for each of the replica match configurations.
