### PR TITLE
Add mismatched render response metric

### DIFF
--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -280,6 +280,7 @@ func metricsServer(app *App) *http.Server {
 	prometheus.MustRegister(app.prometheusMetrics.Renders)
 	prometheus.MustRegister(app.prometheusMetrics.RenderMismatches)
 	prometheus.MustRegister(app.prometheusMetrics.RenderFixedMismatches)
+	prometheus.MustRegister(app.prometheusMetrics.RenderMismatchedResponses)
 	prometheus.MustRegister(app.prometheusMetrics.FindNotFound)
 	prometheus.MustRegister(app.prometheusMetrics.RequestCancel)
 	prometheus.MustRegister(app.prometheusMetrics.DurationExp)

--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -393,6 +393,9 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request) {
 
 	Metrics.Responses.Add(1)
 	app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusOK), "render").Inc()
+	if stats.MismatchCount > stats.FixedMismatchCount {
+		app.prometheusMetrics.RenderMismatchedResponses.Inc()
+	}
 
 	if writeErr != nil {
 		accessLogger.Error("error writing the response",

--- a/app/carbonzipper/metrics.go
+++ b/app/carbonzipper/metrics.go
@@ -55,21 +55,22 @@ var Metrics = struct {
 
 // PrometheusMetrics keeps all the metrics exposed on /metrics endpoint
 type PrometheusMetrics struct {
-	Requests              prometheus.Counter
-	Responses             *prometheus.CounterVec
-	RenderMismatches      prometheus.Counter
-	RenderFixedMismatches prometheus.Counter
-	Renders               prometheus.Counter
-	FindNotFound          prometheus.Counter
-	RequestCancel         *prometheus.CounterVec
-	DurationExp           prometheus.Histogram
-	DurationLin           prometheus.Histogram
-	RenderDurationExp     prometheus.Histogram
-	RenderOutDurationExp  *prometheus.HistogramVec
-	FindDurationExp       prometheus.Histogram
-	FindDurationLin       prometheus.Histogram
-	TimeInQueueExp        prometheus.Histogram
-	TimeInQueueLin        prometheus.Histogram
+	Requests                  prometheus.Counter
+	Responses                 *prometheus.CounterVec
+	RenderMismatches          prometheus.Counter
+	RenderFixedMismatches     prometheus.Counter
+	RenderMismatchedResponses prometheus.Counter
+	Renders                   prometheus.Counter
+	FindNotFound              prometheus.Counter
+	RequestCancel             *prometheus.CounterVec
+	DurationExp               prometheus.Histogram
+	DurationLin               prometheus.Histogram
+	RenderDurationExp         prometheus.Histogram
+	RenderOutDurationExp      *prometheus.HistogramVec
+	FindDurationExp           prometheus.Histogram
+	FindDurationLin           prometheus.Histogram
+	TimeInQueueExp            prometheus.Histogram
+	TimeInQueueLin            prometheus.Histogram
 }
 
 // NewPrometheusMetrics creates a set of default Prom metrics
@@ -87,6 +88,12 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 				Help: "Count of HTTP responses, partitioned by return code and handler",
 			},
 			[]string{"code", "handler"},
+		),
+		RenderMismatchedResponses: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "render_mismatched_responses_total",
+				Help: "Count of mismatched (unfixed) render responses",
+			},
 		),
 		RenderFixedMismatches: prometheus.NewCounter(
 			prometheus.CounterOpts{


### PR DESCRIPTION
## What issue is this change attempting to solve?

It adds the metric to measure the number of render responses having mismatches in them (queries with inconsistency).

## How does this change solve the problem? Why is this the best approach?

Simply adds a counter.
