### PR TITLE
Add mismatch approximate float check config

### DIFF
--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -309,8 +309,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request) {
 	request.Trace.OutDuration = app.prometheusMetrics.RenderOutDurationExp
 	bs := app.filterBackendByTopLevelDomain(request.Targets)
 	bs = backend.Filter(bs, request.Targets)
-	metrics, stats, errs := backend.Renders(ctx, bs, request, app.config.RenderReplicaMatchMode,
-		app.config.RenderReplicaMismatchReportLimit)
+	metrics, stats, errs := backend.Renders(ctx, bs, request, app.config.RenderReplicaMismatchConfig)
 	app.prometheusMetrics.Renders.Add(float64(stats.DataPointCount))
 	app.prometheusMetrics.RenderMismatches.Add(float64(stats.MismatchCount))
 	app.prometheusMetrics.RenderFixedMismatches.Add(float64(stats.FixedMismatchCount))

--- a/cfg/common.go
+++ b/cfg/common.go
@@ -126,8 +126,11 @@ func DefaultCommonConfig() Common {
 		},
 		PrintErrorStackTrace: false,
 
-		RenderReplicaMatchMode:           ReplicaMatchModeNormal,
-		RenderReplicaMismatchReportLimit: 10,
+		RenderReplicaMismatchConfig: RenderReplicaMismatchConfig{
+			RenderReplicaMismatchApproximateCheck: false,
+			RenderReplicaMatchMode:                ReplicaMatchModeNormal,
+			RenderReplicaMismatchReportLimit:      10,
+		},
 	}
 }
 
@@ -171,6 +174,15 @@ type Common struct {
 	Traces               Traces `yaml:"traces"`
 	PrintErrorStackTrace bool   `yaml:"printErrorStackTrace"`
 
+	// RenderReplicaMismatchConfig configures the render mismatch related operations.
+	RenderReplicaMismatchConfig RenderReplicaMismatchConfig `yaml:"renderReplicaMismatchConfig"`
+}
+
+type RenderReplicaMismatchConfig struct {
+	// RenderReplicaMismatchApproximateCheck enables the approximate float equality
+	// check while checking for mismatches.
+	RenderReplicaMismatchApproximateCheck bool `yaml:"renderReplicaMismatchApproximateCheck"`
+
 	// RenderReplicaMatchMode indicates how carbonzipper merges the metrics from replica backends.
 	// Possible values are:
 	//
@@ -184,6 +196,14 @@ type Common struct {
 	// RenderReplicaMismatchReportLimit limits the number of mismatched metrics to be logged
 	// for a single render request.
 	RenderReplicaMismatchReportLimit int `yaml:"renderReplicaMismatchReportLimit"`
+}
+
+func (c *RenderReplicaMismatchConfig) String() string {
+	eqCheckDesc := "WithExactEqCheck"
+	if c.RenderReplicaMismatchApproximateCheck {
+		eqCheckDesc = "WithApproximateEqCheck"
+	}
+	return string(c.RenderReplicaMatchMode) + eqCheckDesc
 }
 
 // GetBackends returns the list of backends from common configuration

--- a/pkg/backend/benchmark_test.go
+++ b/pkg/backend/benchmark_test.go
@@ -64,12 +64,38 @@ func BenchmarkRenders(b *testing.B) {
 	}
 
 	ctx := context.Background()
-	renderReplicaMatchModes := []cfg.ReplicaMatchMode{cfg.ReplicaMatchModeNormal, cfg.ReplicaMatchModeCheck, cfg.ReplicaMatchModeMajority}
-	for _, replicaMatchMode := range renderReplicaMatchModes {
+	renderReplicaMismatchConfigs := []cfg.RenderReplicaMismatchConfig{
+		{
+			RenderReplicaMismatchApproximateCheck: false,
+			RenderReplicaMatchMode:                cfg.ReplicaMatchModeNormal,
+			RenderReplicaMismatchReportLimit:      0,
+		},
+		{
+			RenderReplicaMismatchApproximateCheck: false,
+			RenderReplicaMatchMode:                cfg.ReplicaMatchModeCheck,
+			RenderReplicaMismatchReportLimit:      0,
+		},
+		{
+			RenderReplicaMismatchApproximateCheck: true,
+			RenderReplicaMatchMode:                cfg.ReplicaMatchModeCheck,
+			RenderReplicaMismatchReportLimit:      0,
+		},
+		{
+			RenderReplicaMismatchApproximateCheck: false,
+			RenderReplicaMatchMode:                cfg.ReplicaMatchModeMajority,
+			RenderReplicaMismatchReportLimit:      0,
+		},
+		{
+			RenderReplicaMismatchApproximateCheck: true,
+			RenderReplicaMatchMode:                cfg.ReplicaMatchModeMajority,
+			RenderReplicaMismatchReportLimit:      0,
+		},
+	}
+	for _, replicaMatchMode := range renderReplicaMismatchConfigs {
 		cc := replicaMatchMode
-		b.Run(fmt.Sprintf("BenchmarkRenders/ReplicaMatchMode%s", string(cc)), func(b *testing.B) {
+		b.Run(fmt.Sprintf("BenchmarkRenders/ReplicaMatchMode-%s", cc.String()), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				Renders(ctx, backends, types.NewRenderRequest(nil, 0, 0), cc, 10)
+				Renders(ctx, backends, types.NewRenderRequest(nil, 0, 0), cc)
 			}
 		})
 	}
@@ -127,16 +153,42 @@ func BenchmarkRendersStorm(b *testing.B) {
 	n := 50
 	errs := make(chan []error, n)
 
-	renderReplicaMatchModes := []cfg.ReplicaMatchMode{cfg.ReplicaMatchModeNormal, cfg.ReplicaMatchModeCheck, cfg.ReplicaMatchModeMajority}
-	for _, replicaMatchMode := range renderReplicaMatchModes {
+	renderReplicaMismatchConfigs := []cfg.RenderReplicaMismatchConfig{
+		{
+			RenderReplicaMismatchApproximateCheck: false,
+			RenderReplicaMatchMode:                cfg.ReplicaMatchModeNormal,
+			RenderReplicaMismatchReportLimit:      0,
+		},
+		{
+			RenderReplicaMismatchApproximateCheck: false,
+			RenderReplicaMatchMode:                cfg.ReplicaMatchModeCheck,
+			RenderReplicaMismatchReportLimit:      0,
+		},
+		{
+			RenderReplicaMismatchApproximateCheck: true,
+			RenderReplicaMatchMode:                cfg.ReplicaMatchModeCheck,
+			RenderReplicaMismatchReportLimit:      0,
+		},
+		{
+			RenderReplicaMismatchApproximateCheck: false,
+			RenderReplicaMatchMode:                cfg.ReplicaMatchModeMajority,
+			RenderReplicaMismatchReportLimit:      0,
+		},
+		{
+			RenderReplicaMismatchApproximateCheck: true,
+			RenderReplicaMatchMode:                cfg.ReplicaMatchModeMajority,
+			RenderReplicaMismatchReportLimit:      0,
+		},
+	}
+	for _, replicaMatchMode := range renderReplicaMismatchConfigs {
 		cc := replicaMatchMode
-		b.Run(fmt.Sprintf("BenchmarkRendersStorm/ReplicaMatchMode%s", string(cc)), func(b *testing.B) {
+		b.Run(fmt.Sprintf("BenchmarkRendersStorm/ReplicaMatchMode-%s", cc.String()), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				for j := 0; j < n; j++ {
 					wg.Add(1)
 					go func() {
 						defer wg.Done()
-						_, _, err := Renders(ctx, backends, types.NewRenderRequest(nil, 0, 0), cc, 10)
+						_, _, err := Renders(ctx, backends, types.NewRenderRequest(nil, 0, 0), cc)
 						errs <- err
 					}()
 				}

--- a/pkg/backend/rpc.go
+++ b/pkg/backend/rpc.go
@@ -45,7 +45,7 @@ type Backend interface {
 // replicaMatchMode indicates how data points of the metrics fetched from replicas
 // will be checked and applied on the final metrics. replicaMismatchReportLimit limits
 // the number of mismatched metrics reported in log for each render request.
-func Renders(ctx context.Context, backends []Backend, request types.RenderRequest, replicaMatchMode cfg.ReplicaMatchMode, replicaMismatchReportLimit int) ([]types.Metric, types.MetricRenderStats, []error) {
+func Renders(ctx context.Context, backends []Backend, request types.RenderRequest, replicaMismatchConfig cfg.RenderReplicaMismatchConfig) ([]types.Metric, types.MetricRenderStats, []error) {
 	if len(backends) == 0 {
 		return nil, types.MetricRenderStats{}, nil
 	}
@@ -75,7 +75,7 @@ func Renders(ctx context.Context, backends []Backend, request types.RenderReques
 		}
 	}
 
-	metrics, stats := types.MergeMetrics(msgs, replicaMatchMode, replicaMismatchReportLimit)
+	metrics, stats := types.MergeMetrics(msgs, replicaMismatchConfig)
 	return metrics, stats, errs
 }
 

--- a/pkg/backend/rpc_test.go
+++ b/pkg/backend/rpc_test.go
@@ -65,7 +65,11 @@ func TestCarbonapiv2FindsEmpty(t *testing.T) {
 }
 
 func TestCarbonapiv2RendersEmpty(t *testing.T) {
-	got, _, err := Renders(context.Background(), []Backend{}, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeNormal, 10)
+	got, _, err := Renders(context.Background(), []Backend{}, types.NewRenderRequest(nil, 0, 1), cfg.RenderReplicaMismatchConfig{
+		RenderReplicaMismatchApproximateCheck: false,
+		RenderReplicaMatchMode:                cfg.ReplicaMatchModeNormal,
+		RenderReplicaMismatchReportLimit:      10,
+	})
 	if err != nil {
 		t.Error(err)
 		return
@@ -96,7 +100,11 @@ func TestCarbonapiv2Renders(t *testing.T) {
 		backends = append(backends, b)
 	}
 
-	got, stats, errs := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeMajority, 10)
+	got, stats, errs := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), cfg.RenderReplicaMismatchConfig{
+		RenderReplicaMismatchApproximateCheck: false,
+		RenderReplicaMatchMode:                cfg.ReplicaMatchModeMajority,
+		RenderReplicaMismatchReportLimit:      10,
+	})
 	if len(errs) != 0 {
 		t.Error(errs[0])
 		return
@@ -130,7 +138,11 @@ func TestCarbonapiv2RendersError(t *testing.T) {
 
 	backends := []Backend{mock.New(mock.Config{Render: render})}
 
-	_, _, err := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), cfg.ReplicaMatchModeNormal, 10)
+	_, _, err := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), cfg.RenderReplicaMismatchConfig{
+		RenderReplicaMismatchApproximateCheck: false,
+		RenderReplicaMatchMode:                cfg.ReplicaMatchModeNormal,
+		RenderReplicaMismatchReportLimit:      10,
+	})
 	if err == nil {
 		t.Error("Expected error")
 	}

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -100,7 +100,7 @@ func TestMergeManyMetricsWithNormal(t *testing.T) {
 		IsAbsent: []bool{false},
 	}
 
-	got, _ := MergeMetrics(input, cfg.ReplicaMatchModeNormal, 0)
+	got, _ := MergeMetrics(input, cfg.RenderReplicaMismatchConfig{RenderReplicaMatchMode: cfg.ReplicaMatchModeNormal})
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -134,7 +134,7 @@ func TestMergeManyMismatchedMetricsWithCheck(t *testing.T) {
 		IsAbsent: []bool{false, false},
 	}
 
-	got, stats := MergeMetrics(input, cfg.ReplicaMatchModeCheck, 10)
+	got, stats := MergeMetrics(input, cfg.RenderReplicaMismatchConfig{RenderReplicaMatchMode: cfg.ReplicaMatchModeCheck})
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -180,7 +180,7 @@ func TestMergeManyMismatchedMetricsWithMajority(t *testing.T) {
 		IsAbsent: []bool{false, false},
 	}
 
-	got, stats := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
+	got, stats := MergeMetrics(input, cfg.RenderReplicaMismatchConfig{RenderReplicaMatchMode: cfg.ReplicaMatchModeMajority})
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -233,7 +233,7 @@ func TestMergeManyMinorityMismatchedMetricsWithCheck(t *testing.T) {
 		IsAbsent: []bool{false, false},
 	}
 
-	got, stats := MergeMetrics(input, cfg.ReplicaMatchModeCheck, 10)
+	got, stats := MergeMetrics(input, cfg.RenderReplicaMismatchConfig{RenderReplicaMatchMode: cfg.ReplicaMatchModeCheck})
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -285,7 +285,7 @@ func TestMergeManyMinorityMismatchedMetricsWithMajority(t *testing.T) {
 		IsAbsent: []bool{false, false},
 	}
 
-	got, stats := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
+	got, stats := MergeMetrics(input, cfg.RenderReplicaMismatchConfig{RenderReplicaMatchMode: cfg.ReplicaMatchModeMajority})
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -338,7 +338,7 @@ func TestMergeManyRiskyAndMismatchedMetricsWithCheck(t *testing.T) {
 		IsAbsent: []bool{false, false, false},
 	}
 
-	got, stats := MergeMetrics(input, cfg.ReplicaMatchModeCheck, 10)
+	got, stats := MergeMetrics(input, cfg.RenderReplicaMismatchConfig{RenderReplicaMatchMode: cfg.ReplicaMatchModeCheck})
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -391,7 +391,7 @@ func TestMergeManyRiskyAndMismatchedMetricsWithMajority(t *testing.T) {
 		IsAbsent: []bool{false, false, false},
 	}
 
-	got, stats := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
+	got, stats := MergeMetrics(input, cfg.RenderReplicaMismatchConfig{RenderReplicaMatchMode: cfg.ReplicaMatchModeMajority})
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -413,7 +413,7 @@ func TestMergeManyRiskyAndMismatchedMetricsWithMajority(t *testing.T) {
 	}
 }
 
-func TestMergeManyRiskyAndMismatchedMetricsWithMajorityBadFloat(t *testing.T) {
+func TestMergeManyRiskyAndMismatchedMetricsWithMajorityApproximateBadFloat(t *testing.T) {
 	f1 := 0.1
 	f2 := 0.2
 	f3 := 0.3
@@ -448,7 +448,10 @@ func TestMergeManyRiskyAndMismatchedMetricsWithMajorityBadFloat(t *testing.T) {
 		IsAbsent: []bool{false, false, false},
 	}
 
-	got, stats := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
+	got, stats := MergeMetrics(input, cfg.RenderReplicaMismatchConfig{
+		RenderReplicaMatchMode:                cfg.ReplicaMatchModeMajority,
+		RenderReplicaMismatchApproximateCheck: true,
+	})
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -470,7 +473,7 @@ func TestMergeManyRiskyAndMismatchedMetricsWithMajorityBadFloat(t *testing.T) {
 	}
 }
 
-func TestMergeMismatchedMetricsWithMajorityBadFloat(t *testing.T) {
+func TestMergeMismatchedMetricsWithMajorityApproximateBadFloat(t *testing.T) {
 	f1 := 0.1
 	f2 := 0.2
 	f3 := 0.3
@@ -505,7 +508,10 @@ func TestMergeMismatchedMetricsWithMajorityBadFloat(t *testing.T) {
 		IsAbsent: []bool{false, false, false},
 	}
 
-	got, stats := MergeMetrics(input, cfg.ReplicaMatchModeMajority, 10)
+	got, stats := MergeMetrics(input, cfg.RenderReplicaMismatchConfig{
+		RenderReplicaMatchMode:                cfg.ReplicaMatchModeMajority,
+		RenderReplicaMismatchApproximateCheck: true,
+	})
 	if len(got) != 1 {
 		t.Errorf("Expected 1 metric, got %d", len(got))
 	}
@@ -545,7 +551,7 @@ func TestMergeManyMetricsDifferent(t *testing.T) {
 		},
 	}
 
-	got, _ := MergeMetrics(input, cfg.ReplicaMatchModeNormal, 0)
+	got, _ := MergeMetrics(input, cfg.RenderReplicaMismatchConfig{RenderReplicaMatchMode: cfg.ReplicaMatchModeNormal})
 	if len(got) != 2 {
 		t.Errorf("Expected 2 metrics, got %d", len(got))
 	}
@@ -834,7 +840,7 @@ func TestMergeMetricsDifferingStepTimes6(t *testing.T) {
 }
 
 func doTest(t *testing.T, input []Metric, expected Metric) {
-	got, _ := mergeMetrics(input, cfg.ReplicaMatchModeNormal)
+	got, _ := mergeMetrics(input, cfg.RenderReplicaMismatchConfig{RenderReplicaMatchMode: cfg.ReplicaMatchModeNormal})
 
 	if !MetricsEqual(got, expected) {
 		t.Errorf("Merge failed\nExp: %+v\nGot: %+v\n", expected, got)


### PR DESCRIPTION
## What issue is this change attempting to solve?
Because of the performance impact of float approximate checks, a
new config is introduced to determine if the floats should be
checked approximately or exactly.
The whole mismatch related configs are also encaped into one
struct.

## How does this change solve the problem? Why is this the best approach?
Adds a bool config for approximate checks
