### PR TITLE
Optimize zipper majority vote

### DIFF
--- a/pkg/backend/benchmark_test.go
+++ b/pkg/backend/benchmark_test.go
@@ -102,14 +102,30 @@ func BenchmarkRenders(b *testing.B) {
 }
 
 func BenchmarkRendersStorm(b *testing.B) {
-	secPerHour := int(12 * time.Hour / time.Second)
+	secPerMonth := int(30 * 24 * time.Hour / time.Second)
 
+	allZeroValues1 := make([]float64, secPerMonth)
+	allZeroValues2 := make([]float64, secPerMonth)
+	allOneValues := make([]float64, secPerMonth)
+	for i := range allOneValues {
+		allOneValues[i] = 1.0
+	}
 	metrics := carbonapi_v2_pb.MultiFetchResponse{
 		Metrics: []carbonapi_v2_pb.FetchResponse{
 			carbonapi_v2_pb.FetchResponse{
 				Name:     "foo",
-				Values:   make([]float64, secPerHour),
-				IsAbsent: make([]bool, secPerHour),
+				Values:   allZeroValues1,
+				IsAbsent: make([]bool, secPerMonth),
+			},
+			carbonapi_v2_pb.FetchResponse{
+				Name:     "foo",
+				Values:   allOneValues,
+				IsAbsent: make([]bool, secPerMonth),
+			},
+			carbonapi_v2_pb.FetchResponse{
+				Name:     "foo",
+				Values:   allZeroValues2,
+				IsAbsent: make([]bool, secPerMonth),
 			},
 		},
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -326,8 +326,8 @@ func getPointMajorityValue(values []float64, equalityFunc floatEqualityFunc) (ma
 	for _, v := range values {
 		if i == 0 {
 			m = v
-		}
-		if (equalityFunc == nil && m == v) || (equalityFunc != nil && equalityFunc(m, v)) {
+			i = 1
+		} else if (equalityFunc == nil && m == v) || (equalityFunc != nil && equalityFunc(m, v)) {
 			i++
 		} else {
 			i--


### PR DESCRIPTION
## What issue is this change attempting to solve?

Regarding the performance issues seen on majority read feature introduced in #348 on carbonzipper rendered replica metrics, this PR attempts to optimize the computation on merge functionality of zipper.

## How does this change solve the problem? Why is this the best approach?
Using the [Boyer–Moore majority vote algorithm](https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_majority_vote_algorithm) (proposed by @bom-d-van) The performance of majority voting is increased. The benchmark results (with new data) is presented:

before Boyer–Moore majority vote algorithm:
```
goos: linux
goarch: amd64
pkg: github.com/bookingcom/carbonapi/pkg/backend
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkRendersStorm/BenchmarkRendersStorm/ReplicaMatchMode-normalWithExactEqCheck-8         	       1	6052688709 ns/op
BenchmarkRendersStorm/BenchmarkRendersStorm/ReplicaMatchMode-checkWithExactEqCheck-8          	       1	7349380146 ns/op
BenchmarkRendersStorm/BenchmarkRendersStorm/ReplicaMatchMode-checkWithApproximateEqCheck-8    	       1	10030765581 ns/op
BenchmarkRendersStorm/BenchmarkRendersStorm/ReplicaMatchMode-majorityWithExactEqCheck-8       	       1	33215526638 ns/op
BenchmarkRendersStorm/BenchmarkRendersStorm/ReplicaMatchMode-majorityWithApproximateEqCheck-8 	       1	39880077185 ns/op
```
with Boyer–Moore majority vote algorithm:
```
goos: linux
goarch: amd64
pkg: github.com/bookingcom/carbonapi/pkg/backend
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkRendersStorm/BenchmarkRendersStorm/ReplicaMatchMode-normalWithExactEqCheck-8         	       1	6213874116 ns/op
BenchmarkRendersStorm/BenchmarkRendersStorm/ReplicaMatchMode-checkWithExactEqCheck-8          	       1	7012712732 ns/op
BenchmarkRendersStorm/BenchmarkRendersStorm/ReplicaMatchMode-checkWithApproximateEqCheck-8    	       1	10050420245 ns/op
BenchmarkRendersStorm/BenchmarkRendersStorm/ReplicaMatchMode-majorityWithExactEqCheck-8       	       1	20160802573 ns/op
BenchmarkRendersStorm/BenchmarkRendersStorm/ReplicaMatchMode-majorityWithApproximateEqCheck-8 	       1	31473745254 ns/op
```

**Update:**

After some optimization there is a huge performance improvement (The comparison is between before this PR and the latest changes in this PR):
```
name                                                                        old time/op  new time/op  delta
Renders/BenchmarkRenders/ReplicaMatchMode-normalWithExactEqCheck-8          2.36ms ± 0%  2.26ms ± 0%   ~     (p=1.000 n=1+1)
Renders/BenchmarkRenders/ReplicaMatchMode-checkWithExactEqCheck-8           11.1ms ± 0%   3.6ms ± 0%   ~     (p=1.000 n=1+1)
Renders/BenchmarkRenders/ReplicaMatchMode-checkWithApproximateEqCheck-8     11.5ms ± 0%   4.7ms ± 0%   ~     (p=1.000 n=1+1)
Renders/BenchmarkRenders/ReplicaMatchMode-majorityWithExactEqCheck-8        10.2ms ± 0%   3.8ms ± 0%   ~     (p=1.000 n=1+1)
Renders/BenchmarkRenders/ReplicaMatchMode-majorityWithApproximateEqCheck-8  11.5ms ± 0%   3.9ms ± 0%   ~     (p=1.000 n=1+1)
RendersMismatchStorm/ReplicaMatchMode-normalWithExactEqCheck-8               9.15s ± 0%   7.33s ± 0%   ~     (p=1.000 n=1+1)
RendersMismatchStorm/ReplicaMatchMode-checkWithExactEqCheck-8                18.1s ± 0%    8.0s ± 0%   ~     (p=1.000 n=1+1)
RendersMismatchStorm/ReplicaMatchMode-majorityWithExactEqCheck-8             49.6s ± 0%   10.6s ± 0%   ~     (p=1.000 n=1+1)
RendersMismatchStorm/ReplicaMatchMode-checkWithApproximateEqCheck-8          21.3s ± 0%   13.5s ± 0%   ~     (p=1.000 n=1+1)
RendersMismatchStorm/ReplicaMatchMode-majorityWithApproximateEqCheck-8       63.3s ± 0%   26.2s ± 0%   ~     (p=1.000 n=1+1)
RendersStorm/ReplicaMatchMode-normalWithExactEqCheck-8                       6.68s ± 0%   6.92s ± 0%   ~     (p=1.000 n=1+1)
RendersStorm/ReplicaMatchMode-checkWithExactEqCheck-8                        21.2s ± 0%    9.1s ± 0%   ~     (p=1.000 n=1+1)
RendersStorm/ReplicaMatchMode-majorityWithExactEqCheck-8                     21.0s ± 0%    8.8s ± 0%   ~     (p=1.000 n=1+1)
RendersStorm/ReplicaMatchMode-checkWithApproximateEqCheck-8                  20.9s ± 0%    9.6s ± 0%   ~     (p=1.000 n=1+1)
RendersStorm/ReplicaMatchMode-majorityWithApproximateEqCheck-8               21.3s ± 0%   10.3s ± 0%   ~     (p=1.000 n=1+1)

```
