### PR TITLE
Fix bug in majority vote function

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -333,7 +333,7 @@ func getPointMajorityValue(values []float64, equalityFunc floatEqualityFunc) (ma
 			i--
 		}
 		if i > valuesCount/2 {
-			return m, isMajority, nil
+			return m, true, nil
 		}
 	}
 


### PR DESCRIPTION
There was a bug in the function. it was returning false instead of true in case of earlier majority.
