### PR TITLE
Add mismatch report offset config

### DIFF
--- a/cfg/common.go
+++ b/cfg/common.go
@@ -130,6 +130,7 @@ func DefaultCommonConfig() Common {
 			RenderReplicaMismatchApproximateCheck: false,
 			RenderReplicaMatchMode:                ReplicaMatchModeNormal,
 			RenderReplicaMismatchReportLimit:      10,
+			MismatchReportOffsetSeconds:           120,
 		},
 	}
 }
@@ -196,6 +197,14 @@ type RenderReplicaMismatchConfig struct {
 	// RenderReplicaMismatchReportLimit limits the number of mismatched metrics to be logged
 	// for a single render request.
 	RenderReplicaMismatchReportLimit int `yaml:"renderReplicaMismatchReportLimit"`
+
+	// MismatchReportOffsetSeconds indicates the range (now - offset, now) in which mismatches
+	// are not exposed in the report.
+	// The reason to define such a config is that late rollup mismatches are highly probable
+	// as the values are being aggregated independently and asynchronously. Therefore, late mismatches
+	// are not good indicators of overall metric consistency.
+	// The default value is 120.
+	MismatchReportOffsetSeconds int `yaml:"mismatchReportOffsetSeconds"`
 }
 
 func (c *RenderReplicaMismatchConfig) String() string {

--- a/pkg/backend/benchmark_test.go
+++ b/pkg/backend/benchmark_test.go
@@ -126,11 +126,14 @@ func createSingleBackendMetrics() []carbonapi_v2_pb.FetchResponse {
 	metricsCount := 600
 	metrics := make([]carbonapi_v2_pb.FetchResponse, metricsCount)
 	dpCount := 10800
+	step := 60
 	for i := 0; i < 600; i++ {
 		metrics[i] = carbonapi_v2_pb.FetchResponse{
-			Name:     fmt.Sprintf("metric.foo%d", i),
-			Values:   make([]float64, dpCount),
-			IsAbsent: make([]bool, dpCount),
+			Name:      fmt.Sprintf("metric.foo%d", i),
+			Values:    make([]float64, dpCount),
+			IsAbsent:  make([]bool, dpCount),
+			StepTime:  int32(step),
+			StartTime: int32(int(time.Now().Unix()) - dpCount*step),
 		}
 	}
 	return metrics
@@ -193,26 +196,31 @@ func BenchmarkRendersStorm(b *testing.B) {
 			RenderReplicaMismatchApproximateCheck: false,
 			RenderReplicaMatchMode:                cfg.ReplicaMatchModeNormal,
 			RenderReplicaMismatchReportLimit:      0,
+			MismatchReportOffsetSeconds:           120,
 		},
 		{
 			RenderReplicaMismatchApproximateCheck: false,
 			RenderReplicaMatchMode:                cfg.ReplicaMatchModeCheck,
 			RenderReplicaMismatchReportLimit:      0,
+			MismatchReportOffsetSeconds:           120,
 		},
 		{
 			RenderReplicaMismatchApproximateCheck: false,
 			RenderReplicaMatchMode:                cfg.ReplicaMatchModeMajority,
 			RenderReplicaMismatchReportLimit:      0,
+			MismatchReportOffsetSeconds:           120,
 		},
 		{
 			RenderReplicaMismatchApproximateCheck: true,
 			RenderReplicaMatchMode:                cfg.ReplicaMatchModeCheck,
 			RenderReplicaMismatchReportLimit:      0,
+			MismatchReportOffsetSeconds:           120,
 		},
 		{
 			RenderReplicaMismatchApproximateCheck: true,
 			RenderReplicaMatchMode:                cfg.ReplicaMatchModeMajority,
 			RenderReplicaMismatchReportLimit:      0,
+			MismatchReportOffsetSeconds:           120,
 		},
 	}
 	for _, replicaMatchMode := range renderReplicaMismatchConfigs {
@@ -297,26 +305,31 @@ func BenchmarkRendersMismatchStorm(b *testing.B) {
 			RenderReplicaMismatchApproximateCheck: false,
 			RenderReplicaMatchMode:                cfg.ReplicaMatchModeNormal,
 			RenderReplicaMismatchReportLimit:      0,
+			MismatchReportOffsetSeconds:           120,
 		},
 		{
 			RenderReplicaMismatchApproximateCheck: false,
 			RenderReplicaMatchMode:                cfg.ReplicaMatchModeCheck,
 			RenderReplicaMismatchReportLimit:      0,
+			MismatchReportOffsetSeconds:           120,
 		},
 		{
 			RenderReplicaMismatchApproximateCheck: false,
 			RenderReplicaMatchMode:                cfg.ReplicaMatchModeMajority,
 			RenderReplicaMismatchReportLimit:      0,
+			MismatchReportOffsetSeconds:           120,
 		},
 		{
 			RenderReplicaMismatchApproximateCheck: true,
 			RenderReplicaMatchMode:                cfg.ReplicaMatchModeCheck,
 			RenderReplicaMismatchReportLimit:      0,
+			MismatchReportOffsetSeconds:           120,
 		},
 		{
 			RenderReplicaMismatchApproximateCheck: true,
 			RenderReplicaMatchMode:                cfg.ReplicaMatchModeMajority,
 			RenderReplicaMismatchReportLimit:      0,
+			MismatchReportOffsetSeconds:           120,
 		},
 	}
 	for _, replicaMatchMode := range renderReplicaMismatchConfigs {


### PR DESCRIPTION
Majorly this feature is developed because of rolled up metrics.
Data points are aggregated and rolled up in each of stores
individually and asynchronously. Therefore, it is very likely that
latest data points in the lower archive would have different
partial values. The new config adds the offset so the late
mismatches are not reported.
This helps the users to have a more clear objective and view on
the consistency of the data stored and returned.

## What issue is this change attempting to solve?

## How does this change solve the problem? Why is this the best approach?

## How can we be sure this works as expected?

