### PR TITLE
Upgrade go version in dockerfiles

### DIFF
--- a/docker/carbonapi/Dockerfile
+++ b/docker/carbonapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16
+FROM golang:1.18
 
 RUN apt-get update
 RUN apt-get install -y libcairo2-dev

--- a/docker/go-carbon/Dockerfile
+++ b/docker/go-carbon/Dockerfile
@@ -1,10 +1,9 @@
-FROM golang:1.14
+FROM golang:1.18
 
 RUN mkdir -p /data/graphite/whisper/
 COPY ./docker/go-carbon/*.conf /etc/
 
-RUN go get github.com/go-graphite/go-carbon
-RUN go install github.com/go-graphite/go-carbon
+RUN go install github.com/go-graphite/go-carbon@latest
 
 EXPOSE 2003 2004 7002 7007 2003/udp
 

--- a/docker/nanotube/Dockerfile
+++ b/docker/nanotube/Dockerfile
@@ -1,7 +1,6 @@
-FROM golang:1.16
+FROM golang:1.18
 
-RUN go get github.com/bookingcom/nanotube/cmd/nanotube
-RUN go install github.com/bookingcom/nanotube/cmd/nanotube
+RUN go install github.com/bookingcom/nanotube/cmd/nanotube@latest
 COPY ./docker/nanotube/config/ /etc/nanotube/config
 
 EXPOSE 2003

--- a/docker/zipper/Dockerfile
+++ b/docker/zipper/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16
+FROM golang:1.18
 
 RUN apt-get update
 RUN apt-get install -y libcairo2-dev


### PR DESCRIPTION
The CI integration test is now failing because of the go version. 
This PR fixes this issue.