### PR TITLE
Refactor log levels

### DIFF
--- a/app/carbonapi/app.go
+++ b/app/carbonapi/app.go
@@ -391,15 +391,20 @@ func (app *App) deferredAccessLogging(accessLogger *zap.Logger, r *http.Request,
 	if err != nil {
 		accessLogger.Error("could not marshal access log details", zap.Error(err))
 	}
-
+	var logMsg string
+	if accessLogDetails.HttpCode/100 == 2 {
+		logMsg = "request served"
+	} else {
+		logMsg = "request failed"
+	}
 	// TODO (grzkv) This logic is not obvious for the user
 	if logAsError {
-		accessLogger.Error("request failed", fields...)
+		accessLogger.Error(logMsg, fields...)
 		apiMetrics.Errors.Add(1)
 	} else {
 		// TODO (grzkv) The code can differ from the real one. Clean up
 		// accessLogDetails.HttpCode = http.StatusOK
-		accessLogger.Info("request served", fields...)
+		accessLogger.Info(logMsg, fields...)
 		apiMetrics.Responses.Add(1)
 	}
 

--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -173,7 +173,7 @@ func (app *App) findHandler(w http.ResponseWriter, req *http.Request, logger *za
 	if writeErr != nil {
 		Metrics.Errors.Add(1)
 		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(499), "find").Inc()
-		logger.Error("error writing the response",
+		logger.Warn("error writing the response",
 			zap.Int("http_code", 499),
 			zap.Duration("runtime_seconds", time.Since(t0)),
 			zap.Error(writeErr),
@@ -385,7 +385,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, logger *
 	if writeErr != nil {
 		Metrics.Errors.Add(1)
 		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(499), "render").Inc()
-		logger.Error("error writing the response",
+		logger.Warn("error writing the response",
 			zap.Int("http_code", 499),
 			zap.Duration("runtime_seconds", time.Since(t0)),
 			zap.Error(writeErr),
@@ -519,7 +519,7 @@ func (app *App) infoHandler(w http.ResponseWriter, req *http.Request, logger *za
 	if writeErr != nil {
 		Metrics.Errors.Add(1)
 		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(499), "info").Inc()
-		logger.Error("error writing the response",
+		logger.Warn("error writing the response",
 			zap.Int("http_code", 499),
 			zap.Duration("runtime_seconds", time.Since(t0)),
 			zap.Error(writeErr),

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -254,7 +254,7 @@ func MergeMetrics(metrics [][]Metric, replicaMismatchConfig cfg.RenderReplicaMis
 
 	metricsUnfixedMismatchCount := metricsStat.MismatchCount - metricsStat.FixedMismatchCount
 	if metricsUnfixedMismatchCount > 0 {
-		logger.Warn("metric unfixed replica mismatch observed",
+		logger.Info("metric unfixed replica mismatch observed",
 			zap.Any("replica_mismatched_metrics", mismatchedMetricReports),
 			zap.Int("replica_mismatches_total", metricsStat.MismatchCount),
 			zap.Int("replica_fixed_mismatches_total", metricsStat.FixedMismatchCount),


### PR DESCRIPTION
Client errors were producing error level logs which didn't make sense. This PR revises the log levels in carbonapi and carbonzipper.

