### PR TITLE
Fixing errors in CI that succeeds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
         run: sudo apt-get install libcairo2-dev -y
       - name: checkout code
         uses: actions/checkout@v2
-      - name: check
-        run: make all check
+      - name: test
+        run: make test
       - name: integration test
         run: tests/system_test.sh
   golangci:

--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,11 @@ build:
 	$(PKGCONF) $(GO) build -mod vendor $(TAGS) $(LDFLAGS) $(GCFLAGS) $(PKG_CARBONAPI)
 	$(PKGCONF) $(GO) build -mod vendor $(TAGS) $(LDFLAGS) $(GCFLAGS) $(PKG_CARBONZIPPER)
 
-vet:
-	go vet -composites=false ./...
-
 lint:
 	golangci-lint run
 
-check: test vet
-
 test:
-	$(PKGCONF) $(GO) test ./... -v -race -coverprofile=coverage.txt -covermode=atomic
+	$(PKGCONF) $(GO) test ./... -race -coverprofile=coverage.txt -covermode=atomic
 
 clean:
 	rm -f carbonapi carbonzipper

--- a/app/carbonzipper/http_handlers_test.go
+++ b/app/carbonzipper/http_handlers_test.go
@@ -925,8 +925,6 @@ func TestInfoSingleBackend(t *testing.T) {
 			t.Fatalf("got code %d expected %d for %s", w.Code, tst.code, tst.path)
 		}
 
-		t.Log(w.Body.String())
-
 		if w.Body.String() != tst.body {
 			t.Fatalf("unexpected body: want %q got %q", tst.body, w.Body.String())
 		}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"reflect"
-	"regexp"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -434,8 +433,6 @@ func TestParseExpr(t *testing.T) {
 		// for fixing golangci-lint: Using the variable on range scope `tt` in function literal
 		tt := ttr
 		t.Run(tt.s, func(t *testing.T) {
-			t.Logf("run case: go test -run 'TestParseExpr/%s'", regexp.QuoteMeta(tt.s))
-
 			e, _, err := ParseExpr(tt.s)
 			if err != tt.err {
 				t.Errorf(`parse for %+v expects error "%v" but received "%v"`, tt.s, tt.err, err)


### PR DESCRIPTION
## What issue is this change attempting to solve?
Fixes #365 

See https://github.com/bookingcom/carbonapi/issues/365#issuecomment-1149804051 for details.

In addition:
* removed unnecessary `govet` as it is not part of testing and is run by `golangci-lint`,
* removed superfluous build during the test.