### PR TITLE
Corrected floats comparison in a test to take into account limited precison of floating point numbers.

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -284,7 +284,7 @@ var (
 
 type floatEqualityFunc func(a, b float64) bool
 
-func areFloatsApproximatelyEqual(a, b float64) bool {
+func AreFloatsApproximatelyEqual(a, b float64) bool {
 	if a == b {
 		return true
 	}
@@ -350,7 +350,7 @@ func mergeMetrics(metrics []Metric, replicaMismatchConfig cfg.RenderReplicaMisma
 
 	var equalityFunc floatEqualityFunc
 	if replicaMismatchConfig.RenderReplicaMismatchApproximateCheck {
-		equalityFunc = areFloatsApproximatelyEqual
+		equalityFunc = AreFloatsApproximatelyEqual
 	}
 
 	replicaMatchMode := replicaMismatchConfig.RenderReplicaMatchMode

--- a/tests/helper.go
+++ b/tests/helper.go
@@ -277,11 +277,27 @@ func TestMultiReturnEvalExpr(t *testing.T, tt *MultiReturnEvalTestItem) {
 		if r[0].Name != gg.Name {
 			t.Errorf("result Name mismatch, got\n%#v,\nwant\n%#v", gg.Name, r[0].Name)
 		}
-		if !reflect.DeepEqual(r[0].Values, gg.Values) || !reflect.DeepEqual(r[0].IsAbsent, gg.IsAbsent) ||
+
+		// TODO (grzkv) : Reuse in other places when similar operation is done.
+		areValsEqual := true
+		if gg.Values == nil && r[0].Values != nil ||
+			gg.Values != nil && r[0].Values == nil ||
+			len(gg.Values) != len(r[0].Values) {
+			areValsEqual = false
+		} else {
+			for i := range gg.Values {
+				if !dataTypes.AreFloatsApproximatelyEqual(gg.Values[i], r[0].Values[i]) {
+					areValsEqual = false
+					break
+				}
+			}
+		}
+
+		if !areValsEqual || !reflect.DeepEqual(r[0].IsAbsent, gg.IsAbsent) ||
 			r[0].StartTime != gg.StartTime ||
 			r[0].StopTime != gg.StopTime ||
 			r[0].StepTime != gg.StepTime {
-			t.Errorf("result mismatch, got\n%#v,\nwant\n%#v", gg, r)
+			t.Errorf("result mismatch, got\n%#v,\nwant\n%#v", gg, r[0])
 		}
 	}
 }


### PR DESCRIPTION
## What issue is this change attempting to solve?
Fixes #367 

This fixes the reported issue. However, we have a similar problem in other places. Also, https://github.com/bookingcom/carbonapi/blob/4eaed1b90740618bda6e5e3c3e23e5c2ed6df368/tests/helper.go#L143 has a number of flaws and we need to replace it.

IMO we also need to do some more investigation on the method we currently use before applying it across the project.

This is why this approach is only applied locally now.

## How can we be sure this works as expected?
Failing tests pass now.
