### PR TITLE
Use noproxy dial option on grpc client

### DIFF
--- a/pkg/backend/net/grpc.go
+++ b/pkg/backend/net/grpc.go
@@ -30,7 +30,7 @@ func NewGrpc(cfg GrpcConfig) (*GrpcBackend, error) {
 	if err != nil {
 		return nil, err
 	}
-	conn, err := grpc.Dial(cfg.GrpcAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.Dial(cfg.GrpcAddress, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithNoProxy())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For http backend client, we do not respect the http proxy environment, so we should do the same on gRPC.