### PR TITLE
Fixing CI lint OOM.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,25 +18,23 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: install cairo
         run: sudo apt-get install libcairo2-dev -y
+      - name: setup linter
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v1.45.2
       - name: checkout code
         uses: actions/checkout@v2
       - name: test
         run: make test
+      - name: lint
+        run: make lint
       - name: integration test
         run: tests/system_test.sh
-  golangci:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.45.2
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-          # Optional: golangci-lint command line arguments.
-          #args: --new-from-rev=f7cdb31b6a6c8
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
+  # golangci:
+  #   name: lint
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: golangci-lint
+  #       uses: golangci/golangci-lint-action@v2
+  #       with:
+  #         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+  #         version: v1.45.2


### PR DESCRIPTION
Made linting a command instead of a separate job in CI.
Apparently, this fits better in the memory limits of GitHub actions and fixes #376 