### PR TITLE
carbonzipper(bug): add proper label to renderHandler

### DIFF
--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -308,7 +308,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, logger *
 	if ctx.Err() != nil {
 		// context was cancelled even if some of the requests succeeded
 		app.prometheusMetrics.RequestCancel.WithLabelValues(
-			"find", ctx.Err().Error(),
+			"render", ctx.Err().Error(),
 		).Inc()
 		span.SetAttribute("error", true)
 		span.SetAttribute("error.message", ctx.Err().Error())


### PR DESCRIPTION

## What issue is this change attempting to solve?
renderHandler of carbonzipper was using an incorrect
"find" label for a RequestCancel metric.

## How does this change solve the problem? Why is this the best approach?

## How can we be sure this works as expected?

