### PR TITLE
carbonapi(bug): fix UUID field in logs

### DIFF
--- a/app/carbonapi/http_handlers.go
+++ b/app/carbonapi/http_handlers.go
@@ -843,7 +843,7 @@ func (app *App) findHandler(w http.ResponseWriter, r *http.Request, logger *zap.
 		span.SetAttribute("graphite.total_metric_count", toLog.TotalMetricCount)
 	} else {
 		logger.Warn("zipper returned error in find request",
-			zap.String("uuid", util.GetUUID(ctx)),
+			zap.String("carbonapi_uuid", util.GetUUID(ctx)),
 			zap.Error(err),
 		)
 		var notFound dataTypes.ErrNotFound


### PR DESCRIPTION
## What issue is this change attempting to solve?

All log lines should contain carbonapi_uuid field in order to
allow traceability of requests. This commit is changing one specific
line where this field was wrongly named "uuid" making harder to trace
"zipper returned error in find request" errors


