### PR TITLE
Switched to a single labeled metric for the time in q in zipper. Start of zipper redesign.

### DIFF
--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -35,7 +35,7 @@ func (app *App) Start(logger *zap.Logger) {
 
 	httputil.PublishTrackedConnections("httptrack")
 
-	handler := initHandlers(app, logger)
+	handler := initHandlers(app, app.Metrics, logger)
 
 	if app.Config.Graphite.Pattern == "" {
 		app.Config.Graphite.Pattern = "{prefix}.{fqdn}"

--- a/app/carbonzipper/app.go
+++ b/app/carbonzipper/app.go
@@ -1,105 +1,52 @@
 package zipper
 
 import (
-	"context"
-	"expvar"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
-	"os"
-	"runtime"
-	"strings"
-	"sync/atomic"
 	"time"
+
+	bnet "github.com/bookingcom/carbonapi/pkg/backend/net"
 
 	"github.com/dgryski/go-expirecache"
 
 	"github.com/bookingcom/carbonapi/cfg"
-	"github.com/bookingcom/carbonapi/mstats"
 	"github.com/bookingcom/carbonapi/pkg/backend"
-	bnet "github.com/bookingcom/carbonapi/pkg/backend/net"
-	"github.com/bookingcom/carbonapi/pkg/trace"
-	"github.com/bookingcom/carbonapi/pkg/types"
-	"github.com/bookingcom/carbonapi/util"
 
 	"github.com/dgryski/httputil"
 	"github.com/facebookgo/grace/gracehttp"
-	"github.com/peterbourgon/g2g"
-	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
 
-// BuildVersion is replaced by ldflags
-var BuildVersion string
-
 // App represents the main zipper runnable
+// TODO: Remove.
 type App struct {
-	config              cfg.Zipper
-	prometheusMetrics   *PrometheusMetrics
-	backends            []backend.Backend
-	topLevelDomainCache *expirecache.Cache
-}
-
-// New inits backends and makes a new copy of the app. Does not run the app
-func New(config cfg.Zipper, logger *zap.Logger, buildVersion string) (*App, error) {
-	BuildVersion = buildVersion
-	bs, err := initBackends(config, logger)
-	if err != nil {
-		logger.Fatal("Failed to initialize backends",
-			zap.Error(err),
-		)
-		return nil, err
-	}
-
-	app := App{
-		config:              config,
-		prometheusMetrics:   NewPrometheusMetrics(config),
-		backends:            bs,
-		topLevelDomainCache: expirecache.New(0),
-	}
-	return &app, nil
+	Config              cfg.Zipper
+	Metrics             *PrometheusMetrics
+	Backends            []backend.Backend
+	TopLevelDomainCache *expirecache.Cache
 }
 
 // Start start launches the goroutines starts the app execution
-func (app *App) Start(logger *zap.Logger) func() {
-	flush := trace.InitTracer(BuildVersion, "carbonzipper", logger, app.config.Traces)
-
-	// Should print nicer stack traces in case of unexpected panic.
-	defer func() {
-		if r := recover(); r != nil {
-			logger.Fatal("Recovered from unhandled panic",
-				zap.Stack("stacktrace"),
-			)
-		}
-	}()
-
-	// +1 to track every over the number of buckets we track
-	timeBuckets = make([]int64, app.config.Buckets+1)
-	expTimeBuckets = make([]int64, app.config.Buckets+1)
+func (app *App) Start(logger *zap.Logger) {
+	timeBuckets = make([]int64, app.Config.Buckets+1)
+	expTimeBuckets = make([]int64, app.Config.Buckets+1)
 
 	httputil.PublishTrackedConnections("httptrack")
-	publishExpvarz(app)
 
 	handler := initHandlers(app, logger)
 
-	// nothing in the app.config? check the environment
-	if app.config.Graphite.Host == "" {
-		if host := os.Getenv("GRAPHITEHOST") + ":" + os.Getenv("GRAPHITEPORT"); host != ":" {
-			app.config.Graphite.Host = host
-		}
+	if app.Config.Graphite.Pattern == "" {
+		app.Config.Graphite.Pattern = "{prefix}.{fqdn}"
 	}
 
-	if app.config.Graphite.Pattern == "" {
-		app.config.Graphite.Pattern = "{prefix}.{fqdn}"
-	}
-
-	if app.config.Graphite.Prefix == "" {
-		app.config.Graphite.Prefix = "carbon.zipper"
+	if app.Config.Graphite.Prefix == "" {
+		app.Config.Graphite.Prefix = "carbon.zipper"
 	}
 
 	// only register g2g if we have a graphite host
-	if app.config.Graphite.Host != "" {
+	if app.Config.Graphite.Host != "" {
 		initGraphite(app)
 	}
 
@@ -108,80 +55,20 @@ func (app *App) Start(logger *zap.Logger) func() {
 
 	gracehttp.SetLogger(zap.NewStdLog(logger))
 	err := gracehttp.Serve(&http.Server{
-		Addr:         app.config.Listen,
+		Addr:         app.Config.Listen,
 		Handler:      handler,
 		ReadTimeout:  1 * time.Second,
-		WriteTimeout: app.config.Timeouts.Global * 2, // It has to be greater than Timeout.Global because we use that value as per-request context timeout
+		WriteTimeout: app.Config.Timeouts.Global * 2, // It has to be greater than Timeout.Global because we use that value as per-request context timeout
 	}, metricsServer)
 
 	if err != nil {
-		log.Fatal("error during gracehttp.Serve()",
-			zap.Error(err),
-		)
-	}
-	return flush
-}
-
-func (app *App) doProbe() {
-	topLevelDomainCache := make(map[string][]*backend.Backend)
-	for i := 0; i < len(app.backends); i++ {
-		topLevelDomains := getTopLevelDomains(app.backends[i])
-		for _, topLevelDomain := range topLevelDomains {
-			topLevelDomainCache[topLevelDomain] = append(topLevelDomainCache[topLevelDomain], &app.backends[i])
-		}
-	}
-	app.topLevelDomainCache.Set("tlds", topLevelDomainCache, 0, 2*app.config.InternalRoutingCache)
-}
-
-// Returns the backend's top-level domains.
-func getTopLevelDomains(backend backend.Backend) []string {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	request := types.NewFindRequest("*")
-	matches, err := backend.Find(ctx, request)
-	if err != nil {
-		return nil
-	}
-	var paths []string
-	for _, m := range matches.Matches {
-		paths = append(paths, m.Path)
-	}
-	return paths
-}
-
-func (app *App) probeTopLevelDomains() {
-	app.doProbe()
-	probeTicker := time.NewTicker(time.Duration(app.config.InternalRoutingCache) * time.Second)
-	for range probeTicker.C {
-		app.doProbe()
+		log.Fatal("error during gracehttp.Serve()", zap.Error(err))
 	}
 }
 
-func (app *App) bucketRequestTimes(req *http.Request, t time.Duration) {
-	ms := t.Nanoseconds() / int64(time.Millisecond)
-
-	bucket := int(ms / 100)
-	bucketIdx := findBucketIndex(timeBuckets, bucket)
-	atomic.AddInt64(&timeBuckets[bucketIdx], 1)
-
-	expBucket := util.Bucket(ms, app.config.Buckets)
-	expBucketIdx := findBucketIndex(expTimeBuckets, expBucket)
-	atomic.AddInt64(&expTimeBuckets[expBucketIdx], 1)
-
-	app.prometheusMetrics.DurationExp.Observe(t.Seconds())
-	app.prometheusMetrics.DurationLin.Observe(t.Seconds())
-
-	if req.URL.Path == "/render" || req.URL.Path == "/render/" {
-		app.prometheusMetrics.RenderDurationExp.Observe(t.Seconds())
-	}
-	if req.URL.Path == "/metrics/find" || req.URL.Path == "/metrics/find/" {
-		app.prometheusMetrics.FindDurationExp.Observe(t.Seconds())
-		app.prometheusMetrics.FindDurationLin.Observe(t.Seconds())
-	}
-}
-
-func initBackends(config cfg.Zipper, logger *zap.Logger) ([]backend.Backend, error) {
+// InitBackends inits backends.
+// TODO: Move to where the main func is.
+func InitBackends(config cfg.Zipper, logger *zap.Logger) ([]backend.Backend, error) {
 	client := &http.Client{}
 	client.Transport = &http.Transport{
 		MaxIdleConnsPerHost: config.MaxIdleConnsPerHost,
@@ -229,119 +116,4 @@ func initBackends(config cfg.Zipper, logger *zap.Logger) ([]backend.Backend, err
 	}
 
 	return backends, nil
-}
-
-func initGraphite(app *App) {
-	// register our metrics with graphite
-	graphite := g2g.NewGraphite(app.config.Graphite.Host, app.config.Graphite.Interval, 10*time.Second)
-
-	/* #nosec */
-	hostname, _ := os.Hostname()
-	hostname = strings.Replace(hostname, ".", "_", -1)
-
-	prefix := app.config.Graphite.Prefix
-
-	pattern := app.config.Graphite.Pattern
-	pattern = strings.Replace(pattern, "{prefix}", prefix, -1)
-	pattern = strings.Replace(pattern, "{fqdn}", hostname, -1)
-
-	graphite.Register(fmt.Sprintf("%s.requests", pattern), Metrics.Requests)
-	graphite.Register(fmt.Sprintf("%s.responses", pattern), Metrics.Responses)
-	graphite.Register(fmt.Sprintf("%s.errors", pattern), Metrics.Errors)
-
-	graphite.Register(fmt.Sprintf("%s.find_requests", pattern), Metrics.FindRequests)
-	graphite.Register(fmt.Sprintf("%s.find_errors", pattern), Metrics.FindErrors)
-
-	graphite.Register(fmt.Sprintf("%s.render_requests", pattern), Metrics.RenderRequests)
-	graphite.Register(fmt.Sprintf("%s.render_errors", pattern), Metrics.RenderErrors)
-
-	graphite.Register(fmt.Sprintf("%s.info_requests", pattern), Metrics.InfoRequests)
-	graphite.Register(fmt.Sprintf("%s.info_errors", pattern), Metrics.InfoErrors)
-
-	graphite.Register(fmt.Sprintf("%s.timeouts", pattern), Metrics.Timeouts)
-
-	for i := 0; i <= app.config.Buckets; i++ {
-		graphite.Register(fmt.Sprintf("%s.requests_in_%dms_to_%dms", pattern, i*100, (i+1)*100), bucketEntry(i))
-		lower, upper := util.Bounds(i)
-		graphite.Register(fmt.Sprintf("%s.exp.requests_in_%05dms_to_%05dms", pattern, lower, upper), expBucketEntry(i))
-	}
-
-	graphite.Register(fmt.Sprintf("%s.cache_size", pattern), Metrics.CacheSize)
-	graphite.Register(fmt.Sprintf("%s.cache_items", pattern), Metrics.CacheItems)
-
-	graphite.Register(fmt.Sprintf("%s.cache_hits", pattern), Metrics.CacheHits)
-	graphite.Register(fmt.Sprintf("%s.cache_misses", pattern), Metrics.CacheMisses)
-
-	go mstats.Start(app.config.Graphite.Interval)
-
-	graphite.Register(fmt.Sprintf("%s.goroutines", pattern), Metrics.Goroutines)
-	graphite.Register(fmt.Sprintf("%s.uptime", pattern), Metrics.Uptime)
-	graphite.Register(fmt.Sprintf("%s.alloc", pattern), &mstats.Alloc)
-	graphite.Register(fmt.Sprintf("%s.total_alloc", pattern), &mstats.TotalAlloc)
-	graphite.Register(fmt.Sprintf("%s.num_gc", pattern), &mstats.NumGC)
-	graphite.Register(fmt.Sprintf("%s.pause_ns", pattern), &mstats.PauseNS)
-}
-
-func metricsServer(app *App) *http.Server {
-	prometheus.MustRegister(app.prometheusMetrics.Requests)
-	prometheus.MustRegister(app.prometheusMetrics.Responses)
-	prometheus.MustRegister(app.prometheusMetrics.Renders)
-	prometheus.MustRegister(app.prometheusMetrics.RenderMismatches)
-	prometheus.MustRegister(app.prometheusMetrics.RenderFixedMismatches)
-	prometheus.MustRegister(app.prometheusMetrics.RenderMismatchedResponses)
-	prometheus.MustRegister(app.prometheusMetrics.FindNotFound)
-	prometheus.MustRegister(app.prometheusMetrics.RequestCancel)
-	prometheus.MustRegister(app.prometheusMetrics.DurationExp)
-	prometheus.MustRegister(app.prometheusMetrics.DurationLin)
-	prometheus.MustRegister(app.prometheusMetrics.RenderDurationExp)
-	prometheus.MustRegister(app.prometheusMetrics.RenderOutDurationExp)
-	prometheus.MustRegister(app.prometheusMetrics.FindDurationExp)
-	prometheus.MustRegister(app.prometheusMetrics.FindDurationLin)
-	prometheus.MustRegister(app.prometheusMetrics.FindOutDuration)
-	prometheus.MustRegister(app.prometheusMetrics.TimeInQueueExp)
-	prometheus.MustRegister(app.prometheusMetrics.TimeInQueueLin)
-
-	writeTimeout := app.config.Timeouts.Global
-	if writeTimeout < 30*time.Second {
-		writeTimeout = time.Minute
-	}
-
-	r := initMetricHandlers()
-
-	s := &http.Server{
-		Addr:         app.config.ListenInternal,
-		Handler:      r,
-		ReadTimeout:  1 * time.Second,
-		WriteTimeout: writeTimeout,
-	}
-
-	return s
-}
-
-func publishExpvarz(app *App) {
-	expvar.Publish("requestBuckets", expvar.Func(renderTimeBuckets))
-	expvar.Publish("expRequestBuckets", expvar.Func(renderExpTimeBuckets))
-
-	Metrics.Goroutines = expvar.Func(func() interface{} {
-		return runtime.NumGoroutine()
-	})
-	expvar.Publish("goroutines", Metrics.Goroutines)
-
-	startMinute := time.Now().Unix() / 60
-	Metrics.Uptime = expvar.Func(func() interface{} {
-		return time.Now().Unix()/60 - startMinute
-	})
-	expvar.Publish("uptime", Metrics.Uptime)
-
-	// export config via expvars
-	expvar.Publish("config", expvar.Func(func() interface{} { return app.config }))
-
-	/* Configure zipper */
-	// set up caches
-
-	Metrics.CacheSize = expvar.Func(func() interface{} { return app.config.PathCache.ECSize() })
-	expvar.Publish("cacheSize", Metrics.CacheSize)
-
-	Metrics.CacheItems = expvar.Func(func() interface{} { return app.config.PathCache.ECItems() })
-	expvar.Publish("cacheItems", Metrics.CacheItems)
 }

--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -47,7 +47,7 @@ const (
 	formatTypeProtobuf3 = "protobuf3"
 )
 
-func (app *App) findHandler(w http.ResponseWriter, req *http.Request, logger *zap.Logger) {
+func (app *App) findHandler(w http.ResponseWriter, req *http.Request, ms *PrometheusMetrics, logger *zap.Logger) {
 	t0 := time.Now()
 
 	ctx, cancel := context.WithTimeout(req.Context(), app.Config.Timeouts.Global)
@@ -189,7 +189,7 @@ func (app *App) findHandler(w http.ResponseWriter, req *http.Request, logger *za
 	)
 }
 
-func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, logger *zap.Logger) {
+func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, ms *PrometheusMetrics, logger *zap.Logger) {
 	t0 := time.Now()
 	memoryUsage := 0
 
@@ -405,7 +405,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, logger *
 	)
 }
 
-func (app *App) infoHandler(w http.ResponseWriter, req *http.Request, logger *zap.Logger) {
+func (app *App) infoHandler(w http.ResponseWriter, req *http.Request, ms *PrometheusMetrics, logger *zap.Logger) {
 	t0 := time.Now()
 
 	ctx, cancel := context.WithTimeout(req.Context(), app.Config.Timeouts.Global)
@@ -534,7 +534,7 @@ func (app *App) infoHandler(w http.ResponseWriter, req *http.Request, logger *za
 	)
 }
 
-func (app *App) lbCheckHandler(w http.ResponseWriter, req *http.Request, logger *zap.Logger) {
+func (app *App) lbCheckHandler(w http.ResponseWriter, req *http.Request, ms *PrometheusMetrics, logger *zap.Logger) {
 	t0 := time.Now()
 
 	if ce := logger.Check(zap.DebugLevel, "loadbalancer"); ce != nil {

--- a/app/carbonzipper/http_handlers.go
+++ b/app/carbonzipper/http_handlers.go
@@ -50,7 +50,7 @@ const (
 func (app *App) findHandler(w http.ResponseWriter, req *http.Request, logger *zap.Logger) {
 	t0 := time.Now()
 
-	ctx, cancel := context.WithTimeout(req.Context(), app.config.Timeouts.Global)
+	ctx, cancel := context.WithTimeout(req.Context(), app.Config.Timeouts.Global)
 	defer cancel()
 	span := trace.SpanFromContext(ctx)
 
@@ -64,7 +64,7 @@ func (app *App) findHandler(w http.ResponseWriter, req *http.Request, logger *za
 	format := req.FormValue("format")
 
 	Metrics.Requests.Add(1)
-	app.prometheusMetrics.Requests.Inc()
+	app.Metrics.Requests.Inc()
 	Metrics.FindRequests.Add(1)
 
 	logger = logger.With(
@@ -81,12 +81,12 @@ func (app *App) findHandler(w http.ResponseWriter, req *http.Request, logger *za
 	request := types.NewFindRequest(originalQuery)
 	bs := app.filterBackendByTopLevelDomain([]string{originalQuery})
 	bs = backend.Filter(bs, []string{originalQuery})
-	metrics, errs := backend.Finds(ctx, bs, request, app.prometheusMetrics.FindOutDuration)
+	metrics, errs := backend.Finds(ctx, bs, request, app.Metrics.FindOutDuration)
 	err := errorsFanIn(errs, len(bs))
 
 	if ctx.Err() != nil {
 		// context was cancelled even if some of the requests succeeded
-		app.prometheusMetrics.RequestCancel.WithLabelValues(
+		app.Metrics.RequestCancel.WithLabelValues(
 			"find", ctx.Err().Error(),
 		).Inc()
 	}
@@ -102,7 +102,7 @@ func (app *App) findHandler(w http.ResponseWriter, req *http.Request, logger *za
 			// that we found nothing on the monitoring side, so we claim we
 			// returned a 404 code to Prometheus.
 
-			app.prometheusMetrics.FindNotFound.Inc()
+			app.Metrics.FindNotFound.Inc()
 			logger.Info("not found",
 				zap.Error(err))
 			// TODO (grzkv) Should we return here?
@@ -115,7 +115,7 @@ func (app *App) findHandler(w http.ResponseWriter, req *http.Request, logger *za
 			)
 			http.Error(w, err.Error(), code)
 			Metrics.Errors.Add(1)
-			app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(code), "find").Inc()
+			app.Metrics.Responses.WithLabelValues(strconv.Itoa(code), "find").Inc()
 			return
 		}
 	}
@@ -143,7 +143,7 @@ func (app *App) findHandler(w http.ResponseWriter, req *http.Request, logger *za
 		blob, err = json.FindEncoder(metrics)
 	case formatTypeEmpty, formatTypePickle:
 		contentType = contentTypePickle
-		if app.config.GraphiteWeb09Compatibility {
+		if app.Config.GraphiteWeb09Compatibility {
 			blob, err = pickle.FindEncoderV0_9(metrics)
 		} else {
 			blob, err = pickle.FindEncoderV1_0(metrics)
@@ -161,7 +161,7 @@ func (app *App) findHandler(w http.ResponseWriter, req *http.Request, logger *za
 			zap.Error(err),
 		)
 		Metrics.Errors.Add(1)
-		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusInternalServerError), "find").Inc()
+		app.Metrics.Responses.WithLabelValues(strconv.Itoa(http.StatusInternalServerError), "find").Inc()
 		span.SetAttribute("error", true)
 		span.SetAttribute("error.message", err.Error())
 		return
@@ -172,7 +172,7 @@ func (app *App) findHandler(w http.ResponseWriter, req *http.Request, logger *za
 
 	if writeErr != nil {
 		Metrics.Errors.Add(1)
-		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(499), "find").Inc()
+		app.Metrics.Responses.WithLabelValues(strconv.Itoa(499), "find").Inc()
 		logger.Warn("error writing the response",
 			zap.Int("http_code", 499),
 			zap.Duration("runtime_seconds", time.Since(t0)),
@@ -182,7 +182,7 @@ func (app *App) findHandler(w http.ResponseWriter, req *http.Request, logger *za
 	}
 
 	Metrics.Responses.Add(1)
-	app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusOK), "find").Inc()
+	app.Metrics.Responses.WithLabelValues(strconv.Itoa(http.StatusOK), "find").Inc()
 	logger.Info("request served",
 		zap.Int("http_code", http.StatusOK),
 		zap.Duration("runtime_seconds", time.Since(t0)),
@@ -193,7 +193,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, logger *
 	t0 := time.Now()
 	memoryUsage := 0
 
-	ctx, cancel := context.WithTimeout(req.Context(), app.config.Timeouts.Global)
+	ctx, cancel := context.WithTimeout(req.Context(), app.Config.Timeouts.Global)
 	defer cancel()
 	span := trace.SpanFromContext(ctx)
 
@@ -204,7 +204,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, logger *
 	}
 
 	Metrics.Requests.Add(1)
-	app.prometheusMetrics.Requests.Inc()
+	app.Metrics.Requests.Inc()
 	Metrics.RenderRequests.Add(1)
 
 	logger = logger.With(
@@ -223,7 +223,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, logger *
 			zap.Error(err),
 		)
 		Metrics.Errors.Add(1)
-		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusBadRequest), "render").Inc()
+		app.Metrics.Responses.WithLabelValues(strconv.Itoa(http.StatusBadRequest), "render").Inc()
 		return
 	}
 
@@ -248,7 +248,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, logger *
 			zap.Error(err),
 		)
 		Metrics.Responses.Add(1)
-		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusBadRequest), "render").Inc()
+		app.Metrics.Responses.WithLabelValues(strconv.Itoa(http.StatusBadRequest), "render").Inc()
 		span.SetAttribute("error", true)
 		span.SetAttribute("error.message", "from is not a integer")
 		return
@@ -265,7 +265,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, logger *
 			zap.Error(err),
 		)
 		Metrics.Responses.Add(1)
-		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusBadRequest), "render").Inc()
+		app.Metrics.Responses.WithLabelValues(strconv.Itoa(http.StatusBadRequest), "render").Inc()
 		span.SetAttribute("error", true)
 		span.SetAttribute("error.message", "until is not a integer")
 		return
@@ -285,29 +285,27 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, logger *
 			zap.Duration("runtime_seconds", time.Since(t0)),
 		)
 		Metrics.Responses.Add(1)
-		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusBadRequest), "render").Inc()
+		app.Metrics.Responses.WithLabelValues(strconv.Itoa(http.StatusBadRequest), "render").Inc()
 		span.SetAttribute("error", true)
 		span.SetAttribute("error.message", "empty target")
 		return
 	}
 
 	request := types.NewRenderRequest([]string{target}, int32(from), int32(until))
-	request.Trace.OutDuration = app.prometheusMetrics.RenderOutDurationExp
+	request.Trace.OutDuration = app.Metrics.RenderOutDurationExp
 	bs := app.filterBackendByTopLevelDomain(request.Targets)
 	bs = backend.Filter(bs, request.Targets)
-	metrics, stats, errs := backend.Renders(ctx, bs, request, app.config.RenderReplicaMismatchConfig, logger)
-	app.prometheusMetrics.Renders.Add(float64(stats.DataPointCount))
-	app.prometheusMetrics.RenderMismatches.Add(float64(stats.MismatchCount))
-	app.prometheusMetrics.RenderFixedMismatches.Add(float64(stats.FixedMismatchCount))
+	metrics, stats, errs := backend.Renders(ctx, bs, request, app.Config.RenderReplicaMismatchConfig, logger)
+	app.Metrics.Renders.Add(float64(stats.DataPointCount))
+	app.Metrics.RenderMismatches.Add(float64(stats.MismatchCount))
+	app.Metrics.RenderFixedMismatches.Add(float64(stats.FixedMismatchCount))
 	err = errorsFanIn(errs, len(bs))
 	span.SetAttribute("graphite.metrics", len(metrics))
-	// time in queue is converted to ms
-	app.prometheusMetrics.TimeInQueueExp.Observe(float64(request.Trace.Report()[2]) / 1000 / 1000)
-	app.prometheusMetrics.TimeInQueueLin.Observe(float64(request.Trace.Report()[2]) / 1000 / 1000)
+	app.Metrics.TimeInQueue.WithLabelValues("render").Observe(float64(request.Trace.Report()[2]) / 1000 / 1000)
 
 	if ctx.Err() != nil {
 		// context was cancelled even if some of the requests succeeded
-		app.prometheusMetrics.RequestCancel.WithLabelValues(
+		app.Metrics.RequestCancel.WithLabelValues(
 			"render", ctx.Err().Error(),
 		).Inc()
 		span.SetAttribute("error", true)
@@ -339,7 +337,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, logger *
 			Metrics.Errors.Add(1)
 		}
 
-		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(code), "render").Inc()
+		app.Metrics.Responses.WithLabelValues(strconv.Itoa(code), "render").Inc()
 		span.SetAttribute("error", true)
 		span.SetAttribute("error.message", err.Error())
 		return
@@ -372,7 +370,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, logger *
 			zap.Int64s("trace", request.Trace.Report()),
 		)
 		Metrics.Errors.Add(1)
-		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusInternalServerError), "render").Inc()
+		app.Metrics.Responses.WithLabelValues(strconv.Itoa(http.StatusInternalServerError), "render").Inc()
 		span.SetAttribute("error", true)
 		span.SetAttribute("error.message", err.Error())
 
@@ -384,7 +382,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, logger *
 
 	if writeErr != nil {
 		Metrics.Errors.Add(1)
-		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(499), "render").Inc()
+		app.Metrics.Responses.WithLabelValues(strconv.Itoa(499), "render").Inc()
 		logger.Warn("error writing the response",
 			zap.Int("http_code", 499),
 			zap.Duration("runtime_seconds", time.Since(t0)),
@@ -394,9 +392,9 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, logger *
 	}
 
 	Metrics.Responses.Add(1)
-	app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusOK), "render").Inc()
+	app.Metrics.Responses.WithLabelValues(strconv.Itoa(http.StatusOK), "render").Inc()
 	if stats.MismatchCount > stats.FixedMismatchCount {
-		app.prometheusMetrics.RenderMismatchedResponses.Inc()
+		app.Metrics.RenderMismatchedResponses.Inc()
 	}
 
 	logger.Info("request served",
@@ -410,7 +408,7 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, logger *
 func (app *App) infoHandler(w http.ResponseWriter, req *http.Request, logger *zap.Logger) {
 	t0 := time.Now()
 
-	ctx, cancel := context.WithTimeout(req.Context(), app.config.Timeouts.Global)
+	ctx, cancel := context.WithTimeout(req.Context(), app.Config.Timeouts.Global)
 	defer cancel()
 
 	logger = logger.With(
@@ -421,7 +419,7 @@ func (app *App) infoHandler(w http.ResponseWriter, req *http.Request, logger *za
 	logger.Debug("request", zap.String("request", req.URL.RequestURI()))
 
 	Metrics.Requests.Add(1)
-	app.prometheusMetrics.Requests.Inc()
+	app.Metrics.Requests.Inc()
 	Metrics.InfoRequests.Add(1)
 
 	err := req.ParseForm()
@@ -434,7 +432,7 @@ func (app *App) infoHandler(w http.ResponseWriter, req *http.Request, logger *za
 			zap.Error(err),
 		)
 		Metrics.Errors.Add(1)
-		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusBadRequest), "info").Inc()
+		app.Metrics.Responses.WithLabelValues(strconv.Itoa(http.StatusBadRequest), "info").Inc()
 		return
 	}
 
@@ -454,7 +452,7 @@ func (app *App) infoHandler(w http.ResponseWriter, req *http.Request, logger *za
 		)
 		http.Error(w, "info: empty target", http.StatusBadRequest)
 		Metrics.Errors.Add(1)
-		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusBadRequest), "info").Inc()
+		app.Metrics.Responses.WithLabelValues(strconv.Itoa(http.StatusBadRequest), "info").Inc()
 		return
 	}
 
@@ -483,7 +481,7 @@ func (app *App) infoHandler(w http.ResponseWriter, req *http.Request, logger *za
 		)
 		http.Error(w, "info: error processing request", http.StatusInternalServerError)
 		Metrics.Errors.Add(1)
-		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusInternalServerError), "info").Inc()
+		app.Metrics.Responses.WithLabelValues(strconv.Itoa(http.StatusInternalServerError), "info").Inc()
 		return
 	}
 
@@ -509,7 +507,7 @@ func (app *App) infoHandler(w http.ResponseWriter, req *http.Request, logger *za
 			zap.Error(err),
 		)
 		Metrics.Errors.Add(1)
-		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusInternalServerError), "info").Inc()
+		app.Metrics.Responses.WithLabelValues(strconv.Itoa(http.StatusInternalServerError), "info").Inc()
 		return
 	}
 
@@ -518,7 +516,7 @@ func (app *App) infoHandler(w http.ResponseWriter, req *http.Request, logger *za
 
 	if writeErr != nil {
 		Metrics.Errors.Add(1)
-		app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(499), "info").Inc()
+		app.Metrics.Responses.WithLabelValues(strconv.Itoa(499), "info").Inc()
 		logger.Warn("error writing the response",
 			zap.Int("http_code", 499),
 			zap.Duration("runtime_seconds", time.Since(t0)),
@@ -528,7 +526,7 @@ func (app *App) infoHandler(w http.ResponseWriter, req *http.Request, logger *za
 	}
 
 	Metrics.Responses.Add(1)
-	app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusOK), "info").Inc()
+	app.Metrics.Responses.WithLabelValues(strconv.Itoa(http.StatusOK), "info").Inc()
 
 	logger.Info("request served",
 		zap.Int("http_code", http.StatusOK),
@@ -546,7 +544,7 @@ func (app *App) lbCheckHandler(w http.ResponseWriter, req *http.Request, logger 
 	}
 
 	Metrics.Requests.Add(1)
-	app.prometheusMetrics.Requests.Inc()
+	app.Metrics.Requests.Inc()
 
 	fmt.Fprintf(w, "Ok\n")
 	logger.Info("lb request served",
@@ -554,7 +552,7 @@ func (app *App) lbCheckHandler(w http.ResponseWriter, req *http.Request, logger 
 		zap.Duration("runtime_seconds", time.Since(t0)),
 	)
 	Metrics.Responses.Add(1)
-	app.prometheusMetrics.Responses.WithLabelValues(strconv.Itoa(http.StatusOK),
+	app.Metrics.Responses.WithLabelValues(strconv.Itoa(http.StatusOK),
 		"lbcheck").Inc()
 }
 
@@ -564,11 +562,11 @@ func (app *App) filterBackendByTopLevelDomain(targets []string) []backend.Backen
 		targetTlds = append(targetTlds, getTopLevelDomain(target))
 	}
 
-	bs := app.filterByTopLevelDomain(app.backends, targetTlds)
+	bs := app.filterByTopLevelDomain(app.Backends, targetTlds)
 	if len(bs) > 0 {
 		return bs
 	}
-	return app.backends
+	return app.Backends
 }
 
 func getTopLevelDomain(target string) string {
@@ -579,7 +577,7 @@ func (app *App) filterByTopLevelDomain(backends []backend.Backend, targetTLDs []
 	bs := make([]backend.Backend, 0)
 	allTLDBackends := make([]*backend.Backend, 0)
 
-	topLevelDomainCache, _ := app.topLevelDomainCache.Get("tlds")
+	topLevelDomainCache, _ := app.TopLevelDomainCache.Get("tlds")
 	tldCache := make(map[string][]*backend.Backend)
 	if x, ok := topLevelDomainCache.(map[string][]*backend.Backend); ok {
 		tldCache = x

--- a/app/carbonzipper/tldcache.go
+++ b/app/carbonzipper/tldcache.go
@@ -1,0 +1,45 @@
+package zipper
+
+import (
+	"context"
+	"time"
+
+	"github.com/bookingcom/carbonapi/pkg/backend"
+	"github.com/bookingcom/carbonapi/pkg/types"
+)
+
+func (app *App) doProbe() {
+	topLevelDomainCache := make(map[string][]*backend.Backend)
+	for i := 0; i < len(app.Backends); i++ {
+		topLevelDomains := getTopLevelDomains(app.Backends[i])
+		for _, topLevelDomain := range topLevelDomains {
+			topLevelDomainCache[topLevelDomain] = append(topLevelDomainCache[topLevelDomain], &app.Backends[i])
+		}
+	}
+	app.TopLevelDomainCache.Set("tlds", topLevelDomainCache, 0, 2*app.Config.InternalRoutingCache)
+}
+
+// Returns the backend's top-level domains.
+func getTopLevelDomains(backend backend.Backend) []string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	request := types.NewFindRequest("*")
+	matches, err := backend.Find(ctx, request)
+	if err != nil {
+		return nil
+	}
+	var paths []string
+	for _, m := range matches.Matches {
+		paths = append(paths, m.Path)
+	}
+	return paths
+}
+
+func (app *App) probeTopLevelDomains() {
+	app.doProbe()
+	probeTicker := time.NewTicker(time.Duration(app.Config.InternalRoutingCache) * time.Second)
+	for range probeTicker.C {
+		app.doProbe()
+	}
+}

--- a/pkg/backend/benchmark_test.go
+++ b/pkg/backend/benchmark_test.go
@@ -23,7 +23,7 @@ func BenchmarkRenders(b *testing.B) {
 
 	metrics := carbonapi_v2_pb.MultiFetchResponse{
 		Metrics: []*carbonapi_v2_pb.FetchResponse{
-			&carbonapi_v2_pb.FetchResponse{
+			{
 				Name:     "foo",
 				Values:   make([]float64, secPerHour),
 				IsAbsent: make([]bool, secPerHour),

--- a/pkg/backend/net/benchmark_test.go
+++ b/pkg/backend/net/benchmark_test.go
@@ -44,7 +44,7 @@ func BenchmarkCall(b *testing.B) {
 	trace := types.NewTrace()
 	u := bk.url("")
 	for i := 0; i < b.N; i++ {
-		bk.call(ctx, trace, u)
+		bk.call(ctx, trace, u, "")
 	}
 }
 

--- a/pkg/backend/net/net.go
+++ b/pkg/backend/net/net.go
@@ -50,9 +50,10 @@ type Backend struct {
 	client         *http.Client
 	timeout        time.Duration
 	limiter        *prioritylimiter.Limiter
-	logger         *zap.Logger
 	cache          *expirecache.Cache
 	cacheExpirySec int32
+
+	logger         *zap.Logger
 }
 
 // Config configures an HTTP backend.
@@ -297,7 +298,7 @@ func (b Backend) Render(ctx context.Context, request types.RenderRequest) ([]typ
 	u = carbonapiV2RenderEncoder(u, from, until, targets)
 	request.Trace.AddMarshal(t0)
 
-	contentType, resp, err := b.call(ctx, request.Trace, u)
+	contentType, resp, err := b.call(ctx, request.Trace, u, )
 	if err != nil {
 		if code, ok := err.(ErrHTTPCode); ok && code == http.StatusNotFound {
 			return nil, types.ErrMetricsNotFound

--- a/pkg/backend/net/net_test.go
+++ b/pkg/backend/net/net_test.go
@@ -103,7 +103,7 @@ func TestCall(t *testing.T) {
 		return
 	}
 
-	_, got, err := b.call(context.Background(), types.NewTrace(), b.url("/render"))
+	_, got, err := b.call(context.Background(), types.NewTrace(), b.url("/render"), "render")
 	if err != nil {
 		t.Error(err)
 	}
@@ -128,7 +128,7 @@ func TestCallServerError(t *testing.T) {
 		return
 	}
 
-	_, _, err = b.call(context.Background(), types.NewTrace(), b.url("/render"))
+	_, _, err = b.call(context.Background(), types.NewTrace(), b.url("/render"), "render")
 	if err == nil {
 		t.Error("Expected error")
 	}
@@ -147,7 +147,7 @@ func TestCallTimeout(t *testing.T) {
 		return
 	}
 
-	_, _, err = b.call(context.Background(), types.NewTrace(), b.url("/render"))
+	_, _, err = b.call(context.Background(), types.NewTrace(), b.url("/render"), "render")
 	if err == nil {
 		t.Error("Expected error")
 	}
@@ -170,7 +170,7 @@ func TestCallLimiterTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 0)
 	defer cancel()
 
-	_, _, err = b.call(ctx, types.NewTrace(), b.url("/render"))
+	_, _, err = b.call(ctx, types.NewTrace(), b.url("/render"), "render")
 	if err == nil {
 		t.Error("Expected to time out")
 	}
@@ -193,7 +193,7 @@ func TestCallTimeoutLeavesLimiter(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 0)
 	defer cancel()
 
-	_, _, err = b.call(ctx, types.NewTrace(), b.url("/render"))
+	_, _, err = b.call(ctx, types.NewTrace(), b.url("/render"), "render")
 	if err == nil {
 		t.Error("Expected to time out")
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -76,8 +76,7 @@ func NewRenderRequest(targets []string, from int32, until int32) RenderRequest {
 	}
 }
 
-// TODO (grzkv): Move to a separate package
-
+// TODO: Remove.
 type Trace struct {
 	callCount     *int64
 	inMarshalNS   *int64


### PR DESCRIPTION
Note: This PR includes unfinished refactoring. Some rough edges are to be expected.

## What issue is this change attempting to solve?
* Fixes time in queue for zipper stats.
* Refactoring/redesign of the zipper.
  * Removed parts of the global state
  * Partially removed expvars
  * Restructured modules
  * Misc cleanups