### PR TITLE
Emadolsky/fix limiter on grpc render

### DIFF
--- a/pkg/app/zipper/http_handlers.go
+++ b/pkg/app/zipper/http_handlers.go
@@ -154,7 +154,7 @@ func (app *App) findHandler(w http.ResponseWriter, req *http.Request, ms *Promet
 
 	if err != nil {
 		http.Error(w, "error marshaling data", http.StatusInternalServerError)
-		logger.Error("render failed",
+		logger.Error("find failed",
 			zap.Int("http_code", http.StatusInternalServerError),
 			zap.String("reason", "error marshaling data"),
 			zap.Duration("runtime_seconds", time.Since(t0)),

--- a/pkg/backend/net/grpc.go
+++ b/pkg/backend/net/grpc.go
@@ -75,13 +75,9 @@ func (gb *GrpcBackend) Render(ctx context.Context, request types.RenderRequest) 
 
 	ctx, cancel := gb.setTimeout(ctx)
 	defer cancel()
-	stream, err := gb.carbonV2Client.Render(ctx, multiFetchRequest, grpc.MaxCallRecvMsgSize(gb.maxRecvMsgSize))
-	if err != nil {
-		return nil, err
-	}
 
 	t1 := time.Now()
-	err = gb.enter(ctx)
+	err := gb.enter(ctx)
 	request.Trace.AddLimiter(t1)
 	if err != nil {
 		return nil, err
@@ -95,6 +91,11 @@ func (gb *GrpcBackend) Render(ctx context.Context, request types.RenderRequest) 
 			)
 		}
 	}()
+
+	stream, err := gb.carbonV2Client.Render(ctx, multiFetchRequest, grpc.MaxCallRecvMsgSize(gb.maxRecvMsgSize))
+	if err != nil {
+		return nil, err
+	}
 
 	var fetchedMetrics []types.Metric
 	for {


### PR DESCRIPTION
## What issue is this change attempting to solve?
Request limiter in gRPC render was used wrong. It should prevent backend client to go on and send the request to storages but it didn't.  

## How does this change solve the problem? Why is this the best approach?
Send the request and get the stream after the request is passed through limiter.