### PR TITLE
Improve backend-related metrics in zipper

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 1m
+  timeout: 2m
   tests: true
   build-tags: [ cairo ]
   skip-dirs: []

--- a/pkg/app/zipper/app.go
+++ b/pkg/app/zipper/app.go
@@ -98,6 +98,7 @@ func InitBackends(config cfg.Zipper, ms *PrometheusMetrics, logger *zap.Logger) 
 			Limit:              config.ConcurrencyLimitPerServer,
 			PathCacheExpirySec: uint32(config.ExpireDelaySec),
 			QHist:              ms.TimeInQueueSeconds,
+			Responses:          ms.BackendResponses,
 			Logger:             logger,
 		}
 		if host.Grpc != "" {

--- a/pkg/backend/rpc.go
+++ b/pkg/backend/rpc.go
@@ -166,11 +166,11 @@ func Finds(ctx context.Context, backends []Backend, request types.FindRequest, d
 }
 
 // Filter filters the given backends by whether they Contain() the given targets.
-func Filter(backends []Backend, targets []string) []Backend {
+func Filter(backends []Backend, targets []string) ([]Backend, bool) {
 	if bs := filter(backends, targets); len(bs) > 0 {
-		return bs
+		return bs, true
 	}
-	return backends
+	return backends, false
 }
 
 func filter(backends []Backend, targets []string) []Backend {

--- a/pkg/backend/rpc_test.go
+++ b/pkg/backend/rpc_test.go
@@ -23,7 +23,10 @@ func TestFilter(t *testing.T) {
 		}),
 	}
 
-	got := Filter(backends, nil)
+	got, filtered := Filter(backends, nil)
+	if !filtered {
+		t.Errorf("Expected to be filtered, but remained unfiltered")
+	}
 	if len(got) != 1 {
 		t.Errorf("Expected 1 backend, got %d", len(got))
 	}
@@ -36,7 +39,10 @@ func TestFilterNoneContains(t *testing.T) {
 		}),
 	}
 
-	got := Filter(backends, nil)
+	got, filtered := Filter(backends, nil)
+	if filtered {
+		t.Errorf("Expected to remain unfiltered, but filtered")
+	}
 	if len(got) != 1 {
 		t.Errorf("Expected 1 backend, got %d", len(got))
 	}


### PR DESCRIPTION
- Introduced path cache filter metric: A counter to count the number of successful backend filters on zipper.
- Introduced backend status metric: A counterVec to count the status codes received from the storage backends.
- Added TimeInQueue histogram observation to gRPC backend calls as well as HTTP calls.
