### PR TITLE
Add 'enableCacheForRenderResolveGlobs' config param

### DIFF
--- a/config/carbonapi.yaml
+++ b/config/carbonapi.yaml
@@ -61,6 +61,10 @@ resolveGlobs: 100
 # For some backends you might want to set it to 0
 # If you noticing carbonzipper OOM then this is a parameter to tune.
 
+# Indicates if carbonapi should use cache when sending preflight find requests to resolve the globs.
+# Note that useCache parameter should be sent in the request for this config to be taken into account.
+enableCacheForRenderResolveGlobs: false
+
 # functionsConfigs:
 #     graphiteWeb: ./graphiteWeb.example.yaml
 

--- a/pkg/app/carbonapi/http_handlers.go
+++ b/pkg/app/carbonapi/http_handlers.go
@@ -412,7 +412,8 @@ func (app *App) getTargetData(ctx context.Context, target string, exp parser.Exp
 		}
 
 		// This _sometimes_ sends a *find* request
-		renderRequests, err := app.getRenderRequests(ctx, m, useCache, toLog)
+		useCacheForRenderResolveGlobs := useCache && app.config.EnableCacheForRenderResolveGlobs
+		renderRequests, err := app.getRenderRequests(ctx, m, useCacheForRenderResolveGlobs, toLog)
 		if err != nil {
 			metricErrs = append(metricErrs, err)
 			continue

--- a/pkg/cfg/api.go
+++ b/pkg/cfg/api.go
@@ -84,13 +84,14 @@ type API struct {
 
 	// TODO (grzkv): Move backends list to a single backend here
 
-	ResolveGlobs            int           `yaml:"resolveGlobs"`
-	Cache                   CacheConfig   `yaml:"cache"`
-	TimezoneString          string        `yaml:"tz"`
-	PidFile                 string        `yaml:"pidFile"`
-	BlockHeaderFile         string        `yaml:"blockHeaderFile"`
-	BlockHeaderUpdatePeriod time.Duration `yaml:"blockHeaderUpdatePeriod"`
-	HeadersToLog            []string      `yaml:"headersToLog"`
+	ResolveGlobs                     int           `yaml:"resolveGlobs"`
+	EnableCacheForRenderResolveGlobs bool          `yaml:"enableCacheForRenderResolveGlobs"`
+	Cache                            CacheConfig   `yaml:"cache"`
+	TimezoneString                   string        `yaml:"tz"`
+	PidFile                          string        `yaml:"pidFile"`
+	BlockHeaderFile                  string        `yaml:"blockHeaderFile"`
+	BlockHeaderUpdatePeriod          time.Duration `yaml:"blockHeaderUpdatePeriod"`
+	HeadersToLog                     []string      `yaml:"headersToLog"`
 
 	UnicodeRangeTables        []string          `yaml:"unicodeRangeTables"`
 	IgnoreClientTimeout       bool              `yaml:"ignoreClientTimeout"`


### PR DESCRIPTION
For carbonapi. This parameter allows us to trigger usage of cache for render resolve globs (preflight find requests).
