### PR TITLE
Add tld cache extra prefixes to zipper

### DIFF
--- a/cmd/carbonzipper/main.go
+++ b/cmd/carbonzipper/main.go
@@ -76,6 +76,7 @@ func main() {
 		Metrics:             ms,
 		Backends:            bs,
 		TopLevelDomainCache: expirecache.New(0),
+		TLDPrefixes:         zipper.InitTLDPrefixes(logger, config.TLDCacheExtraPrefixes),
 	}
 
 	flush := trace.InitTracer(BuildVersion, "carbonzipper", logger, app.Config.Traces)

--- a/config/carbonzipper.yaml
+++ b/config/carbonzipper.yaml
@@ -39,6 +39,17 @@ maxIdleConnsPerHost: 100
 # Default: 600 (10 minutes)
 expireDelaySec: 120
 
+# In addition to first namespace of metrics as TLDs, zipper tries
+# to query for namespaces of these prefixes. This is helpful if some metrics
+# are not divided in the backends by only the first namespace.
+# e.g. by configuring:
+#
+# tldCacheExtraPrefixes:
+#   - carbon
+#
+# zipper sends 'carbon.*' find query to the 'carbon' tld backends, and extracts 'carbon.agents'
+# and any other trailing namespaces of 'carbon' from them.
+
 # "http://host:port" array of instances of carbonserver stores
 # This is the *ONLY* config element that MUST be specified.
 backendsByDC:

--- a/pkg/app/zipper/app.go
+++ b/pkg/app/zipper/app.go
@@ -26,6 +26,7 @@ type App struct {
 	Metrics             *PrometheusMetrics
 	Backends            []backend.Backend
 	TopLevelDomainCache *expirecache.Cache
+	TLDPrefixes         []tldPrefix
 }
 
 // Start start launches the goroutines starts the app execution

--- a/pkg/app/zipper/http_handlers.go
+++ b/pkg/app/zipper/http_handlers.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/bookingcom/carbonapi/pkg/backend"
@@ -570,7 +569,7 @@ func (app *App) lbCheckHandler(w http.ResponseWriter, req *http.Request, ms *Pro
 func (app *App) filterBackendByTopLevelDomain(targets []string) []backend.Backend {
 	targetTlds := make([]string, 0, len(targets))
 	for _, target := range targets {
-		targetTlds = append(targetTlds, getTopLevelDomain(target, app.Config.TLDCacheExtraPrefixes))
+		targetTlds = append(targetTlds, getTargetTopLevelDomain(target, app.TLDPrefixes))
 	}
 
 	bs := app.filterByTopLevelDomain(app.Backends, targetTlds)
@@ -578,21 +577,6 @@ func (app *App) filterBackendByTopLevelDomain(targets []string) []backend.Backen
 		return bs
 	}
 	return app.Backends
-}
-
-func getTopLevelDomain(target string, extraPrefixes []string) string {
-	tld := strings.SplitN(target, ".", 2)[0]
-	for _, prefix := range extraPrefixes {
-		if strings.HasPrefix(target, prefix) {
-			nsCount := strings.Count(prefix, ".") + 1
-			splitTarget := strings.SplitN(target, ".", nsCount+2)  // prefix + ns | rest
-			foundTLD := strings.Join(splitTarget[:nsCount+1], ".") // prefix + ns
-			if len(foundTLD) > len(tld) {
-				tld = foundTLD
-			}
-		}
-	}
-	return tld
 }
 
 func (app *App) filterByTopLevelDomain(backends []backend.Backend, targetTLDs []string) []backend.Backend {

--- a/pkg/app/zipper/http_handlers_test.go
+++ b/pkg/app/zipper/http_handlers_test.go
@@ -965,3 +965,39 @@ func getMetricGlobResponse(metric string) types.Matches {
 
 	return types.Matches{}
 }
+
+func TestGetTopLevelDomain(t *testing.T) {
+	var tt = []struct {
+		target   string
+		prefixes []string
+		outTLD   string
+	}{
+		{
+			target:   "a.b.f.g.h",
+			prefixes: []string{"a.b", "a.b.c", "v", "b"},
+			outTLD:   "a.b.f",
+		},
+		{
+			target:   "a.b.c.g.h",
+			prefixes: []string{"a.b", "a.b.c", "v", "b"},
+			outTLD:   "a.b.c.g",
+		},
+		{
+			target:   "a.h.f.g.h",
+			prefixes: []string{"a.b", "a.b.c", "v", "b"},
+			outTLD:   "a",
+		},
+		{
+			target:   "b.h.f.g.h",
+			prefixes: []string{"a.b", "a.b.c", "v", "b"},
+			outTLD:   "b.h",
+		},
+	}
+
+	for _, tst := range tt {
+		tld := getTopLevelDomain(tst.target, tst.prefixes)
+		if tld != tst.outTLD {
+			t.Fatalf("unexpected tld: expected %+v, got %+v", tst.outTLD, tld)
+		}
+	}
+}

--- a/pkg/app/zipper/http_handlers_test.go
+++ b/pkg/app/zipper/http_handlers_test.go
@@ -965,39 +965,3 @@ func getMetricGlobResponse(metric string) types.Matches {
 
 	return types.Matches{}
 }
-
-func TestGetTopLevelDomain(t *testing.T) {
-	var tt = []struct {
-		target   string
-		prefixes []string
-		outTLD   string
-	}{
-		{
-			target:   "a.b.f.g.h",
-			prefixes: []string{"a.b", "a.b.c", "v", "b"},
-			outTLD:   "a.b.f",
-		},
-		{
-			target:   "a.b.c.g.h",
-			prefixes: []string{"a.b", "a.b.c", "v", "b"},
-			outTLD:   "a.b.c.g",
-		},
-		{
-			target:   "a.h.f.g.h",
-			prefixes: []string{"a.b", "a.b.c", "v", "b"},
-			outTLD:   "a",
-		},
-		{
-			target:   "b.h.f.g.h",
-			prefixes: []string{"a.b", "a.b.c", "v", "b"},
-			outTLD:   "b.h",
-		},
-	}
-
-	for _, tst := range tt {
-		tld := getTopLevelDomain(tst.target, tst.prefixes)
-		if tld != tst.outTLD {
-			t.Fatalf("unexpected tld: expected %+v, got %+v", tst.outTLD, tld)
-		}
-	}
-}

--- a/pkg/app/zipper/tldcache.go
+++ b/pkg/app/zipper/tldcache.go
@@ -6,22 +6,24 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
 	"github.com/bookingcom/carbonapi/pkg/backend"
 	"github.com/bookingcom/carbonapi/pkg/types"
-	"github.com/pkg/errors"
 )
+
+type tldPrefix struct {
+	prefix        string
+	segments      []string
+	segmentsCount int
+}
 
 func (app *App) probeTopLevelDomains(ms *PrometheusMetrics) {
 	probeTicker := time.NewTicker(time.Duration(app.Config.InternalRoutingCache) * time.Second) // TODO: The ticker resources are never freed
 	for {
 		topLevelDomainCache := make(map[string][]*backend.Backend)
-		// We should always have empty prefix to get default TLDs
-		allPrefixes := []string{""}
-		allPrefixes = append(allPrefixes, app.Config.TLDCacheExtraPrefixes...)
-		// Sorting to avoid involving unnecessary backends
-		sortedPrefixes := sortedByNsCount(allPrefixes)
-		for _, prefix := range sortedPrefixes {
-			prefix = trimPrefix(prefix)
+		for _, prefix := range app.TLDPrefixes {
 			bs := getBackendsForPrefix(prefix, app.Backends, topLevelDomainCache)
 			for i := range bs {
 				topLevelDomains, err := getTopLevelDomains(*bs[i], prefix)
@@ -45,39 +47,19 @@ func (app *App) probeTopLevelDomains(ms *PrometheusMetrics) {
 	}
 }
 
-type tldPrefix struct {
-	prefix  string
-	nsCount int
-}
-
-func sortedByNsCount(prefixes []string) []string {
-	countedPrefixes := make([]tldPrefix, len(prefixes))
-	for i, prefix := range prefixes {
-		nsCount := 0
-		if prefix != "" {
-			nsCount = strings.Count(prefix, ".") + 1
-		}
-		countedPrefixes[i] = tldPrefix{
-			prefix:  prefix,
-			nsCount: nsCount,
-		}
+func (p *tldPrefix) query() string {
+	query := "*"
+	if p.prefix != "" {
+		query = p.prefix + ".*"
 	}
-	sort.Slice(countedPrefixes, func(i, j int) bool {
-		return countedPrefixes[i].nsCount < countedPrefixes[j].nsCount
-	})
-	sortedPrefixes := make([]string, len(prefixes))
-	for i := range countedPrefixes {
-		sortedPrefixes[i] = countedPrefixes[i].prefix
-	}
-	return sortedPrefixes
+	return query
 }
 
 // getBackendsForPrefix returns the backends that need to be queried in order to populate TLD cache for the prefix.
-// it reuses already fetched tlds to find out about the info. if no info is there, it returns all the backends.
-func getBackendsForPrefix(prefix string, backends []backend.Backend, tldCache map[string][]*backend.Backend) []*backend.Backend {
-	segments := strings.Split(prefix, ".")
-	for i := len(segments); i > 0; i-- {
-		p := strings.Join(segments[:i], ".")
+// It reuses already fetched tlds to find out about the info. If no info is there, it returns all the backends.
+func getBackendsForPrefix(prefix tldPrefix, backends []backend.Backend, tldCache map[string][]*backend.Backend) []*backend.Backend {
+	for i := prefix.segmentsCount; i > 0; i-- {
+		p := strings.Join(prefix.segments[:i], ".")
 		if filteredBackends, ok := tldCache[p]; ok {
 			return filteredBackends
 		}
@@ -89,20 +71,12 @@ func getBackendsForPrefix(prefix string, backends []backend.Backend, tldCache ma
 	return allBackends
 }
 
-func trimPrefix(prefix string) string {
-	return strings.Trim(prefix, ".*")
-}
-
 // Returns the backend's top-level domains.
-func getTopLevelDomains(backend backend.Backend, prefix string) ([]string, error) {
+func getTopLevelDomains(backend backend.Backend, prefix tldPrefix) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	query := "*"
-	if prefix != "" {
-		query = prefix + ".*"
-	}
-	request := types.NewFindRequest(query)
+	request := types.NewFindRequest(prefix.query())
 	matches, err := backend.Find(ctx, request)
 	if err != nil {
 		return nil, errors.Wrap(err, "find request failed")
@@ -112,4 +86,57 @@ func getTopLevelDomains(backend backend.Backend, prefix string) ([]string, error
 		paths = append(paths, m.Path)
 	}
 	return paths, nil
+}
+
+// InitTLDPrefixes gets unprocessed prefixes read from config, validates them (discards invalid ones),
+// and sorts them in ascending order
+func InitTLDPrefixes(logger *zap.Logger, cfgPrefixes []string) []tldPrefix {
+	tldPrefixes := []tldPrefix{
+		// We should always have empty prefix to get default TLDs
+		{prefix: "", segments: nil, segmentsCount: 0},
+	}
+
+	for _, p := range cfgPrefixes {
+		segments := strings.Split(p, ".")
+		var invalid bool
+		for _, s := range segments {
+			if s == "" {
+				invalid = true
+				break
+			}
+		}
+		if invalid {
+			logger.Warn("tld prefix invalid", zap.String("prefix", p))
+			continue
+		}
+		tldPrefixes = append(tldPrefixes, tldPrefix{
+			prefix:        p,
+			segments:      segments,
+			segmentsCount: len(segments),
+		})
+	}
+	// Sorting to avoid involving unnecessary backends and to optimize identifying query TLDs
+	sort.Slice(tldPrefixes, func(i, j int) bool {
+		return tldPrefixes[i].segmentsCount < tldPrefixes[j].segmentsCount
+	})
+	var uniqueTLDPrefixes []tldPrefix
+	for i := range tldPrefixes {
+		if i == 0 || tldPrefixes[i].prefix != tldPrefixes[i-1].prefix {
+			uniqueTLDPrefixes = append(uniqueTLDPrefixes, tldPrefixes[i])
+		}
+	}
+	return uniqueTLDPrefixes
+}
+
+func getTargetTopLevelDomain(target string, prefixes []tldPrefix) string {
+	tld := strings.SplitN(target, ".", 2)[0]
+	for i := len(prefixes) - 1; i >= 0; i-- {
+		p := prefixes[i]
+		if strings.HasPrefix(target, p.prefix) {
+			splitTarget := strings.SplitN(target, ".", p.segmentsCount+2)  // prefix + ns | rest
+			foundTLD := strings.Join(splitTarget[:p.segmentsCount+1], ".") // prefix + ns
+			return foundTLD
+		}
+	}
+	return tld
 }

--- a/pkg/app/zipper/tldcache_test.go
+++ b/pkg/app/zipper/tldcache_test.go
@@ -1,0 +1,107 @@
+package zipper
+
+import (
+	"github.com/bookingcom/carbonapi/pkg/backend"
+	"github.com/bookingcom/carbonapi/pkg/backend/mock"
+	"reflect"
+	"testing"
+)
+
+func TestGetBackendsForPrefix(t *testing.T) {
+	allBackends := []backend.Backend{
+		mock.Backend{Address: "0"},
+		mock.Backend{Address: "1"},
+		mock.Backend{Address: "2"},
+		mock.Backend{Address: "3"},
+	}
+	var tt = []struct {
+		prefix      string
+		backends    []backend.Backend
+		tldCache    map[string][]*backend.Backend
+		outBackends []*backend.Backend
+	}{
+		{
+			prefix:      "",
+			backends:    allBackends,
+			tldCache:    map[string][]*backend.Backend{},
+			outBackends: []*backend.Backend{&allBackends[0], &allBackends[1], &allBackends[2], &allBackends[3]},
+		},
+		{
+			prefix:   "a",
+			backends: allBackends,
+			tldCache: map[string][]*backend.Backend{
+				"b": {&allBackends[0], &allBackends[1]},
+				"c": {&allBackends[2], &allBackends[3]},
+			},
+			outBackends: []*backend.Backend{&allBackends[0], &allBackends[1], &allBackends[2], &allBackends[3]},
+		},
+		{
+			prefix:   "a",
+			backends: allBackends,
+			tldCache: map[string][]*backend.Backend{
+				"a": {&allBackends[0], &allBackends[1]},
+				"c": {&allBackends[2], &allBackends[3]},
+			},
+			outBackends: []*backend.Backend{&allBackends[0], &allBackends[1]},
+		},
+		{
+			prefix:   "a.b.c",
+			backends: allBackends,
+			tldCache: map[string][]*backend.Backend{
+				"a": {&allBackends[0], &allBackends[1]},
+				"c": {&allBackends[2], &allBackends[3]},
+			},
+			outBackends: []*backend.Backend{&allBackends[0], &allBackends[1]},
+		},
+		{
+			prefix:   "a.b.c",
+			backends: allBackends,
+			tldCache: map[string][]*backend.Backend{
+				"a":   {&allBackends[0], &allBackends[1]},
+				"c":   {&allBackends[2], &allBackends[3]},
+				"a.b": {&allBackends[1]},
+			},
+			outBackends: []*backend.Backend{&allBackends[1]},
+		},
+	}
+
+	for _, tst := range tt {
+		bs := getBackendsForPrefix(tst.prefix, tst.backends, tst.tldCache)
+		if len(bs) != len(tst.outBackends) {
+			t.Fatalf("unexpected number of backends: expected %d, got %d", len(tst.outBackends), len(bs))
+		}
+		for i := range bs {
+			if (*bs[i]).GetServerAddress() != (*tst.outBackends[i]).GetServerAddress() {
+				t.Fatalf("unexpected backend at position %d: expected backend %s, actual %s",
+					i, (*tst.outBackends[i]).GetServerAddress(), (*bs[i]).GetServerAddress())
+			}
+		}
+	}
+}
+
+func TestSortedByNsCount(t *testing.T) {
+	var tt = []struct {
+		prefixes    []string
+		outPrefixes []string
+	}{
+		{
+			prefixes:    []string{"a.b", "", "a.b.c", "a"},
+			outPrefixes: []string{"", "a", "a.b", "a.b.c"},
+		},
+		{
+			prefixes:    []string{"a.b.c", "a", "a.a.a"},
+			outPrefixes: []string{"a", "a.b.c", "a.a.a"},
+		},
+		{
+			prefixes:    []string{""},
+			outPrefixes: []string{""},
+		},
+	}
+
+	for _, tst := range tt {
+		res := sortedByNsCount(tst.prefixes)
+		if !reflect.DeepEqual(res, tst.outPrefixes) {
+			t.Fatalf("unexpected sort: expected %+v, got %+v", tst.outPrefixes, res)
+		}
+	}
+}

--- a/pkg/backend/mock/mock.go
+++ b/pkg/backend/mock/mock.go
@@ -22,6 +22,7 @@ import (
 
 // Backend is a mock backend.
 type Backend struct {
+	Address  string
 	find     func(context.Context, types.FindRequest) (types.Matches, error)
 	info     func(context.Context, types.InfoRequest) ([]types.Info, error)
 	render   func(context.Context, types.RenderRequest) ([]types.Metric, error)
@@ -100,7 +101,7 @@ func (b Backend) Contains(targets []string) bool {
 }
 
 func (b Backend) GetServerAddress() string {
-	return ""
+	return b.Address
 }
 
 func (b Backend) GetCluster() string {

--- a/pkg/cfg/common.go
+++ b/pkg/cfg/common.go
@@ -177,9 +177,10 @@ type Common struct {
 	KeepAliveInterval         time.Duration `yaml:"keepAliveInterval"`
 	MaxIdleConnsPerHost       int           `yaml:"maxIdleConnsPerHost"`
 
-	ExpireDelaySec             int32 `yaml:"expireDelaySec"`
-	InternalRoutingCache       int32 `yaml:"internalRoutingCache"`
-	GraphiteWeb09Compatibility bool  `yaml:"graphite09compat"`
+	ExpireDelaySec             int32    `yaml:"expireDelaySec"`
+	InternalRoutingCache       int32    `yaml:"internalRoutingCache"`
+	TLDCacheExtraPrefixes      []string `yaml:"tldCacheExtraPrefixes"`
+	GraphiteWeb09Compatibility bool     `yaml:"graphite09compat"`
 
 	Buckets      int            `yaml:"buckets"`
 	Graphite     GraphiteConfig `yaml:"graphite"`


### PR DESCRIPTION
## What issue is this change attempting to solve?
This new config adds the functionality to probe deeper paths on zipper in order to involve less backends on queries when metrics are broken into different cluster from the non-leading namespaces.

## How does this change solve the problem? Why is this the best approach?
In addition to normal TLD probes, probes with the configured prefixes are also sent. the results already gathered from the previous probes sent at the same iteration is used to optimize the backends receiving the probes.

## How can we be sure this works as expected?
New tests are introduced and the functionality is manually tested on local.
