### PR TITLE
Fixing out of index error during metric sorting

### DIFF
--- a/expr/sort.go
+++ b/expr/sort.go
@@ -121,9 +121,9 @@ func sortByBraces(metrics []*types.MetricData, part int, pattern string) {
 	}
 }
 
-// splitByDotsIgnoringBraces split string by dots, ignoring dots in curly and normal braces
+// SplitByDotsIgnoringBraces split string by dots, ignoring dots in curly and normal braces
 // please note it doesn't support enclosed brackets because we don't need it
-func splitByDotsIgnoringBraces(str string) []string {
+func SplitByDotsIgnoringBraces(str string) []string {
 	result := make([]string, 0, len(str))
 	item := make([]rune, 0, len(str))
 	inBracket := false
@@ -149,7 +149,7 @@ func SortMetrics(metrics []*types.MetricData, mfetch parser.MetricRequest) {
 	if !strings.ContainsAny(mfetch.Metric, "*?[{") {
 		return
 	}
-	parts := splitByDotsIgnoringBraces(mfetch.Metric)
+	parts := SplitByDotsIgnoringBraces(mfetch.Metric)
 	// Proceed backwards by segments, sorting once for each segment that has a glob that calls for sorting.
 	// By using a stable sort, the rightmost segments will be preserved as "sub-sorts" of any more leftward segments.
 	for i := len(parts) - 1; i >= 0; i-- {

--- a/expr/sort.go
+++ b/expr/sort.go
@@ -39,7 +39,7 @@ func getPart(metric *types.MetricData, part int) string {
 	if part < len(parts) {
 		return parts[part]
 	}
-	// otherwise return last part
+	// TODO: that should never happen, maybe we should log it
 	return parts[len(parts)-1]
 }
 

--- a/expr/sort.go
+++ b/expr/sort.go
@@ -38,7 +38,7 @@ func getPart(metric *types.MetricData, part int) string {
 	if part < len(parts) {
 		return parts[part]
 	}
-	// TODO: that should never happen, maybe we should log it
+	// TODO: that should never happen, maybe we should log it or generate error
 	return parts[len(parts)-1]
 }
 
@@ -123,7 +123,7 @@ func sortByBraces(metrics []*types.MetricData, part int, pattern string) {
 
 // SplitByDotsIgnoringBraces split string by dots, ignoring dots in curly and normal braces
 // please note it doesn't support enclosed brackets because we don't need it
-func SplitByDotsIgnoringBraces(str string) []string {
+func splitByDotsIgnoringBraces(str string) []string {
 	result := make([]string, 0, len(str))
 	item := make([]rune, 0, len(str))
 	inBracket := false
@@ -149,7 +149,7 @@ func SortMetrics(metrics []*types.MetricData, mfetch parser.MetricRequest) {
 	if !strings.ContainsAny(mfetch.Metric, "*?[{") {
 		return
 	}
-	parts := SplitByDotsIgnoringBraces(mfetch.Metric)
+	parts := splitByDotsIgnoringBraces(mfetch.Metric)
 	// Proceed backwards by segments, sorting once for each segment that has a glob that calls for sorting.
 	// By using a stable sort, the rightmost segments will be preserved as "sub-sorts" of any more leftward segments.
 	for i := len(parts) - 1; i >= 0; i-- {

--- a/expr/sort.go
+++ b/expr/sort.go
@@ -2,7 +2,6 @@ package expr
 
 import (
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -122,11 +121,27 @@ func sortByBraces(metrics []*types.MetricData, part int, pattern string) {
 	}
 }
 
-// compile regex for sorting
-// it splits string by dots, but ignoring enclosed {} and []
-// it fixes bug when number of dots in pattern and metric can differ
-// causing out of index error in getParts() above
-var reSplitByDotsIgnoreBraces = regexp.MustCompile(`\s*(\{[^}]*\}|\[[^]]*\]|[^.]+)`)
+// splitByDotsIgnoringBraces split string by dots, ignoring dots in curly and normal braces
+// please note it doesn't support enclosed brackets because we don't need it
+func splitByDotsIgnoringBraces(str string) []string {
+	result := make([]string, 0, len(str))
+	item := make([]rune, 0, len(str))
+	inBracket := false
+	for _, c := range str {
+		ch := string(c)
+		if ch == "." && !inBracket {
+			result = append(result, string(item))
+			item = make([]rune, 0, len(str))
+			continue
+		} else if ch == "[" || ch == "{" {
+			inBracket = true
+		} else if ch == "]" || ch == "}" {
+			inBracket = false
+		}
+		item = append(item, c)
+	}
+	return append(result, string(item))
+}
 
 // SortMetrics sort metric data alphabetically.
 func SortMetrics(metrics []*types.MetricData, mfetch parser.MetricRequest) {
@@ -134,7 +149,7 @@ func SortMetrics(metrics []*types.MetricData, mfetch parser.MetricRequest) {
 	if !strings.ContainsAny(mfetch.Metric, "*?[{") {
 		return
 	}
-	parts := reSplitByDotsIgnoreBraces.FindAllString(mfetch.Metric, -1)
+	parts := splitByDotsIgnoringBraces(mfetch.Metric)
 	// Proceed backwards by segments, sorting once for each segment that has a glob that calls for sorting.
 	// By using a stable sort, the rightmost segments will be preserved as "sub-sorts" of any more leftward segments.
 	for i := len(parts) - 1; i >= 0; i-- {

--- a/expr/sort_test.go
+++ b/expr/sort_test.go
@@ -19,7 +19,7 @@ func TestSplitByDotsIgnoringBraces(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		res := SplitByDotsIgnoringBraces(test.str)
+		res := splitByDotsIgnoringBraces(test.str)
 		if !reflect.DeepEqual(res, test.result) {
 			t.Errorf("[%d] Expected %q but have %q", i, test.result, res)
 		}

--- a/expr/sort_test.go
+++ b/expr/sort_test.go
@@ -1,11 +1,30 @@
 package expr
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/bookingcom/carbonapi/expr/types"
 	"github.com/bookingcom/carbonapi/pkg/parser"
 )
+
+func TestSplitByDotsIgnoringBraces(t *testing.T) {
+	tests := []struct {
+		str    string
+		result []string
+	}{
+		{
+			"a.*.[c-d].{b-*,c*}.[e].{j,k}.l.m.{*.Status,*}.JVM.Memory.Heap.*",
+			[]string{"a", "*", "[c-d]", "{b-*,c*}", "[e]", "{j,k}", "l", "m", "{*.Status,*}", "JVM", "Memory", "Heap", "*"},
+		},
+	}
+	for i, test := range tests {
+		res := SplitByDotsIgnoringBraces(test.str)
+		if !reflect.DeepEqual(res, test.result) {
+			t.Errorf("[%d] Expected %q but have %q", i, test.result, res)
+		}
+	}
+}
 
 func TestSortMetrics(t *testing.T) {
 	const (

--- a/expr/sort_test.go
+++ b/expr/sort_test.go
@@ -24,7 +24,7 @@ func TestSortMetrics(t *testing.T) {
 	}{
 		{
 			[]*types.MetricData{
-				//NOTE(nnuss): keep these lines lexically sorted ;)
+				// Note that these lines lexically sorted
 				types.MakeMetricData(bronze, []float64{}, 1, 0),
 				types.MakeMetricData(first, []float64{}, 1, 0),
 				types.MakeMetricData(fourth, []float64{}, 1, 0),
@@ -39,16 +39,62 @@ func TestSortMetrics(t *testing.T) {
 				Until:  1,
 			},
 			[]*types.MetricData{
-				//These are in the brace appearance order
+				// First part : These are in the brace appearance order
 				types.MakeMetricData(first, []float64{}, 1, 0),
 				types.MakeMetricData(second, []float64{}, 1, 0),
 				types.MakeMetricData(third, []float64{}, 1, 0),
 				types.MakeMetricData(fourth, []float64{}, 1, 0),
-
-				//These are in the slice order as above and come after
+				//Second part: These are in the slice order as above and come after
 				types.MakeMetricData(bronze, []float64{}, 1, 0),
 				types.MakeMetricData(gold, []float64{}, 1, 0),
 				types.MakeMetricData(silver, []float64{}, 1, 0),
+			},
+		},
+		{
+			[]*types.MetricData{
+				// Note that source now it's in random order
+				types.MakeMetricData(third, []float64{}, 1, 0),
+				types.MakeMetricData(silver, []float64{}, 1, 0),
+				types.MakeMetricData(first, []float64{}, 1, 0),
+				types.MakeMetricData(gold, []float64{}, 1, 0),
+				types.MakeMetricData(second, []float64{}, 1, 0),
+				types.MakeMetricData(bronze, []float64{}, 1, 0),
+				types.MakeMetricData(fourth, []float64{}, 1, 0),
+			},
+			parser.MetricRequest{
+				Metric: "a.*.c.d",
+				From:   0,
+				Until:  1,
+			},
+			[]*types.MetricData{
+				// And result is sorted by glob in 2nd field
+				types.MakeMetricData(bronze, []float64{}, 1, 0),
+				types.MakeMetricData(first, []float64{}, 1, 0),
+				types.MakeMetricData(fourth, []float64{}, 1, 0),
+				types.MakeMetricData(gold, []float64{}, 1, 0),
+				types.MakeMetricData(second, []float64{}, 1, 0),
+				types.MakeMetricData(silver, []float64{}, 1, 0),
+				types.MakeMetricData(third, []float64{}, 1, 0),
+			},
+		},
+		{
+			[]*types.MetricData{
+				// Just picking 3 random metric
+				types.MakeMetricData(first, []float64{}, 1, 0),
+				types.MakeMetricData(fourth, []float64{}, 1, 0),
+				types.MakeMetricData(bronze, []float64{}, 1, 0),
+			},
+			parser.MetricRequest{
+				Metric: "a.{*.first,*}.c.d",
+				From:   0,
+				Until:  1,
+			},
+			[]*types.MetricData{
+				// Sorted by glob in 2nd field, also but should be no error
+				// despite query have 4 dots and metric has 3
+				types.MakeMetricData(bronze, []float64{}, 1, 0),
+				types.MakeMetricData(first, []float64{}, 1, 0),
+				types.MakeMetricData(fourth, []float64{}, 1, 0),
 			},
 		},
 	}


### PR DESCRIPTION
## What issue is this change attempting to solve?
It's related to this PR https://github.com/go-graphite/carbonapi/issues/128. Before this change it's possible that query can have more dots than requested metric. Obvious example:
Metrics: 
```
a.b1.c.d
a.b2.c.d
a.b3.c.d
a.b4.c.d
```
Query: `a.{*.b1,*}.c.*`
Query looks strange, but it's valid and it was taken from real example. 
So, in the case above sorting will cause out of index error in `getPart()` function (and caused panic, intercepted only in http module, which is not good).

## How does this change solve the problem? Why is this the best approach?
Instead of splitting query by dots using simple `strings.Split()` I'm splitting it by using tricky regex, which will ignore dots inside square or curly bracket pairs. In that case sort will work properly and will not cause errors in queries above. 
I also included range protection in getPart() but proper splitting should fix underlying issue and not just mask it, as range protection alone doing. Performance wise that should not do much hurt - regex compiles once, split will be done once for every query, only if it contains globs. 

## How can we be sure this works as expected?
I added 2 more test cases for sort - one for error which I fixed and another to test that sort by glob also happening.

