### PR TITLE
Zipper can now be run as part of carbonapi.

### DIFF
--- a/cmd/carbonzipper/main.go
+++ b/cmd/carbonzipper/main.go
@@ -2,17 +2,10 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"log"
-	"os"
-	"runtime"
 
 	"github.com/bookingcom/carbonapi/pkg/app/zipper"
-	"github.com/bookingcom/carbonapi/pkg/cfg"
-	"github.com/bookingcom/carbonapi/pkg/trace"
-	"github.com/dgryski/go-expirecache"
 	"github.com/facebookgo/pidfile"
-	"go.uber.org/zap"
 )
 
 var BuildVersion string
@@ -26,61 +19,7 @@ func main() {
 		log.Fatalln("error during pidfile.Write():", err)
 	}
 
-	if *configFile == "" {
-		log.Fatal("missing config file option")
-	}
+	app, lg := zipper.Setup(*configFile, BuildVersion, "", nil)
 
-	fh, err := os.Open(*configFile)
-	if err != nil {
-		log.Fatalf("unable to read config file: %s", err)
-	}
-
-	config, err := cfg.ParseZipperConfig(fh)
-	if err != nil {
-		log.Fatalf("failed to parse config at %s: %s", *configFile, err)
-	}
-	fh.Close()
-
-	if config.MaxProcs != 0 {
-		runtime.GOMAXPROCS(config.MaxProcs)
-	}
-
-	if len(config.GetBackends()) == 0 {
-		log.Fatal("no Backends loaded -- exiting")
-	}
-
-	logger, err := config.LoggerConfig.Build()
-	if err != nil {
-		log.Fatalf("failed to initiate logger: %s", err)
-	}
-	logger = logger.Named("carbonzipper")
-	defer func() {
-		if syncErr := logger.Sync(); syncErr != nil {
-			log.Fatalf("could not sync the logger: %v", syncErr)
-		}
-	}()
-
-	logger.Info("starting carbonzipper",
-		zap.String("build_version", BuildVersion),
-		zap.String("zipperConfig", fmt.Sprintf("%+v", config)),
-	)
-
-	ms := zipper.NewPrometheusMetrics(config)
-	bs, err := zipper.InitBackends(config, ms, logger)
-	if err != nil {
-		logger.Fatal("failed to init backends", zap.Error(err))
-	}
-
-	app := &zipper.App{
-		Config:              config,
-		Metrics:             ms,
-		Backends:            bs,
-		TopLevelDomainCache: expirecache.New(0),
-		TLDPrefixes:         zipper.InitTLDPrefixes(logger, config.TLDCacheExtraPrefixes),
-	}
-
-	flush := trace.InitTracer(BuildVersion, "carbonzipper", logger, app.Config.Traces)
-	defer flush()
-
-	app.Start(logger)
+	app.Start(true, lg)
 }

--- a/pkg/app/carbonapi/app.go
+++ b/pkg/app/carbonapi/app.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/bookingcom/carbonapi/expr/functions"
 	"github.com/bookingcom/carbonapi/expr/functions/cairo/png"
+	"github.com/bookingcom/carbonapi/pkg/app/zipper"
 	"github.com/bookingcom/carbonapi/pkg/backend"
 	bnet "github.com/bookingcom/carbonapi/pkg/backend/net"
 	"github.com/bookingcom/carbonapi/pkg/blocker"
@@ -44,6 +45,9 @@ type App struct {
 	backend backend.Backend
 
 	prometheusMetrics PrometheusMetrics
+	Lg *zap.Logger
+
+	Zipper *zipper.App
 }
 
 // New creates a new app

--- a/pkg/app/zipper/http_handlers_test.go
+++ b/pkg/app/zipper/http_handlers_test.go
@@ -19,7 +19,7 @@ func newTestApp() (*App, *PrometheusMetrics, *zap.Logger) {
 	lg, _ := zap.NewDevelopment()
 	config := cfg.DefaultZipperConfig()
 
-	ms := NewPrometheusMetrics(config)
+	ms := NewPrometheusMetrics(config, "")
 
 	bs, err := InitBackends(config, ms, lg)
 	if err != nil {
@@ -28,7 +28,7 @@ func newTestApp() (*App, *PrometheusMetrics, *zap.Logger) {
 
 	app := App{
 		Config:              config,
-		Metrics:             NewPrometheusMetrics(config),
+		Metrics:             NewPrometheusMetrics(config, ""),
 		Backends:            bs,
 		TopLevelDomainCache: expirecache.New(0),
 	}

--- a/pkg/app/zipper/metrics.go
+++ b/pkg/app/zipper/metrics.go
@@ -36,62 +36,71 @@ type PrometheusMetrics struct {
 }
 
 // NewPrometheusMetrics creates a set of default Prom metrics
-func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
+func NewPrometheusMetrics(config cfg.Zipper, ns string) *PrometheusMetrics {
 	return &PrometheusMetrics{
 		Requests: prometheus.NewCounter(
 			prometheus.CounterOpts{
-				Name: "http_request_total",
-				Help: "Count of HTTP requests",
+				Namespace: ns,
+				Name:      "http_request_total",
+				Help:      "Count of HTTP requests",
 			},
 		),
 		Responses: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "http_responses_total",
-				Help: "Count of HTTP responses, partitioned by return code and handler",
+				Namespace: ns,
+				Name:      "http_responses_total",
+				Help:      "Count of HTTP responses, partitioned by return code and handler",
 			},
 			[]string{"code", "handler"},
 		),
 		RenderMismatchedResponses: prometheus.NewCounter(
 			prometheus.CounterOpts{
-				Name: "render_mismatched_responses_total",
-				Help: "Count of mismatched (unfixed) render responses",
+				Namespace: ns,
+				Name:      "render_mismatched_responses_total",
+				Help:      "Count of mismatched (unfixed) render responses",
 			},
 		),
 		RenderFixedMismatches: prometheus.NewCounter(
 			prometheus.CounterOpts{
-				Name: "render_fixed_mismatches_total",
-				Help: "Count of fixed mismatched rendered data points",
+				Namespace: ns,
+				Name:      "render_fixed_mismatches_total",
+				Help:      "Count of fixed mismatched rendered data points",
 			},
 		),
 		RenderMismatches: prometheus.NewCounter(
 			prometheus.CounterOpts{
-				Name: "render_mismatches_total",
-				Help: "Count of mismatched rendered data points",
+				Namespace: ns,
+				Name:      "render_mismatches_total",
+				Help:      "Count of mismatched rendered data points",
 			},
 		),
 		Renders: prometheus.NewCounter(
 			prometheus.CounterOpts{
-				Name: "render_total",
-				Help: "Count of rendered data points",
+				Namespace: ns,
+				Name:      "render_total",
+				Help:      "Count of rendered data points",
 			},
 		),
 		FindNotFound: prometheus.NewCounter(
 			prometheus.CounterOpts{
-				Name: "find_not_found",
-				Help: "Count of not-found /find responses",
+				Namespace: ns,
+				Name:      "find_not_found",
+				Help:      "Count of not-found /find responses",
 			},
 		),
 		RequestCancel: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "request_cancel",
-				Help: "Context cancellations or incoming requests due to manual cancels or timeouts",
+				Namespace: ns,
+				Name:      "request_cancel",
+				Help:      "Context cancellations or incoming requests due to manual cancels or timeouts",
 			},
 			[]string{"handler", "cause"},
 		),
 		RenderDurationExp: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
-				Name: "render_request_duration_seconds_exp",
-				Help: "The duration of render requests (exponential)",
+				Namespace: ns,
+				Name:      "render_request_duration_seconds_exp",
+				Help:      "The duration of render requests (exponential)",
 				Buckets: prometheus.ExponentialBuckets(
 					config.Monitoring.RenderDurationExp.Start,
 					config.Monitoring.RenderDurationExp.BucketSize,
@@ -100,8 +109,9 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 		),
 		RenderOutDurationExp: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name: "render_outbound_request_duration_seconds_exp",
-				Help: "The durations of render requests sent to storages (exponential)",
+				Namespace: ns,
+				Name:      "render_outbound_request_duration_seconds_exp",
+				Help:      "The durations of render requests sent to storages (exponential)",
 				Buckets: prometheus.ExponentialBuckets(
 					// TODO (grzkv) Do we need a separate config?
 					// The buckets should be of comparable size.
@@ -113,8 +123,9 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 		),
 		FindDurationExp: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
-				Name: "find_request_duration_seconds_exp",
-				Help: "The duration of find requests (exponential)",
+				Namespace: ns,
+				Name:      "find_request_duration_seconds_exp",
+				Help:      "The duration of find requests (exponential)",
 				Buckets: prometheus.ExponentialBuckets(
 					config.Monitoring.FindDurationExp.Start,
 					config.Monitoring.FindDurationExp.BucketSize,
@@ -123,8 +134,9 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 		),
 		FindDurationLin: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
-				Name: "find_request_duration_seconds_lin",
-				Help: "The duration of find requests (linear), in ms",
+				Namespace: ns,
+				Name:      "find_request_duration_seconds_lin",
+				Help:      "The duration of find requests (linear), in ms",
 				Buckets: prometheus.LinearBuckets(
 					config.Monitoring.FindDurationLin.Start,
 					config.Monitoring.FindDurationLin.BucketSize,
@@ -133,8 +145,9 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 		),
 		FindOutDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name: "find_out_duration_seconds",
-				Help: "Duration of outgoing find requests per backend cluster.",
+				Namespace: ns,
+				Name:      "find_out_duration_seconds",
+				Help:      "Duration of outgoing find requests per backend cluster.",
 				Buckets: prometheus.ExponentialBuckets(
 					config.Monitoring.FindOutDuration.Start,
 					config.Monitoring.FindOutDuration.BucketSize,
@@ -144,8 +157,9 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 		),
 		TimeInQueueSeconds: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name: "time_in_queue",
-				Help: "Time a request spends in queue in seconds.",
+				Namespace: ns,
+				Name:      "time_in_queue",
+				Help:      "Time a request spends in queue in seconds.",
 				Buckets: prometheus.ExponentialBuckets(
 					config.Monitoring.TimeInQueueExpHistogram.Start/1000, // converstion ms -> s
 					config.Monitoring.TimeInQueueExpHistogram.BucketSize,
@@ -155,40 +169,45 @@ func NewPrometheusMetrics(config cfg.Zipper) *PrometheusMetrics {
 		),
 		TLDCacheProbeReqTotal: prometheus.NewCounter(
 			prometheus.CounterOpts{
-				Name: "tldcache_probe_req_total",
-				Help: "The total number of find requests sent by TLD cache as probes.",
+				Namespace: ns,
+				Name:      "tldcache_probe_req_total",
+				Help:      "The total number of find requests sent by TLD cache as probes.",
 			},
 		),
 		TLDCacheProbeErrors: prometheus.NewCounter(
 			prometheus.CounterOpts{
-				Name: "tldcache_probe_errors_total",
-				Help: "The total number of failed find requests sent by TLD cache as probes.",
+				Namespace: ns,
+				Name:      "tldcache_probe_errors_total",
+				Help:      "The total number of failed find requests sent by TLD cache as probes.",
 			},
 		),
 		TLDCacheHostsPerDomain: *prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "tldcache_num_hosts_per_domain",
-				Help: "The number of hosts per top-level domain.",
+				Namespace: ns,
+				Name:      "tldcache_num_hosts_per_domain",
+				Help:      "The number of hosts per top-level domain.",
 			},
 			[]string{"domain"},
 		),
 		PathCacheFilteredRequests: prometheus.NewCounter(
 			prometheus.CounterOpts{
-				Name: "path_cache_filtered_requests_total",
-				Help: "The total number of requests with successful backend filter by path caches",
+				Namespace: ns,
+				Name:      "path_cache_filtered_requests_total",
+				Help:      "The total number of requests with successful backend filter by path caches",
 			},
 		),
 		BackendResponses: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "backend_responses_total",
-				Help: "Count of backend responses, partitioned by return code and handler",
+				Namespace: ns,
+				Name:      "backend_responses_total",
+				Help:      "Count of backend responses, partitioned by return code and handler",
 			},
 			[]string{"code", "handler"},
 		),
 	}
 }
 
-func metricsServer(app *App) *http.Server {
+func metricsServer(app *App, serve bool) *http.Server {
 	prometheus.MustRegister(app.Metrics.Requests)
 	prometheus.MustRegister(app.Metrics.Responses)
 	prometheus.MustRegister(app.Metrics.Renders)
@@ -216,14 +235,19 @@ func metricsServer(app *App) *http.Server {
 		writeTimeout = time.Minute
 	}
 
-	r := initMetricHandlers()
+	if serve {
+		r := initMetricHandlers()
+		s := &http.Server{
+			Handler:      r,
+			ReadTimeout:  1 * time.Second,
+			WriteTimeout: writeTimeout,
+		}
 
-	s := &http.Server{
-		Addr:         app.Config.ListenInternal,
-		Handler:      r,
-		ReadTimeout:  1 * time.Second,
-		WriteTimeout: writeTimeout,
+		s.Addr = app.Config.ListenInternal
+
+		return s
+	} else {
+		return nil
 	}
 
-	return s
 }

--- a/pkg/app/zipper/zipper.go
+++ b/pkg/app/zipper/zipper.go
@@ -4,15 +4,81 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+	"os"
+	"runtime"
 	"sort"
 
 	"github.com/bookingcom/carbonapi/pkg/backend"
+	"github.com/bookingcom/carbonapi/pkg/cfg"
 	"github.com/bookingcom/carbonapi/pkg/types"
-	"go.opentelemetry.io/otel/api/trace"
+	"github.com/dgryski/go-expirecache"
 	"go.uber.org/zap"
 )
 
-func Find(app *App, ctx context.Context, originalQuery string, span *trace.Span, ms *PrometheusMetrics, lg *zap.Logger) (types.Matches, error) {
+// Setup sets up the zipper for future lanuch.
+// lgOverride optionally overrides logger if non-nil. TODO: Remove after merge is done.
+// metricsNS adds namespace to Prom metrics if non-empty. TODO: Remove after merge is done.
+func Setup(configFile string, BuildVersion string, metricsNS string, lgOverride *zap.Logger) (*App, *zap.Logger) {
+	if configFile == "" {
+		log.Fatal("missing config file option")
+	}
+
+	fh, err := os.Open(configFile)
+	if err != nil {
+		log.Fatalf("unable to read config file: %s", err)
+	}
+
+	config, err := cfg.ParseZipperConfig(fh)
+	if err != nil {
+		log.Fatalf("failed to parse config at %s: %s", configFile, err)
+	}
+	fh.Close()
+
+	if config.MaxProcs != 0 {
+		runtime.GOMAXPROCS(config.MaxProcs)
+	}
+
+	if len(config.GetBackends()) == 0 {
+		log.Fatal("no Backends loaded -- exiting")
+	}
+
+	var logger *zap.Logger
+	if lgOverride != nil {
+		logger = lgOverride.With(zap.Bool("zipper", true))
+	} else {
+		logger, err = config.LoggerConfig.Build()
+		if err != nil {
+			log.Fatalf("failed to initiate logger: %s", err)
+		}
+		logger = logger.Named("carbonzipper")
+	}
+
+	logger.Info("starting carbonzipper",
+		zap.String("build_version", BuildVersion),
+		zap.String("zipperConfig", fmt.Sprintf("%+v", config)),
+	)
+
+	ms := NewPrometheusMetrics(config, metricsNS)
+	bs, err := InitBackends(config, ms, logger)
+	if err != nil {
+		logger.Fatal("failed to init backends", zap.Error(err))
+	}
+
+	app := &App{
+		Config:              config,
+		Metrics:             ms,
+		Backends:            bs,
+		TopLevelDomainCache: expirecache.New(0),
+		TLDPrefixes:         InitTLDPrefixes(logger, config.TLDCacheExtraPrefixes),
+		Lg: logger,
+	}
+
+	return app, logger
+}
+
+// Find executes find request by checking cache and sending it to the backends.
+func Find(app *App, ctx context.Context, originalQuery string, ms *PrometheusMetrics, lg *zap.Logger) (types.Matches, error) {
 	request := types.NewFindRequest(originalQuery)
 	bs := app.filterBackendByTopLevelDomain([]string{originalQuery})
 	var filteredByPathCache bool
@@ -20,7 +86,7 @@ func Find(app *App, ctx context.Context, originalQuery string, span *trace.Span,
 	if filteredByPathCache {
 		ms.PathCacheFilteredRequests.Inc()
 	}
-	metrics, errs := backend.Finds(ctx, bs, request, app.Metrics.FindOutDuration)
+	metrics, errs := backend.Finds(ctx, bs, request, ms.FindOutDuration)
 	err := errorsFanIn(errs, len(bs))
 
 	if ctx.Err() != nil {
@@ -29,8 +95,6 @@ func Find(app *App, ctx context.Context, originalQuery string, span *trace.Span,
 	}
 
 	if err != nil {
-		(*span).SetAttribute("error", true)
-		(*span).SetAttribute("error.message", err.Error())
 		var notFound types.ErrNotFound
 		if errors.As(err, &notFound) {
 			// graphite-web 0.9.12 needs to get a 200 OK response with an empty
@@ -56,11 +120,10 @@ func Find(app *App, ctx context.Context, originalQuery string, span *trace.Span,
 		return metrics.Matches[i].Path < metrics.Matches[j].Path
 	})
 
-	(*span).SetAttribute("graphite.total_metric_count", len(metrics.Matches))
-
 	return metrics, nil
 }
 
+// Render executes the render request by checking cache and sending it to the backends.
 func Render(app *App, ctx context.Context, target string, from int64, until int64,
 	ms *PrometheusMetrics, lg *zap.Logger) ([]types.Metric, error) {
 
@@ -86,6 +149,23 @@ func Render(app *App, ctx context.Context, target string, from int64, until int6
 	}
 
 	return metrics, err
+}
+
+// Info executes the info request by checking cache and sending it to the backends.
+func Info(app *App, ctx context.Context, target string, ms *PrometheusMetrics, lg *zap.Logger) ([]types.Info, error) {
+	request := types.NewInfoRequest(target)
+
+	bs := app.filterBackendByTopLevelDomain([]string{target})
+	var filteredByPathCache bool
+	bs, filteredByPathCache = backend.Filter(bs, []string{target})
+	if filteredByPathCache {
+		ms.PathCacheFilteredRequests.Inc()
+	}
+
+	infos, errs := backend.Infos(ctx, bs, request)
+	err := errorsFanIn(errs, len(bs))
+
+	return infos, err
 }
 
 func errorsFanIn(errs []error, nBackends int) error {

--- a/pkg/cfg/api.go
+++ b/pkg/cfg/api.go
@@ -98,6 +98,11 @@ type API struct {
 	DefaultColors             map[string]string `yaml:"defaultColors"`
 	FunctionsConfigs          map[string]string `yaml:"functionsConfig"`
 	GraphiteVersionForGrafana string            `yaml:"graphiteVersionForGrafana"`
+
+	// EmbedZipper makes carbonapi to use zipper as a package, not as a service.
+	EmbedZipper bool `yaml:"embedZipper"`
+	// ZipperConfig represents the config for the embedded zipper.
+	ZipperConfig string `yaml:"zipperConfig"`
 }
 
 // CacheConfig configs the cache


### PR DESCRIPTION
*This is an intermediate stage in the re-design. There are a lot of temporary plugs that will be cleaned-up later. The design is work in progress and rough corners are to be expected.*

## What issue is this change attempting to solve?
This merges `zipper` into `carbonapi`. They can now be run as a single binary if a corresponding option is set.

`carbonapi` will still use `zipper` as an external service by default.

## How does this change solve the problem? Why is this the best approach?
`Zipper` features were transformed into a package that is used both by `zipper` and by `carbonapi`.

## How can we be sure this works as expected?
Tested locally and on live traffic.

## Notes
* Embedded `zipper` exposes its metrics along w/ `carbonapi` but prefixed w/ `zipper_`. This allows to monitor embedded `zipper` w/o conflicts, but it's temporary and will go away when the merge is done.
* Embedded `zipper` uses `carbonapi` logger w/ and additional mark. The mark is to be removed when re-design is done.