### PR TITLE
fixing panic in cairo because of abnormal image size

### DIFF
--- a/expr/functions/cairo/png/cairo.go
+++ b/expr/functions/cairo/png/cairo.go
@@ -6,6 +6,7 @@ package png
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"image/color"
 	"io/ioutil"
@@ -967,6 +968,17 @@ func marshalCairo(p PictureParams, results []*types.MetricData, backend cairoBac
 
 		yUnitSystem: p.YUnitSystem,
 		yDivisors:   p.YDivisors,
+	}
+
+	// See https://github.com/Automattic/node-canvas/issues/1374#issuecomment-467918480
+	// and https://github.com/freedesktop/cairo/blob/929262dd54ffae81721ffe9b2c59faa7b045c663/src/cairo-image-surface.c#L59-L62
+	var maxImageSize float64
+	maxImageSize = 32767
+	if params.width > maxImageSize {
+		return nil, errors.New(fmt.Sprintf("Invalid picture width %g, should be =< %g", params.width, maxImageSize))
+	}
+	if params.height > maxImageSize {
+		return nil, errors.New(fmt.Sprintf("Invalid picture height %g, should be =< %g", params.height, maxImageSize))
 	}
 
 	margin := float64(params.margin)


### PR DESCRIPTION
## What issue is this change attempting to solve?
Panic `invalid value (typically too big) for the size of the input (surface, pattern, etc.)` in cairo module, probably caused by abnormal image size. Cairo has [hardcoded](https://github.com/freedesktop/cairo/blob/929262dd54ffae81721ffe9b2c59faa7b045c663/src/cairo-image-surface.c#L59-L62) height/width limitation (should be less or equal than 32767 pixels).
```
2022/09/27 10:22:14 http: panic serving 127.0.0.1:33430: invalid value (typically too big) for the size of the input (surface, pattern, etc.)
goroutine 75082862 [running]:
net/http.(*conn).serve.func1()
        /usr/lib/golang/src/net/http/server.go:1825 +0xbf
panic({0xc97e60, 0x15a87a0})
        /usr/lib/golang/src/runtime/panic.go:844 +0x258
github.com/evmar/gocairo/cairo.ImageSurfaceCreate(0xc0002008a0?, 0xd7b0c7?, 0x4?)
        /gopath/src/github.com/bookingcom/carbonapi/vendor/github.com/evmar/gocairo/cairo/cairo.go:2888 +0xd1
github.com/bookingcom/carbonapi/expr/functions/cairo/png.imageSurfaceCreate(0xd7b0c7?, 0x4?, 0xeac918?, 0xeac918?)
        /gopath/src/github.com/bookingcom/carbonapi/expr/functions/cairo/png/pixel_ratio.go:64 +0x3f
github.com/bookingcom/carbonapi/expr/functions/cairo/png.marshalCairo({0x3ff0000000000000, 0xc000000000000000, 0x4069000000000000, 0xa, 0x0, {0xd7c144, 0x5}, {0xd7b96a, 0x5}, {0xd7b2b3, ...}, ...}, ...)
        /gopath/src/github.com/bookingcom/carbonapi/expr/functions/cairo/png/cairo.go:991 +0x88c
github.com/bookingcom/carbonapi/expr/functions/cairo/png.MarshalPNGRequest(0x0?, {0xc032d55200, 0x6, 0x6}, {0x0?, 0xbda802?})
        /gopath/src/github.com/bookingcom/carbonapi/expr/functions/cairo/png/cairo.go:890 +0xe5
github.com/bookingcom/carbonapi/pkg/app/carbonapi.(*App).renderWriteBody(0xc0001f7800, {0xc032d55200?, 0x6, 0x6}, {{0xc089867f90, 0x1, 0x1}, {0xc042aba8e6, 0x3}, {0x0, ...}, ...}, ...)

```
## How does this change solve the problem? Why is this the best approach?
Fix is quite obvious - check parameters and return error in `marshalCairo()`. Then user will get `400 Bad Request` instead.

## How can we be sure this works as expected?
Not sure if needed for such small fix.
