### PR TITLE
Added limiter for the render requests to the embedded zipper.

### DIFF
--- a/cmd/carbonapi/main.go
+++ b/cmd/carbonapi/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bookingcom/carbonapi/pkg/app/carbonapi"
 	"github.com/bookingcom/carbonapi/pkg/app/zipper"
 	"github.com/bookingcom/carbonapi/pkg/cfg"
+	"github.com/bookingcom/carbonapi/pkg/prioritylimiter"
 	"go.uber.org/zap"
 )
 
@@ -54,6 +55,7 @@ func main() {
 		lg.Info("starting embedded zipper")
 		var zlg *zap.Logger
 		app.Zipper, zlg = zipper.Setup(apiConfig.ZipperConfig, BuildVersion, "zipper", lg)
+		app.ZipperLimiter = prioritylimiter.New(apiConfig.ConcurrencyLimitPerServer)
 		// flush := trace.InitTracer(BuildVersion, "carbonzipper", zlg, app.Zipper.Config.Traces)
 		// defer flush()
 		go app.Zipper.Start(false, zlg)

--- a/pkg/app/carbonapi/app.go
+++ b/pkg/app/carbonapi/app.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bookingcom/carbonapi/pkg/carbonapipb"
 	"github.com/bookingcom/carbonapi/pkg/cfg"
 	"github.com/bookingcom/carbonapi/pkg/parser"
+	"github.com/bookingcom/carbonapi/pkg/prioritylimiter"
 	"github.com/bookingcom/carbonapi/pkg/trace"
 
 	"github.com/facebookgo/grace/gracehttp"
@@ -48,6 +49,7 @@ type App struct {
 	Lg *zap.Logger
 
 	Zipper *zipper.App
+	ZipperLimiter *prioritylimiter.Limiter
 }
 
 // New creates a new app

--- a/pkg/app/carbonapi/http_handlers.go
+++ b/pkg/app/carbonapi/http_handlers.go
@@ -516,8 +516,10 @@ func (app *App) sendRenderRequest(ctx context.Context, ch chan<- renderResponse,
 	var err error
 	var metrics []dataTypes.Metric
 	if app.Zipper != nil {
-		metrics, err = zipper.Render(app.Zipper, ctx, path, int64(from), int64(until),
-			app.Zipper.Metrics, app.Zipper.Lg)
+		// TODO: Cleanup the limiter.
+		_ = app.ZipperLimiter.Enter(ctx, util.GetPriority(ctx), util.GetUUID(ctx)) // This is a temporary fix.
+		metrics, err = zipper.Render(app.Zipper, ctx, path, int64(from), int64(until), app.Zipper.Metrics, app.Zipper.Lg)
+		app.ZipperLimiter.Leave()
 	} else {
 		metrics, err = app.backend.Render(ctx, request)
 	}


### PR DESCRIPTION
## What issue is this change attempting to solve?
This prevents potential contention and other concurrency issues. The limiter will be removed or reworked after redesign is done.

## How can we be sure this works as expected?
Tested locally and on live traffic.
