### PR TITLE
Improve capi cache logic and logs

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -11,18 +12,26 @@ import (
 type TestMemcache struct {
 	delayMs uint32
 	data    map[string]([]byte)
+	errKeys map[string]bool
 }
 
 func (m *TestMemcache) Get(k string) (res *memcache.Item, err error) {
 	time.Sleep(time.Duration(m.delayMs) * time.Millisecond)
+	if _, there := m.errKeys[k]; there {
+		return nil, errors.New("cache test err")
+	}
 	if _, there := m.data[k]; there {
 		return &memcache.Item{
 			Key:   k,
-			Value: ([]byte)(m.data[k]),
+			Value: m.data[k],
 		}, nil
 	} else {
 		return nil, memcache.ErrCacheMiss
 	}
+}
+
+func (m *TestMemcache) SetErr(key string) {
+	m.errKeys[key] = true
 }
 
 func (m *TestMemcache) Set(i *memcache.Item) error {
@@ -93,7 +102,49 @@ func TestReplicatedMemcacheTimeout(t *testing.T) {
 	m.Set("b", bData, 0)
 
 	aRes, err := m.Get("a")
-	if err != ErrTimeout {
+	if err == nil || err == ErrNotFound {
 		t.Fatalf("Expected timeout, got val %v, err %v", aRes, err)
+	}
+}
+
+func TestGetFromReplica(t *testing.T) {
+	aData := []byte("aval")
+
+	m := &TestMemcache{
+		delayMs: 1,
+		data: map[string][]byte{
+			getCacheHashKey("a"): aData,
+		},
+		errKeys: map[string]bool{
+			getCacheHashKey("c"): true,
+		},
+	}
+
+	resCh := make(chan cacheResponse, 1)
+	getFromReplica(m, "a", "", resCh)
+	res := <-resCh
+	if res.err != nil {
+		t.Fatalf("unexpected error occured %v", res.err)
+	}
+	if !res.found {
+		t.Fatal("unexpected not found returned")
+	}
+	if string(res.data) != string(aData) {
+		t.Fatalf("unequal data returned got %v, expected %v", string(res.data), string(aData))
+	}
+
+	getFromReplica(m, "b", "", resCh)
+	res = <-resCh
+	if res.err != nil {
+		t.Fatalf("unexpected error occured %v", res.err)
+	}
+	if res.found {
+		t.Fatal("unexpected found returned")
+	}
+
+	getFromReplica(m, "c", "", resCh)
+	res = <-resCh
+	if res.err == nil {
+		t.Fatal("unexpected nil error")
 	}
 }

--- a/pkg/carbonapipb/carbonapi.pb.go
+++ b/pkg/carbonapipb/carbonapi.pb.go
@@ -46,6 +46,7 @@ type AccessLogDetails struct {
 	FromCache                     bool              `json:"from_cache"`
 	ZipperRequests                int64             `json:"zipper_requests,omitempty"`
 	TotalMetricCount              int64             `json:"total_metric_count"`
+	CacheErrs                     string            `json:"cache_errs"`
 }
 
 func splitAddr(addr string) (string, string) {


### PR DESCRIPTION
## What issue is this change attempting to solve?
Currently, there's no visibility over cache errors. This PR takes into account errors happened during set/get of cache.

## How does this change solve the problem? Why is this the best approach?
It is ensured that the errors are escalated and caught on references. Then, errors are added to carbonapi request logs.

## How can we be sure this works as expected?
Tests are improved.
