### PR TITLE
Observability additions for carbonapi.

### DIFF
--- a/cmd/carbonapi/main.go
+++ b/cmd/carbonapi/main.go
@@ -8,9 +8,7 @@ import (
 	"runtime"
 
 	"github.com/bookingcom/carbonapi/pkg/app/carbonapi"
-	"github.com/bookingcom/carbonapi/pkg/app/zipper"
 	"github.com/bookingcom/carbonapi/pkg/cfg"
-	"github.com/bookingcom/carbonapi/pkg/prioritylimiter"
 	"go.uber.org/zap"
 )
 
@@ -49,16 +47,6 @@ func main() {
 	app, err := carbonapi.New(apiConfig, lg, BuildVersion)
 	if err != nil {
 		lg.Error("Error initializing app")
-	}
-
-	if apiConfig.EmbedZipper {
-		lg.Info("starting embedded zipper")
-		var zlg *zap.Logger
-		app.Zipper, zlg = zipper.Setup(apiConfig.ZipperConfig, BuildVersion, "zipper", lg)
-		app.ZipperLimiter = prioritylimiter.New(apiConfig.ConcurrencyLimitPerServer)
-		// flush := trace.InitTracer(BuildVersion, "carbonzipper", zlg, app.Zipper.Config.Traces)
-		// defer flush()
-		go app.Zipper.Start(false, zlg)
 	}
 
 	flush := app.Start(lg)

--- a/pkg/app/carbonapi/app_test.go
+++ b/pkg/app/carbonapi/app_test.go
@@ -141,7 +141,7 @@ func SetUpTestConfig() (*App, http.Handler) {
 		config:            config,
 		queryCache:        cache.NewMemcached("capi", 50, ""),
 		findCache:         cache.NewExpireCache(1000),
-		prometheusMetrics: newPrometheusMetrics(config),
+		ms: newPrometheusMetrics(config),
 	}
 	app.backend = mock.New(mock.Config{
 		Find:   find,

--- a/pkg/app/carbonapi/metrics.go
+++ b/pkg/app/carbonapi/metrics.go
@@ -15,6 +15,8 @@ type PrometheusMetrics struct {
 	DurationExp       prometheus.Histogram
 	DurationLin       prometheus.Histogram
 
+	RequestsOut *prometheus.CounterVec
+
 	RenderDurationExp         prometheus.Histogram
 	RenderDurationLinSimple   prometheus.Histogram
 	RenderDurationExpSimple   prometheus.Histogram
@@ -30,6 +32,10 @@ type PrometheusMetrics struct {
 	TimeInQueueLin          prometheus.Histogram
 	ActiveUpstreamRequests  prometheus.Gauge
 	WaitingUpstreamRequests prometheus.Gauge
+
+	CacheRequests *prometheus.CounterVec
+	CacheRespRead *prometheus.CounterVec
+	CacheTimeouts *prometheus.CounterVec
 }
 
 func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
@@ -75,6 +81,12 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 					config.Zipper.Common.Monitoring.RequestDurationExp.BucketSize,
 					config.Zipper.Common.Monitoring.RequestDurationExp.BucketsNum),
 			},
+		),
+		RequestsOut: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "requests_out_total",
+				Help: "The number of requests that are propagated to be queried to backends",
+			}, []string{"request"},
 		),
 		DurationLin: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
@@ -208,6 +220,27 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 				Name: "waiting_upstream_requests",
 				Help: "Number of upstream requests waiting on the limiter",
 			},
+		),
+		CacheRequests: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "cache_requests",
+				Help: "Counter of requests to the top-level cache",
+			},
+			[]string{"request", "operation"},
+		),
+		CacheRespRead: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "cache_resp_read",
+				Help: "Counter of responses from the top-level cache that we have acutally read",
+			},
+			[]string{"request", "operation", "status"},
+		),
+		CacheTimeouts: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "cache_timeouts",
+				Help: "Counter of top-level cache timed-out requests",
+			},
+			[]string{"request"},
 		),
 	}
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
-	"github.com/google/go-cmp/cmp"
 )
 
 type TestMemcache struct {
@@ -40,71 +39,6 @@ func (m *TestMemcache) Set(i *memcache.Item) error {
 	}
 	m.data[i.Key] = i.Value
 	return nil
-}
-
-func TestReplicatedMemcacheWithPartialTimeout(t *testing.T) {
-	m := ReplicatedMemcached{
-		prefix:    "test",
-		timeoutMs: 20,
-		instances: []Cache{
-			&TestMemcache{
-				delayMs: 1,
-			},
-			&TestMemcache{
-				delayMs: 10,
-			},
-			&TestMemcache{
-				// this one will timeout every time
-				delayMs: 100,
-			},
-		},
-	}
-
-	aData := []byte("aval")
-	bData := []byte("bval")
-	m.Set("a", aData, 0)
-	m.Set("b", bData, 0)
-
-	aRes, err := m.Get("a")
-	if !cmp.Equal(aRes, aData) {
-		t.Fatalf("Expected %v value for key %s, got %v", aData, "a", aRes)
-	}
-	if err != nil {
-		t.Fatalf("Error while getting value for key %s; %v", "a", err)
-	}
-
-	xRes, err := m.Get("x")
-	if err != ErrNotFound {
-		t.Fatalf("Expected cache miss, that did not happen. Got %v and err %v instead", xRes, err)
-	}
-}
-
-func TestReplicatedMemcacheTimeout(t *testing.T) {
-	m := ReplicatedMemcached{
-		prefix:    "test",
-		timeoutMs: 10,
-		instances: []Cache{
-			&TestMemcache{
-				delayMs: 250,
-			},
-			&TestMemcache{
-				delayMs: 230,
-			},
-			&TestMemcache{
-				delayMs: 100,
-			},
-		},
-	}
-
-	aData := []byte("aval")
-	bData := []byte("bval")
-	m.Set("a", aData, 0)
-	m.Set("b", bData, 0)
-
-	aRes, err := m.Get("a")
-	if err == nil || err == ErrNotFound {
-		t.Fatalf("Expected timeout, got val %v, err %v", aRes, err)
-	}
 }
 
 func TestGetFromReplica(t *testing.T) {


### PR DESCRIPTION
## What issue is this change attempting to solve?
Several observability additions:

* a set of metrics for carbonapi memcached. Fixes #241 
* metrics to count requests propagated to remotes from carbonapi
* added metrics to the zipper limiter in carbonapi

Also, added a limiter to find requests from carbonapi to zipper.

## How can we be sure this works as expected?
Tested locally and on live traffic.
