### PR TITLE
Added observability to limiter and to errors in HTTP requests.

### DIFF
--- a/pkg/app/carbonapi/http_handlers.go
+++ b/pkg/app/carbonapi/http_handlers.go
@@ -523,7 +523,7 @@ func (app *App) sendRenderRequest(ctx context.Context, ch chan<- renderResponse,
 	if app.Zipper != nil {
 		// TODO: Cleanup the limiter.
 		_ = app.ZipperLimiter.Enter(ctx, util.GetPriority(ctx), util.GetUUID(ctx))
-		app.ms.RequestsOut.WithLabelValues("render").Inc()
+		app.ms.UpstreamRequests.WithLabelValues("render").Inc()
 		metrics, err = zipper.Render(app.Zipper, ctx, path, int64(from), int64(until), app.Zipper.Metrics, app.Zipper.Lg)
 		app.ZipperLimiter.Leave()
 	} else {
@@ -752,7 +752,7 @@ func (app *App) resolveGlobs(ctx context.Context, metric string, useCache bool, 
 
 	if app.Zipper != nil {
 		_ = app.ZipperLimiter.Enter(ctx, util.GetPriority(ctx), util.GetUUID(ctx))
-		app.ms.RequestsOut.WithLabelValues("find").Inc()
+		app.ms.UpstreamRequests.WithLabelValues("find").Inc()
 		matches, err = zipper.Find(app.Zipper, ctx, request.Query, app.Zipper.Metrics, app.Zipper.Lg)
 		app.ZipperLimiter.Leave()
 	} else {
@@ -1074,7 +1074,7 @@ func (app *App) infoHandler(w http.ResponseWriter, r *http.Request, logger *zap.
 	var infos []dataTypes.Info
 	var err error
 	if app.Zipper != nil {
-		app.ms.RequestsOut.WithLabelValues("info").Inc()
+		app.ms.UpstreamRequests.WithLabelValues("info").Inc()
 		infos, err = zipper.Info(app.Zipper, ctx, query, app.Zipper.Metrics, app.Zipper.Lg)
 	} else {
 		infos, err = app.backend.Info(ctx, request)

--- a/pkg/app/zipper/app.go
+++ b/pkg/app/zipper/app.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	bnet "github.com/bookingcom/carbonapi/pkg/backend/net"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/dgryski/go-expirecache"
 
@@ -77,6 +79,11 @@ func InitBackends(config cfg.Zipper, ms *PrometheusMetrics, logger *zap.Logger) 
 		dc, cluster, _ := config.InfoOfBackend(host.Http)
 		var b backend.Backend
 		var err error
+
+		limiterExits, err := ms.BackendLimiterExits.CurryWith(prometheus.Labels{"backend": host.Http})
+		if err != nil {
+			return nil, errors.Wrap(err, "currying the metric for LimiterExits failed")
+		}
 		bConf := bnet.Config{
 			Address:            host.Http,
 			DC:                 dc,
@@ -88,6 +95,10 @@ func InitBackends(config cfg.Zipper, ms *PrometheusMetrics, logger *zap.Logger) 
 			QHist:              ms.TimeInQueueSeconds,
 			Responses:          ms.BackendResponses,
 			Logger:             logger,
+			ActiveRequests:     ms.ActiveUpstreamRequests.WithLabelValues(host.Http),
+			WaitingRequests:    ms.WaitingUpstreamRequests.WithLabelValues(host.Http),
+			LimiterEnters:      ms.BackendLimiterEnters.WithLabelValues(host.Http),
+			LimiterExits:       limiterExits,
 		}
 		if host.Grpc != "" {
 			b, err = bnet.NewGrpc(bnet.GrpcConfig{

--- a/pkg/backend/net/grpc.go
+++ b/pkg/backend/net/grpc.go
@@ -261,16 +261,16 @@ func (gb *GrpcBackend) Info(ctx context.Context, request types.InfoRequest) ([]t
 }
 
 func (gb *GrpcBackend) countResponse(err error, request string) {
-	if gb.responses == nil {
+	if gb.responsesCount == nil {
 		return
 	}
 	if err == nil {
-		gb.responses.WithLabelValues(strconv.Itoa(int(codes.OK)), request).Inc()
+		gb.responsesCount.WithLabelValues(strconv.Itoa(int(codes.OK)), request).Inc()
 	} else {
 		code := status.Code(err)
 		if code == codes.Unknown {
 			return
 		}
-		gb.responses.WithLabelValues(strconv.Itoa(int(code)), request).Inc()
+		gb.responsesCount.WithLabelValues(strconv.Itoa(int(code)), request).Inc()
 	}
 }

--- a/pkg/backend/net/net_test.go
+++ b/pkg/backend/net/net_test.go
@@ -222,7 +222,7 @@ func TestDo(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, got, err := b.do(types.NewTrace(), req)
+	_, got, err := b.do(types.NewTrace(), req, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -257,7 +257,7 @@ func TestDoHTTPTimeout(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, _, err = b.do(types.NewTrace(), req)
+	_, _, err = b.do(types.NewTrace(), req, "")
 	if err == nil {
 		t.Errorf("Expected error")
 	}
@@ -283,7 +283,7 @@ func TestDoHTTPError(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, _, err = b.do(types.NewTrace(), req)
+	_, _, err = b.do(types.NewTrace(), req, "")
 	if err == nil {
 		t.Errorf("Expected error")
 	}


### PR DESCRIPTION
## What issue is this change attempting to solve?

* Added a set of metrics for a limiter that covers carbonapi, standalone and embedded zipper.
* Added visibility to errors in HTTP requests to backends.

## How can we be sure this works as expected?
Tested locally and on live traffic.
