### PR TITLE
Fixed routing of the pprof queries. Small refactoring.

### DIFF
--- a/pkg/app/zipper/routes.go
+++ b/pkg/app/zipper/routes.go
@@ -31,7 +31,11 @@ func initMetricHandlers() http.Handler {
 
 	r.Handle("/metrics", promhttp.Handler())
 
-	r.PathPrefix("/debug/pprof").HandlerFunc(pprof.Index)
+	r.HandleFunc("/debug/pprof", pprof.Index)
+	r.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	r.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	r.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	r.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 	return r
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -89,7 +89,7 @@ type Trace struct {
 }
 
 func (t Trace) ObserveOutDuration(ti time.Duration, dc string, cluster string) {
-	if t.OutDuration != nil { // TODO: check when it is nil
+	if t.OutDuration != nil {
 		(*t.OutDuration).With(prometheus.Labels{"cluster": cluster, "dc": dc}).Observe(ti.Seconds())
 	}
 }


### PR DESCRIPTION
## What issue is this change attempting to solve?
The cpu, trace and some other profiles cannot be obtained for carbonapi and zipper because the routing is broken.

We route as
```
r.PathPrefix("/debug/pprof").HandlerFunc(pprof.Index)
```
but this only serves part of the profiles, not all.

The routing is correctly set in the standard lib here https://cs.opensource.google/go/go/+/refs/tags/go1.19.2:src/net/http/pprof/pprof.go;l=80

## How can we be sure this works as expected?
Tested locally and on a live box.
