### PR TITLE
Processing redesign: Redesigned the backend requests processing.

### DIFF
--- a/pkg/app/carbonapi/app.go
+++ b/pkg/app/carbonapi/app.go
@@ -354,9 +354,8 @@ func initBackend(config cfg.API, logger *zap.Logger, activeUpstreamRequests, wai
 		}).DialContext,
 	}
 
-	// TODO (grzkv): Stop using a list, move to a single value in config
 	if len(config.Backends) == 0 {
-		return backend.NewBackend(nil, 0, 0, nil, nil, nil), errors.New("got empty list of backends from config")
+		return backend.NewBackend(nil, 0, 0, nil, nil, nil, nil), errors.New("got empty list of backends from config")
 	}
 	host := config.Backends[0]
 
@@ -364,7 +363,7 @@ func initBackend(config cfg.API, logger *zap.Logger, activeUpstreamRequests, wai
 		Address:            host,
 		Client:             client,
 		Timeout:            config.Timeouts.AfterStarted,
-		Limit:              config.ConcurrencyLimitPerServer,
+		Limit:              config.ConcurrencyLimitPerServer, // the old limiter stays enabled for carbonapi
 		PathCacheExpirySec: uint32(config.ExpireDelaySec),
 		Logger:             logger,
 		ActiveRequests:     activeUpstreamRequests,
@@ -374,8 +373,8 @@ func initBackend(config cfg.API, logger *zap.Logger, activeUpstreamRequests, wai
 	})
 
 	if err != nil {
-		return backend.NewBackend(b, 0, 0, nil, nil, nil), fmt.Errorf("Couldn't create backend for '%s'", host)
+		return backend.NewBackend(b, 0, 0, nil, nil, nil, nil), fmt.Errorf("Couldn't create backend for '%s'", host)
 	}
 
-	return backend.NewBackend(b, 0, 0, nil, nil, nil), nil
+	return backend.NewBackend(b, 0, 0, nil, nil, nil, nil), nil
 }

--- a/pkg/app/carbonapi/app.go
+++ b/pkg/app/carbonapi/app.go
@@ -356,7 +356,7 @@ func initBackend(config cfg.API, logger *zap.Logger, activeUpstreamRequests, wai
 
 	// TODO (grzkv): Stop using a list, move to a single value in config
 	if len(config.Backends) == 0 {
-		return nil, errors.New("got empty list of backends from config")
+		return backend.NewBackend(nil, 0, 0, nil, nil, nil), errors.New("got empty list of backends from config")
 	}
 	host := config.Backends[0]
 
@@ -374,8 +374,8 @@ func initBackend(config cfg.API, logger *zap.Logger, activeUpstreamRequests, wai
 	})
 
 	if err != nil {
-		return b, fmt.Errorf("Couldn't create backend for '%s'", host)
+		return backend.NewBackend(b, 0, 0, nil, nil, nil), fmt.Errorf("Couldn't create backend for '%s'", host)
 	}
 
-	return b, nil
+	return backend.NewBackend(b, 0, 0, nil, nil, nil), nil
 }

--- a/pkg/app/carbonapi/app_test.go
+++ b/pkg/app/carbonapi/app_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/bookingcom/carbonapi/pkg/backend"
 	"github.com/bookingcom/carbonapi/pkg/backend/mock"
 	"github.com/bookingcom/carbonapi/pkg/blocker"
 	"github.com/bookingcom/carbonapi/pkg/cache"
@@ -143,7 +144,7 @@ func SetUpTestConfig() (*App, http.Handler) {
 		slowQ:      make(chan *renderReq, config.QueueSize),
 		fastQ:      make(chan *renderReq, config.QueueSize),
 	}
-	app.backend = mock.New(mock.Config{
+	app.backend = backend.NewMock(mock.Config{
 		Find:   find,
 		Info:   info,
 		Render: render,
@@ -156,7 +157,7 @@ func SetUpTestConfig() (*App, http.Handler) {
 	setUpConfig(app, logger)
 	handler := initHandlers(app, logger)
 
-	go ProcessRequests(app)
+	ProcessRequests(app)
 
 	return app, handler
 }
@@ -177,7 +178,7 @@ func SetUpTestConfig() (*App, http.Handler) {
 // 		findCache:         cache.NewExpireCache(1000),
 // 		prometheusMetrics: newPrometheusMetrics(config),
 // 	}
-// 	app.backend = mock.New(mock.Config{
+// 	app.backend = backend.NewMock(mock.Config{
 // 		Find:   find,
 // 		Info:   info,
 // 		Render: renderErr,
@@ -198,7 +199,7 @@ func renderHandler(t *testing.T) {
 
 	// WARNING: Test results depend on the order of execution now. ENJOY THE GLOBAL STATE!!!
 	// TODO (grzkv): Fix this
-	testApp.backend = mock.New(mock.Config{
+	testApp.backend = backend.NewMock(mock.Config{
 		Find:   find,
 		Info:   info,
 		Render: render,
@@ -247,7 +248,7 @@ func renderHandlerErrs(t *testing.T) {
 
 			// WARNING: Test results depend on the order of execution now. ENJOY THE GLOBAL STATE!!!
 			// TODO (grzkv): Fix this
-			testApp.backend = mock.New(mock.Config{
+			testApp.backend = backend.NewMock(mock.Config{
 				Find:   find,
 				Info:   info,
 				Render: renderErr,
@@ -269,7 +270,7 @@ func renderHandlerNotFoundErrs(t *testing.T) {
 
 	// WARNING: Test results depend on the order of execution now. ENJOY THE GLOBAL STATE!!!
 	// TODO (grzkv): Fix this
-	testApp.backend = mock.New(mock.Config{
+	testApp.backend = backend.NewMock(mock.Config{
 		Find:   find,
 		Info:   info,
 		Render: renderErrNotFound,

--- a/pkg/app/zipper/app.go
+++ b/pkg/app/zipper/app.go
@@ -91,7 +91,7 @@ func InitBackends(config cfg.Zipper, ms *PrometheusMetrics, logger *zap.Logger) 
 			Cluster:            cluster,
 			Client:             client,
 			Timeout:            config.Timeouts.AfterStarted,
-			Limit:              config.ConcurrencyLimitPerServer,
+			Limit:              0, // the old limiter is disabled
 			PathCacheExpirySec: uint32(config.ExpireDelaySec),
 			QHist:              ms.TimeInQueueSeconds,
 			Responses:          ms.BackendResponses,
@@ -114,8 +114,9 @@ func InitBackends(config cfg.Zipper, ms *PrometheusMetrics, logger *zap.Logger) 
 			config.BackendQueueSize,
 			config.ConcurrencyLimitPerServer,
 			ms.BackendRequestsInQueue,
-			&ms.BackendSemaphoreSaturation,
-			ms.TimeInQueueSeconds)
+			ms.BackendSemaphoreSaturation,
+			ms.TimeInQueueSeconds,
+			ms.BackendEnqueuedRequests)
 
 		if err != nil {
 			return backends, fmt.Errorf("Couldn't create backend for '%s'", host)

--- a/pkg/app/zipper/http_handlers_test.go
+++ b/pkg/app/zipper/http_handlers_test.go
@@ -71,7 +71,7 @@ func TestRenderSingleBackend(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: render,
@@ -108,7 +108,7 @@ func TestRenderSingleGenericBackendError(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithGenericError,
@@ -133,7 +133,7 @@ func TestRenderSingleNotFoundBackendError(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithNotFoundError,
@@ -158,17 +158,17 @@ func TestRenderMultipleBackends(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: render,
@@ -193,27 +193,27 @@ func TestRenderMultipleBackendsSomeErrors(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithGenericError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithNotFoundError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: render,
@@ -238,17 +238,17 @@ func TestRenderMultipleBackendsAllNotfoundErrors(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithNotFoundError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithNotFoundError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithNotFoundError,
@@ -273,32 +273,32 @@ func TestRenderMultipleBackendsAllMixedErrorsBelowThreshold(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithNotFoundError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithGenericError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithGenericError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithNotFoundError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithNotFoundError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithNotFoundError,
@@ -323,47 +323,47 @@ func TestRenderMultipleBackendsAllErrorsMajorityOther(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithNotFoundError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithGenericError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithGenericError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithGenericError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithGenericError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithGenericError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithNotFoundError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithNotFoundError,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: renderWithNotFoundError,
@@ -420,7 +420,7 @@ func TestFindSingleBackend(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: render,
@@ -462,7 +462,7 @@ func TestFindSingleBackendWithGenericError(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithGenericError,
 			Info:   info,
 			Render: render,
@@ -487,7 +487,7 @@ func TestFindSingleBackendWithNotfoundError(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithNotfoundError,
 			Info:   info,
 			Render: render,
@@ -512,22 +512,22 @@ func TestFindManyBackendsAllNotfound(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithNotfoundError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithNotfoundError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithNotfoundError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithNotfoundError,
 			Info:   info,
 			Render: render,
@@ -552,27 +552,27 @@ func TestFindManyBackendsAllErrorsNotFoundMajority(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithNotfoundError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithNotfoundError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithGenericError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithGenericError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithNotfoundError,
 			Info:   info,
 			Render: render,
@@ -597,12 +597,12 @@ func TestFindManyBackendsAllErrorsOthersMajority2(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithGenericError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithNotfoundError,
 			Info:   info,
 			Render: render,
@@ -627,12 +627,12 @@ func TestFindManyBackendsAllErrorsOthersMajoritySmallAmount(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithGenericError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithGenericError,
 			Info:   info,
 			Render: render,
@@ -657,57 +657,57 @@ func TestFindManyBackendsAllErrorsOthersMajority(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithNotfoundError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithNotfoundError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithNotfoundError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithGenericError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithGenericError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithGenericError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithGenericError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithNotfoundError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithNotfoundError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithGenericError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithGenericError,
 			Info:   info,
 			Render: render,
@@ -732,27 +732,27 @@ func TestFindManyBackendsSomeMixedErrors(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithNotfoundError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithNotfoundError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   findWithGenericError,
 			Info:   info,
 			Render: render,
 		}),
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: render,
@@ -803,7 +803,7 @@ func TestInfoSingleBackend(t *testing.T) {
 	app, ms, lg := newTestApp()
 	defer lg.Sync()
 	app.Backends = []backend.Backend{
-		mock.New(mock.Config{
+		backend.NewMock(mock.Config{
 			Find:   find,
 			Info:   info,
 			Render: render,

--- a/pkg/app/zipper/metrics.go
+++ b/pkg/app/zipper/metrics.go
@@ -212,8 +212,13 @@ func NewPrometheusMetrics(config cfg.Zipper, ns string) *PrometheusMetrics {
 		BackendTimeInQSec: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: ns,
-				Name: "backend_time_in_queue",
-				Help: "Time a request to backend spends waiting in queue by request type",
+				Name:      "backend_time_in_queue",
+				Help:      "Time a request to backend spends waiting in queue by request type",
+				Buckets: prometheus.ExponentialBuckets(
+					config.Monitoring.BackendTimeInQSecHistParams.Start,
+					config.Monitoring.BackendTimeInQSecHistParams.BucketSize,
+					config.Monitoring.BackendTimeInQSecHistParams.BucketsNum,
+				),
 			},
 			[]string{"request"},
 		),

--- a/pkg/app/zipper/metrics.go
+++ b/pkg/app/zipper/metrics.go
@@ -31,6 +31,11 @@ type PrometheusMetrics struct {
 	FindDurationLin      prometheus.Histogram
 	FindOutDuration      *prometheus.HistogramVec
 
+	BackendEnqueuedRequests    *prometheus.CounterVec
+	BackendRequestsInQueue     *prometheus.GaugeVec
+	BackendSemaphoreSaturation prometheus.Gauge
+	BackendTimeInQSec          *prometheus.HistogramVec
+
 	TimeInQueueSeconds *prometheus.HistogramVec
 
 	TLDCacheProbeReqTotal  prometheus.Counter
@@ -113,13 +118,13 @@ func NewPrometheusMetrics(config cfg.Zipper, ns string) *PrometheusMetrics {
 		}, []string{"backend"}),
 		BackendLimiterEnters: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "backend_limiter_enters",
-			Help: "Counter of requests that entered a backend limiter by backend",
+			Name:      "backend_limiter_enters",
+			Help:      "Counter of requests that entered a backend limiter by backend",
 		}, []string{"backend"}),
 		BackendLimiterExits: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: ns,
-			Name: "backend_limiter_exits",
-			Help: "Counter of backend limiter exits by backend and by status",
+			Name:      "backend_limiter_exits",
+			Help:      "Counter of backend limiter exits by backend and by status",
 		}, []string{"backend", "status"}),
 		RenderDurationExp: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
@@ -180,6 +185,39 @@ func NewPrometheusMetrics(config cfg.Zipper, ns string) *PrometheusMetrics {
 			},
 			[]string{"cluster"},
 		),
+
+		BackendEnqueuedRequests: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: ns,
+				Name:      "backend_enqueued_requests",
+				Help:      "The number of requests to backends put in their respective queues.",
+			},
+			[]string{"request"},
+		),
+		BackendRequestsInQueue: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: ns,
+				Name:      "backend_requests_in_queue",
+				Help:      "The number of requests currently in the queue by request type.",
+			},
+			[]string{"request"},
+		),
+		BackendSemaphoreSaturation: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: ns,
+				Name:      "backend_semaphore_saturation",
+				Help:      "The number of requests currently in flight that saturate the semaphore.",
+			},
+		),
+		BackendTimeInQSec: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: ns,
+				Name: "backend_time_in_queue",
+				Help: "Time a request to backend spends waiting in queue by request type",
+			},
+			[]string{"request"},
+		),
+
 		TimeInQueueSeconds: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: ns,
@@ -254,6 +292,11 @@ func metricsServer(app *App, serve bool) *http.Server {
 	prometheus.MustRegister(app.Metrics.FindDurationLin)
 	prometheus.MustRegister(app.Metrics.FindOutDuration)
 	prometheus.MustRegister(app.Metrics.TimeInQueueSeconds)
+
+	prometheus.MustRegister(app.Metrics.BackendEnqueuedRequests)
+	prometheus.MustRegister(app.Metrics.BackendRequestsInQueue)
+	prometheus.MustRegister(app.Metrics.BackendSemaphoreSaturation)
+	prometheus.MustRegister(app.Metrics.BackendTimeInQSec)
 
 	prometheus.MustRegister(app.Metrics.TLDCacheHostsPerDomain)
 	prometheus.MustRegister(app.Metrics.TLDCacheProbeErrors)

--- a/pkg/app/zipper/tldcache_test.go
+++ b/pkg/app/zipper/tldcache_test.go
@@ -12,10 +12,10 @@ import (
 
 func TestGetBackendsForPrefix(t *testing.T) {
 	allBackends := []backend.Backend{
-		mock.Backend{Address: "0"},
-		mock.Backend{Address: "1"},
-		mock.Backend{Address: "2"},
-		mock.Backend{Address: "3"},
+		backend.NewBackend(mock.Backend{Address: "0"}, 0, 0, nil, nil, nil),
+		backend.NewBackend(mock.Backend{Address: "1"}, 0, 0, nil, nil, nil),
+		backend.NewBackend(mock.Backend{Address: "2"}, 0, 0, nil, nil, nil),
+		backend.NewBackend(mock.Backend{Address: "3"}, 0, 0, nil, nil, nil),
 	}
 	var tt = []struct {
 		prefix      tldPrefix

--- a/pkg/app/zipper/tldcache_test.go
+++ b/pkg/app/zipper/tldcache_test.go
@@ -12,10 +12,10 @@ import (
 
 func TestGetBackendsForPrefix(t *testing.T) {
 	allBackends := []backend.Backend{
-		backend.NewBackend(mock.Backend{Address: "0"}, 0, 0, nil, nil, nil),
-		backend.NewBackend(mock.Backend{Address: "1"}, 0, 0, nil, nil, nil),
-		backend.NewBackend(mock.Backend{Address: "2"}, 0, 0, nil, nil, nil),
-		backend.NewBackend(mock.Backend{Address: "3"}, 0, 0, nil, nil, nil),
+		backend.NewBackend(mock.Backend{Address: "0"}, 0, 0, nil, nil, nil, nil),
+		backend.NewBackend(mock.Backend{Address: "1"}, 0, 0, nil, nil, nil, nil),
+		backend.NewBackend(mock.Backend{Address: "2"}, 0, 0, nil, nil, nil, nil),
+		backend.NewBackend(mock.Backend{Address: "3"}, 0, 0, nil, nil, nil, nil),
 	}
 	var tt = []struct {
 		prefix      tldPrefix

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -1,0 +1,173 @@
+package backend
+
+import (
+	"context"
+	"time"
+
+	"github.com/bookingcom/carbonapi/pkg/backend/mock"
+	"github.com/bookingcom/carbonapi/pkg/types"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+)
+
+type renderReq struct {
+	types.RenderRequest
+
+	Ctx       context.Context
+	StartTime time.Time
+
+	Results chan []types.Metric
+	Errors  chan error
+}
+
+type findReq struct {
+	types.FindRequest
+
+	Ctx       context.Context
+	StartTime time.Time
+
+	Results chan types.Matches
+	Errors  chan error
+}
+
+type infoReq struct {
+	types.InfoRequest
+
+	Ctx       context.Context
+	StartTime time.Time
+
+	Results chan []types.Info
+	Errors  chan error
+}
+
+// The backend to send requests to.
+type Backend struct {
+	BackendImpl
+
+	// Request queues.
+	// There's a separate one for each type, because the stampeding requests of one type should not
+	// impact the other types of requests.
+	// This, for example, removes the dependency between the find and render requests performance.
+	// Huge amount of render requests will not have direct impact on the find requests besides the semphore.
+	RenderQ chan *renderReq
+	FindQ   chan *findReq
+	InfoQ   chan *infoReq // the info requests are expected to be relatively rare
+
+	// The size of the requests semaphore:
+	// The maximum number of simultaneous requests.
+	SemaSize int
+}
+
+// Creates a new backend and starts processing the queues if qSize > 0.
+//
+// Passing qSize == 0 disables async processing, and the backend only works as a proxy to the implementation functions.
+// Using the channels won't work in that mode.
+// TODO (redesign): Remove the option to have qSize == 0 and proxy processor when the redesign is finished.
+func NewBackend(impl BackendImpl, qSize int, semaSize int,
+	requestsInQueue *prometheus.GaugeVec,
+	saturation *prometheus.Gauge,
+	timeInQSec *prometheus.HistogramVec) Backend {
+	b := Backend{
+		BackendImpl: impl,
+		RenderQ:     make(chan *renderReq, qSize),
+		FindQ:       make(chan *findReq, qSize),
+		InfoQ:       make(chan *infoReq, qSize),
+		SemaSize:    semaSize,
+	}
+
+	if qSize > 0 {
+		// Proc is the only function that uses the supplied metrics.
+		// The metrics can be nil if it's not called.
+		// Cannot be called w/ nil metrics.
+		b.Proc(requestsInQueue, *saturation, timeInQSec)
+	}
+
+	return b
+}
+
+// Process the requests in the queue.
+// Should not be called when async processing is disabled.
+// Expects the metrics to be non-nil.
+func (b *Backend) Proc(
+	requestsInQueue *prometheus.GaugeVec,
+	saturation prometheus.Gauge,
+	timeInQSec *prometheus.HistogramVec) {
+
+	semaphore := make(chan bool, b.SemaSize)
+
+	go func() {
+		for r := range b.RenderQ {
+			requestsInQueue.WithLabelValues("render").Dec()
+			semaphore <- true
+			saturation.Inc()
+			timeInQSec.WithLabelValues("render").Observe(float64(time.Now().Sub(r.StartTime)))
+			go func(req *renderReq) {
+				res, err := b.BackendImpl.Render(req.Ctx, req.RenderRequest)
+				if err != nil {
+					req.Errors <- err
+				} else {
+					req.Results <- res
+				}
+				<-semaphore
+				saturation.Dec()
+			}(r)
+		}
+	}()
+	go func() {
+		for r := range b.FindQ {
+			requestsInQueue.WithLabelValues("find").Dec()
+			semaphore <- true
+			saturation.Inc()
+			timeInQSec.WithLabelValues("find").Observe(float64(time.Now().Sub(r.StartTime)))
+			go func(req *findReq) {
+				res, err := b.BackendImpl.Find(req.Ctx, req.FindRequest)
+				if err != nil {
+					req.Errors <- err
+				} else {
+					req.Results <- res
+				}
+				<-semaphore
+				saturation.Dec()
+			}(r)
+		}
+	}()
+	go func() {
+		for r := range b.InfoQ {
+			requestsInQueue.WithLabelValues("info").Dec()
+			semaphore <- true
+			saturation.Inc()
+			timeInQSec.WithLabelValues("info").Observe(float64(time.Now().Sub(r.StartTime)))
+			go func(req *infoReq) {
+				res, err := b.BackendImpl.Info(req.Ctx, req.InfoRequest)
+				if err != nil {
+					req.Errors <- err
+				} else {
+					req.Results <- res
+				}
+				<-semaphore
+				saturation.Dec()
+			}(r)
+		}
+	}()
+}
+
+// The specific backend implementation.
+//
+// At the moment of writing can be one of:
+// * mock, used for tests
+// * net, used for standard comms
+// * grpc, used for streaming gRPC
+type BackendImpl interface {
+	Find(context.Context, types.FindRequest) (types.Matches, error)
+	Info(context.Context, types.InfoRequest) ([]types.Info, error)
+	Render(context.Context, types.RenderRequest) ([]types.Metric, error)
+
+	Contains([]string) bool // Reports whether a backend contains any of the given targets.
+	Logger() *zap.Logger    // A logger used to communicate non-fatal warnings.
+	GetServerAddress() string
+	GetCluster() string
+}
+
+func NewMock(cfg mock.Config) Backend {
+	return NewBackend(mock.New(cfg), 0, 0, nil, nil, nil)
+}

--- a/pkg/backend/benchmark_test.go
+++ b/pkg/backend/benchmark_test.go
@@ -62,7 +62,7 @@ func BenchmarkRenders(b *testing.B) {
 
 	backends := make([]Backend, 0)
 	for i := 0; i < 3; i++ {
-		backends = append(backends, bk)
+		backends = append(backends, NewBackend(bk, 0, 0, nil, nil, nil))
 	}
 
 	ctx := context.Background()
@@ -183,7 +183,7 @@ func BenchmarkRendersStorm(b *testing.B) {
 			b.Fatal(err)
 		}
 
-		backends = append(backends, bk)
+		backends = append(backends, NewBackend(bk, 0, 0, nil, nil, nil))
 	}
 
 	ctx := context.Background()
@@ -288,7 +288,7 @@ func BenchmarkRendersMismatchStorm(b *testing.B) {
 			b.Fatal(err)
 		}
 
-		backends = append(backends, bk)
+		backends = append(backends, NewBackend(bk, 0, 0, nil, nil, nil))
 	}
 
 	ctx := context.Background()

--- a/pkg/backend/benchmark_test.go
+++ b/pkg/backend/benchmark_test.go
@@ -62,7 +62,7 @@ func BenchmarkRenders(b *testing.B) {
 
 	backends := make([]Backend, 0)
 	for i := 0; i < 3; i++ {
-		backends = append(backends, NewBackend(bk, 0, 0, nil, nil, nil))
+		backends = append(backends, NewBackend(bk, 0, 0, nil, nil, nil, nil))
 	}
 
 	ctx := context.Background()
@@ -183,7 +183,7 @@ func BenchmarkRendersStorm(b *testing.B) {
 			b.Fatal(err)
 		}
 
-		backends = append(backends, NewBackend(bk, 0, 0, nil, nil, nil))
+		backends = append(backends, NewBackend(bk, 0, 0, nil, nil, nil, nil))
 	}
 
 	ctx := context.Background()
@@ -288,7 +288,7 @@ func BenchmarkRendersMismatchStorm(b *testing.B) {
 			b.Fatal(err)
 		}
 
-		backends = append(backends, NewBackend(bk, 0, 0, nil, nil, nil))
+		backends = append(backends, NewBackend(bk, 0, 0, nil, nil, nil, nil))
 	}
 
 	ctx := context.Background()

--- a/pkg/backend/net/grpc.go
+++ b/pkg/backend/net/grpc.go
@@ -22,7 +22,7 @@ import (
 // GrpcBackend represents a host that accepts requests for metrics over gRPC and HTTP.
 // This struct overrides Backend interface functions to use gRPC.
 type GrpcBackend struct {
-	*Backend
+	*NetBackend
 	GrpcAddress    string
 	carbonV2Client capi_v2_grpc.CarbonV2Client
 	maxRecvMsgSize int
@@ -47,7 +47,7 @@ func NewGrpc(cfg GrpcConfig) (*GrpcBackend, error) {
 	c := capi_v2_grpc.NewCarbonV2Client(conn)
 
 	return &GrpcBackend{
-		Backend:        b,
+		NetBackend:     b,
 		GrpcAddress:    cfg.GrpcAddress,
 		carbonV2Client: c,
 		maxRecvMsgSize: 100 * 1024 * 1024, // TODO: Make configurable

--- a/pkg/backend/net/net.go
+++ b/pkg/backend/net/net.go
@@ -126,10 +126,8 @@ func New(cfg Config) (*NetBackend, error) {
 		if cfg.ActiveRequests != nil && cfg.WaitingRequests != nil &&
 			cfg.LimiterEnters != nil && cfg.LimiterExits != nil {
 
-			b.limiter = prioritylimiter.New(cfg.Limit, prioritylimiter.WithMetrics(
-				cfg.ActiveRequests, cfg.WaitingRequests, cfg.LimiterEnters, cfg.LimiterExits))
-		} else {
-			b.limiter = prioritylimiter.New(cfg.Limit)
+			b.limiter = prioritylimiter.New(cfg.Limit,
+				prioritylimiter.WithMetrics(cfg.ActiveRequests, cfg.WaitingRequests, cfg.LimiterEnters, cfg.LimiterExits))
 		}
 	}
 

--- a/pkg/backend/net/net_test.go
+++ b/pkg/backend/net/net_test.go
@@ -329,25 +329,6 @@ func TestEnterLimiter(t *testing.T) {
 	}
 }
 
-func TestEnterLimiterTimeout(t *testing.T) {
-	b, err := New(Config{Limit: 1})
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	if err := b.enter(context.Background()); err != nil {
-		t.Error("Expected to enter limiter")
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 0)
-	defer cancel()
-
-	if got := b.enter(ctx); got == nil {
-		t.Error("Expected to time out")
-	}
-}
-
 func TestExitNilLimiter(t *testing.T) {
 	b, err := New(Config{})
 	if err != nil {
@@ -373,18 +354,6 @@ func TestEnterExitLimiter(t *testing.T) {
 
 	if err := b.leave(); err != nil {
 		t.Error("Expected to leave limiter")
-	}
-}
-
-func TestEnterExitLimiterError(t *testing.T) {
-	b, err := New(Config{Limit: 1})
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	if err := b.leave(); err == nil {
-		t.Error("Expected to get error")
 	}
 }
 

--- a/pkg/backend/rpc.go
+++ b/pkg/backend/rpc.go
@@ -26,18 +26,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// Backend codifies the RPC calls a Graphite backend responds to.
-type Backend interface {
-	Find(context.Context, types.FindRequest) (types.Matches, error)
-	Info(context.Context, types.InfoRequest) ([]types.Info, error)
-	Render(context.Context, types.RenderRequest) ([]types.Metric, error)
-
-	Contains([]string) bool // Reports whether a backend contains any of the given targets.
-	Logger() *zap.Logger    // A logger used to communicate non-fatal warnings.
-	GetServerAddress() string
-	GetCluster() string
-}
-
 // TODO(gmagnusson): ^ Remove IsAbsent: IsAbsent[i] => Values[i] == NaN
 // Doing math on NaN is expensive, but assuming that all functions will treat a
 // default value of 0 intelligently is wrong (see multiplication). Thus math
@@ -70,6 +58,13 @@ func Renders(
 				msgCh <- msg
 			}
 		}(backend)
+		// backend.RenderQ <- &renderReq{
+		// 	RenderRequest: request,
+		// 	Ctx:           ctx,
+		// 	StartTime:     time.Now(),
+		// 	Results:       msgCh,
+		// 	Errors:        errCh,
+		// }
 	}
 
 	msgs := make([][]types.Metric, 0, len(backends))

--- a/pkg/backend/rpc_test.go
+++ b/pkg/backend/rpc_test.go
@@ -15,10 +15,10 @@ import (
 
 func TestFilter(t *testing.T) {
 	backends := []Backend{
-		mock.New(mock.Config{
+		NewMock(mock.Config{
 			Contains: func([]string) bool { return true },
 		}),
-		mock.New(mock.Config{
+		NewMock(mock.Config{
 			Contains: func([]string) bool { return false },
 		}),
 	}
@@ -34,7 +34,7 @@ func TestFilter(t *testing.T) {
 
 func TestFilterNoneContains(t *testing.T) {
 	backends := []Backend{
-		mock.New(mock.Config{
+		NewMock(mock.Config{
 			Contains: func([]string) bool { return false },
 		}),
 	}
@@ -105,7 +105,7 @@ func TestCarbonapiv2Renders(t *testing.T) {
 				},
 			}, nil
 		}
-		b := mock.New(mock.Config{Render: render})
+		b := NewMock(mock.Config{Render: render})
 		backends = append(backends, b)
 	}
 
@@ -146,7 +146,7 @@ func TestCarbonapiv2RendersError(t *testing.T) {
 		return nil, errors.New("No")
 	}
 
-	backends := []Backend{mock.New(mock.Config{Render: render})}
+	backends := []Backend{NewMock(mock.Config{Render: render})}
 
 	logger := zap.NewNop()
 	_, _, err := Renders(context.Background(), backends, types.NewRenderRequest(nil, 0, 1), cfg.RenderReplicaMismatchConfig{
@@ -161,7 +161,7 @@ func TestCarbonapiv2RendersError(t *testing.T) {
 
 func TestCarbonapiv2InfosCorrectMerge(t *testing.T) {
 	backends := []Backend{
-		mock.New(mock.Config{
+		NewMock(mock.Config{
 			Info: func(context.Context, types.InfoRequest) ([]types.Info, error) {
 				return []types.Info{
 					types.Info{
@@ -172,7 +172,7 @@ func TestCarbonapiv2InfosCorrectMerge(t *testing.T) {
 				}, nil
 			},
 		}),
-		mock.New(mock.Config{
+		NewMock(mock.Config{
 			Info: func(context.Context, types.InfoRequest) ([]types.Info, error) {
 				return []types.Info{
 					types.Info{
@@ -203,7 +203,7 @@ func TestCarbonapiv2InfosCorrectMerge(t *testing.T) {
 
 func TestCarbonapiv2InfosError(t *testing.T) {
 	backends := []Backend{
-		mock.New(mock.Config{
+		NewMock(mock.Config{
 			Info: func(context.Context, types.InfoRequest) ([]types.Info, error) {
 				return nil, errors.New("No")
 			},
@@ -229,7 +229,7 @@ func TestCarbonapiv2Infos(t *testing.T) {
 				},
 			}, nil
 		}
-		b := mock.New(mock.Config{Info: info})
+		b := NewMock(mock.Config{Info: info})
 		backends = append(backends, b)
 	}
 
@@ -250,7 +250,7 @@ func TestCarbonapiv2FindsError(t *testing.T) {
 		return types.Matches{}, errors.New("No")
 	}
 
-	backends := []Backend{mock.New(mock.Config{Find: find})}
+	backends := []Backend{NewMock(mock.Config{Find: find})}
 
 	_, err := Finds(context.Background(), backends, types.NewFindRequest(""), nil)
 	if err == nil {
@@ -275,7 +275,7 @@ func TestCarbonapiv2Finds(t *testing.T) {
 				},
 			}, nil
 		}
-		b := mock.New(mock.Config{Find: find})
+		b := NewMock(mock.Config{Find: find})
 		backends = append(backends, b)
 	}
 

--- a/pkg/cfg/common.go
+++ b/pkg/cfg/common.go
@@ -55,6 +55,10 @@ func DefaultCommonConfig() Common {
 		KeepAliveInterval:         30 * time.Second,
 		MaxIdleConnsPerHost:       100,
 
+		// The default is intentionally large since we don't want to use this as a limit,
+		// at least for now.
+		BackendQueueSize: 100000,
+
 		ExpireDelaySec:       int32(10 * time.Minute / time.Second),
 		InternalRoutingCache: int32(5 * time.Minute / time.Second),
 
@@ -163,6 +167,7 @@ func GetDefaultLoggerConfig() zap.Config {
 }
 
 // Common is the configuration shared by carbonapi and carbonzipper
+// TODO: This abstraction is not used and has to be removed.
 type Common struct {
 	Listen            string            `yaml:"listen"`
 	ListenInternal    string            `yaml:"listenInternal"`
@@ -176,6 +181,9 @@ type Common struct {
 	ConcurrencyLimitPerServer int           `yaml:"concurrencyLimit"`
 	KeepAliveInterval         time.Duration `yaml:"keepAliveInterval"`
 	MaxIdleConnsPerHost       int           `yaml:"maxIdleConnsPerHost"`
+
+	BackendQueueSize             int `yaml:"backendQueueSize"`
+	BackendMaxConcurrentRequests int `yaml:"backendMaxConcurrentRequests"`
 
 	ExpireDelaySec             int32    `yaml:"expireDelaySec"`
 	InternalRoutingCache       int32    `yaml:"internalRoutingCache"`

--- a/pkg/cfg/common.go
+++ b/pkg/cfg/common.go
@@ -126,6 +126,11 @@ func DefaultCommonConfig() Common {
 				BucketSize: 1.5,
 				BucketsNum: 20,
 			},
+			BackendTimeInQSecHistParams: HistogramConfig{
+				Start:      0.01,
+				BucketSize: 2,
+				BucketsNum: 12,
+			},
 		},
 		Traces: Traces{
 			Timeout:              10 * time.Second,
@@ -334,17 +339,18 @@ func (common Common) InfoOfBackend(address string) (string, string, error) {
 
 // MonitoringConfig allows setting custom monitoring parameters
 type MonitoringConfig struct {
-	RequestDurationExp      HistogramConfig `yaml:"requestDurationExpHistogram"`
-	RequestDurationLin      HistogramConfig `yaml:"requestDurationLinHistogram"`
-	RenderDurationExp       HistogramConfig `yaml:"renderDurationExpHistogram"`
-	RenderDurationLinSimple HistogramConfig `yaml:"renderDurationLinHistogram"`
-	FindDurationExp         HistogramConfig `yaml:"findDurationExpHistogram"`
-	FindDurationLin         HistogramConfig `yaml:"findDurationLinHistogram"`
-	FindDurationLinSimple   HistogramConfig `yaml:"findDurationSimpleLinHistogram"`
-	FindDurationLinComplex  HistogramConfig `yaml:"findDurationComplexLinHistogram"`
-	FindOutDuration         HistogramConfig `yaml:"findDurationByBackend"`
-	TimeInQueueExpHistogram HistogramConfig `yaml:"timeInQueueExpHistogram"` // TODO Change to seconds.
-	TimeInQueueLinHistogram HistogramConfig `yaml:"timeInQueueLinHistogram"`
+	RequestDurationExp          HistogramConfig `yaml:"requestDurationExpHistogram"`
+	RequestDurationLin          HistogramConfig `yaml:"requestDurationLinHistogram"`
+	RenderDurationExp           HistogramConfig `yaml:"renderDurationExpHistogram"`
+	RenderDurationLinSimple     HistogramConfig `yaml:"renderDurationLinHistogram"`
+	FindDurationExp             HistogramConfig `yaml:"findDurationExpHistogram"`
+	FindDurationLin             HistogramConfig `yaml:"findDurationLinHistogram"`
+	FindDurationLinSimple       HistogramConfig `yaml:"findDurationSimpleLinHistogram"`
+	FindDurationLinComplex      HistogramConfig `yaml:"findDurationComplexLinHistogram"`
+	FindOutDuration             HistogramConfig `yaml:"findDurationByBackend"`
+	TimeInQueueExpHistogram     HistogramConfig `yaml:"timeInQueueExpHistogram"` // TODO Change to seconds.
+	TimeInQueueLinHistogram     HistogramConfig `yaml:"timeInQueueLinHistogram"`
+	BackendTimeInQSecHistParams HistogramConfig `yaml:"backendTimeInQSecHistParams"`
 }
 
 // HistogramConfig is histogram config for Prometheus metrics


### PR DESCRIPTION
*Disclaimer: This PR is part of a bigger refactoring. We had to make design compromises to accommodate both the old and the new processing systems at the same time. Once we completely switch to the new system, the design and code can be cleaned-up and ordered. Final touches are part of #407, and we'll do them before closing it.*

## What issue is this change attempting to solve?
This is a continuation of #407

This PR contains the new implementation of the backend requests processing. The old backend limiters were removed and replaced with the new processing via queues. At the same time, the old top-level limiter in `carbonapi` still stays in place and will be removed at the later stages.

## How can we be sure this works as expected?
Tested locally and on live traffic.
