### PR TITLE
Processing redesign: Disabled old limiter in carbonapi. Added timeout handling.

### DIFF
--- a/pkg/app/carbonapi/app.go
+++ b/pkg/app/carbonapi/app.go
@@ -77,7 +77,6 @@ func New(config cfg.API, lg *zap.Logger, buildVersion string) (*App, error) {
 	}
 	app.requestBlocker.ReloadRules()
 
-	// TODO(gmagnusson): Setup backends
 	backend, err := initBackend(app.config, lg,
 		app.ms.ActiveUpstreamRequests, app.ms.WaitingUpstreamRequests,
 		app.ms.UpstreamLimiterEnters, app.ms.UpstreamLimiterExits)
@@ -157,6 +156,7 @@ func (app *App) registerPrometheusMetrics() {
 	prometheus.MustRegister(app.ms.UpstreamEnqueuedRequests)
 	prometheus.MustRegister(app.ms.UpstreamSubRenderNum)
 	prometheus.MustRegister(app.ms.UpstreamTimeInQSec)
+	prometheus.MustRegister(app.ms.UpstreamTimeouts)
 
 	prometheus.MustRegister(app.ms.TimeInQueueExp)
 	prometheus.MustRegister(app.ms.TimeInQueueLin)
@@ -363,7 +363,7 @@ func initBackend(config cfg.API, logger *zap.Logger, activeUpstreamRequests, wai
 		Address:            host,
 		Client:             client,
 		Timeout:            config.Timeouts.AfterStarted,
-		Limit:              config.ConcurrencyLimitPerServer, // the old limiter stays enabled for carbonapi
+		Limit:              0, // the old limiter is DISABLED now. TODO: Cleanup.
 		PathCacheExpirySec: uint32(config.ExpireDelaySec),
 		Logger:             logger,
 		ActiveRequests:     activeUpstreamRequests,

--- a/pkg/app/carbonapi/app.go
+++ b/pkg/app/carbonapi/app.go
@@ -212,6 +212,8 @@ func setUpConfig(app *App, logger *zap.Logger) {
 		}
 		app.queryCache = cache.NewReplicatedMemcached(app.config.Cache.Prefix,
 			app.config.Cache.QueryTimeoutMs,
+			app.config.Cache.MemcachedTimeoutMs,
+			app.config.Cache.MemcachedMaxIdleConns,
 			reqsRender,
 			respReadRender,
 			app.ms.CacheTimeouts.WithLabelValues("render"),
@@ -227,6 +229,8 @@ func setUpConfig(app *App, logger *zap.Logger) {
 		}
 		app.findCache = cache.NewReplicatedMemcached(app.config.Cache.Prefix,
 			app.config.Cache.QueryTimeoutMs,
+			app.config.Cache.MemcachedTimeoutMs,
+			app.config.Cache.MemcachedMaxIdleConns,
 			reqsFind,
 			respReadFind,
 			app.ms.CacheTimeouts.WithLabelValues("find"),

--- a/pkg/app/carbonapi/http_handlers.go
+++ b/pkg/app/carbonapi/http_handlers.go
@@ -442,6 +442,11 @@ func (app *App) getTargetData(ctx context.Context, target string, exp parser.Exp
 
 				Results: rch,
 			}
+			// TODO: Don't rely on context in the final solution.
+			if dl, ok := ctx.Deadline(); ok {
+				// we use microseconds to avoid undefined zero-time behaviour of UnixNano
+				req.DeadlineMicro = dl.UnixMicro()
+			}
 
 			if subrequestCount > app.config.LargeReqSize {
 				app.slowQ <- req

--- a/pkg/app/carbonapi/http_handlers.go
+++ b/pkg/app/carbonapi/http_handlers.go
@@ -517,7 +517,9 @@ func optimistFanIn(errs []error, n int, subj string) (error, string) {
 	errStr := ""
 	for _, e := range errs {
 		var notFound dataTypes.ErrNotFound
-		errStr = errStr + e.Error() + ", "
+		if len(errStr) < 200 {
+			errStr = errStr + e.Error() + ", "
+		}
 		if !errors.As(e, &notFound) {
 			allErrorsNotFound = false
 		}

--- a/pkg/app/carbonapi/metrics.go
+++ b/pkg/app/carbonapi/metrics.go
@@ -31,6 +31,7 @@ type PrometheusMetrics struct {
 	UpstreamEnqueuedRequests    *prometheus.CounterVec
 	UpstreamSubRenderNum        prometheus.Histogram
 	UpstreamTimeInQSec          *prometheus.HistogramVec
+	UpstreamTimeouts            *prometheus.CounterVec
 
 	TimeInQueueExp prometheus.Histogram
 	TimeInQueueLin prometheus.Histogram
@@ -227,6 +228,10 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 				config.UpstreamTimeInQSecHistParams.BucketsNum,
 			),
 		}, []string{"queue"}),
+		UpstreamTimeouts: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "upstream_timedout_requests",
+			Help: "The counter of upstream requests that were never sent upstream because of timeout.",
+		}, []string{"queue", "request"}),
 
 		TimeInQueueExp: prometheus.NewHistogram(
 			prometheus.HistogramOpts{

--- a/pkg/app/carbonapi/proc.go
+++ b/pkg/app/carbonapi/proc.go
@@ -2,14 +2,13 @@ package carbonapi
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/bookingcom/carbonapi/pkg/carbonapipb"
 )
 
 // ProcessRequests processes the queued requests.
-// TODO: Handler request timeouts. The timed-out requests don't need to be forwarded.
-//       Currently, they'll be handled by the old limiter that's still in place.
 func ProcessRequests(app *App) {
 	// semaphore does what semaphores do: It limits the number of concurrent requests.
 	semaphore := make(chan bool, app.config.MaxConcurrentUpstreamRequests)
@@ -17,7 +16,7 @@ func ProcessRequests(app *App) {
 		go func() {
 			for {
 				var req *renderReq
-				var label string
+				var qLabel string
 
 				// During processing we use two independent queues that share the semaphore:
 				// fastQ includes regular requests while slowQ contains large requests.
@@ -29,16 +28,25 @@ func ProcessRequests(app *App) {
 				// effectively increases priority of the smaller requests.
 				select {
 				case req = <-app.fastQ:
-					label = "fast"
+					qLabel = "fast"
 				case req = <-app.slowQ:
-					label = "slow"
+					qLabel = "slow"
 				}
 
-				app.ms.UpstreamRequestsInQueue.WithLabelValues(label).Dec()
+				app.ms.UpstreamRequestsInQueue.WithLabelValues(qLabel).Dec()
+
+				// The use of the atomic load here is a for future safety.
+				// Currently, it's not strictly necessary.
+				dl := atomic.LoadInt64(&req.DeadlineMicro)
+				if dl != 0 && dl < time.Now().UnixMicro() {
+					app.ms.UpstreamTimeInQSec.WithLabelValues(qLabel).Observe(float64(time.Now().Sub(req.StartTime).Seconds()))
+					app.ms.UpstreamTimeouts.WithLabelValues(qLabel, "render")
+					continue
+				}
 
 				semaphore <- true
 				app.ms.UpstreamSemaphoreSaturation.Inc()
-				app.ms.UpstreamTimeInQSec.WithLabelValues(label).Observe(float64(time.Now().Sub(req.StartTime).Seconds()))
+				app.ms.UpstreamTimeInQSec.WithLabelValues(qLabel).Observe(float64(time.Now().Sub(req.StartTime).Seconds()))
 
 				go func(r *renderReq) {
 					r.Results <- app.sendRenderRequest(r.Ctx, r.Path, r.From, r.Until, r.ToLog)
@@ -57,9 +65,10 @@ type renderReq struct {
 	From  int32
 	Until int32
 
-	Ctx       context.Context
-	ToLog     *carbonapipb.AccessLogDetails
-	StartTime time.Time
+	Ctx           context.Context
+	ToLog         *carbonapipb.AccessLogDetails
+	StartTime     time.Time
+	DeadlineMicro int64
 
 	Results chan renderResponse
 }

--- a/pkg/app/zipper/app.go
+++ b/pkg/app/zipper/app.go
@@ -115,7 +115,7 @@ func InitBackends(config cfg.Zipper, ms *PrometheusMetrics, logger *zap.Logger) 
 			config.ConcurrencyLimitPerServer,
 			ms.BackendRequestsInQueue,
 			ms.BackendSemaphoreSaturation,
-			ms.TimeInQueueSeconds,
+			ms.BackendTimeInQSec,
 			ms.BackendEnqueuedRequests)
 
 		if err != nil {

--- a/pkg/app/zipper/zipper.go
+++ b/pkg/app/zipper/zipper.go
@@ -71,7 +71,7 @@ func Setup(configFile string, BuildVersion string, metricsNS string, lgOverride 
 		Backends:            bs,
 		TopLevelDomainCache: expirecache.New(0),
 		TLDPrefixes:         InitTLDPrefixes(logger, config.TLDCacheExtraPrefixes),
-		Lg: logger,
+		Lg:                  logger,
 	}
 
 	return app, logger

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -207,7 +207,8 @@ func (backend Backend) SendRender(ctx context.Context, request types.RenderReque
 	}
 }
 
-func (backend Backend) SendFind(ctx context.Context, request types.FindRequest, msgCh chan types.Matches, errCh chan error, durationHist *prometheus.HistogramVec) {
+func (backend Backend) SendFind(ctx context.Context, request types.FindRequest,
+	msgCh chan types.Matches, errCh chan error, durationHist *prometheus.HistogramVec) {
 	if cap(backend.findQ) > 0 {
 		backend.findQ <- &findReq{
 			FindRequest: request,

--- a/pkg/backend/net/net.go
+++ b/pkg/backend/net/net.go
@@ -300,12 +300,6 @@ func (b NetBackend) call(ctx context.Context, trace types.Trace, u *url.URL, req
 	return contentType, body, err
 }
 
-// TODO(gmagnusson): Should Contains become something different, where instead
-// of answering yes/no to whether the backend contains any of the given
-// targets, it returns a filtered list of targets that the backend contains?
-// Is it worth it to make the distinction? If go-carbon isn't too unhappy about
-// looking up metrics that it doesn't have, we maybe don't need to do this.
-
 // Contains reports whether the backend contains any of the given targets.
 func (b NetBackend) Contains(targets []string) bool {
 	for _, target := range targets {

--- a/pkg/backend/rpc.go
+++ b/pkg/backend/rpc.go
@@ -1,18 +1,3 @@
-/*
-Package backend defines an interface and RPC methods for communication
-with Graphite backends.
-
-Example use:
-
-    var b Backend
-    metrics, err := Render(ctx, b, from, until, targets)
-
-The package will transparently handle concurrent requests to multiple
-backends:
-
-    var bs []Backend
-    metrics, err := Renders(ctx, bs, from, until, targets)
-*/
 package backend
 
 import (
@@ -25,12 +10,6 @@ import (
 
 	"go.uber.org/zap"
 )
-
-// TODO(gmagnusson): ^ Remove IsAbsent: IsAbsent[i] => Values[i] == NaN
-// Doing math on NaN is expensive, but assuming that all functions will treat a
-// default value of 0 intelligently is wrong (see multiplication). Thus math
-// needs an if IsAbsent[i] check anyway, which is also expensive if we're
-// worrying about those levels of performance in the first place.
 
 // Renders makes Render calls to multiple backends.
 // replicaMatchMode indicates how data points of the metrics fetched from replicas

--- a/pkg/cfg/api.go
+++ b/pkg/cfg/api.go
@@ -62,10 +62,12 @@ func DefaultAPIConfig() API {
 
 		ResolveGlobs: 100,
 		Cache: CacheConfig{
-			Type:              "mem",
-			DefaultTimeoutSec: 60,
-			QueryTimeoutMs:    50,
-			Prefix:            "capi",
+			Type:                  "mem",
+			DefaultTimeoutSec:     60,
+			QueryTimeoutMs:        50,
+			Prefix:                "capi",
+			MemcachedTimeoutMs:    1000,
+			MemcachedMaxIdleConns: 50,
 		},
 		// This is an intentionally large number as an intermediate refactored state.
 		// This effectively turns off the queue size limitation.
@@ -137,13 +139,14 @@ type API struct {
 // CacheConfig configs the cache
 type CacheConfig struct {
 	// possible values are: null, mem, memcache, replicatedMemcache
-	Type             string   `yaml:"type"`
-	Size             int      `yaml:"size_mb"`
-	MemcachedServers []string `yaml:"memcachedServers"`
-	// TODO (grzkv): This looks to be used as expiration time for cache
-	DefaultTimeoutSec int32  `yaml:"defaultTimeoutSec"`
-	QueryTimeoutMs    uint64 `yaml:"queryTimeoutMs"`
-	Prefix            string `yaml:"prefix"`
+	Type                  string   `yaml:"type"`
+	Size                  int      `yaml:"size_mb"`
+	MemcachedServers      []string `yaml:"memcachedServers"`
+	DefaultTimeoutSec     int32    `yaml:"defaultTimeoutSec"`
+	QueryTimeoutMs        uint64   `yaml:"queryTimeoutMs"`
+	Prefix                string   `yaml:"prefix"`
+	MemcachedTimeoutMs    int      `yaml:"memcachedTimeoutMs"`
+	MemcachedMaxIdleConns int      `yaml:"memcachedMaxIdleConns"`
 }
 
 type preAPI struct {


### PR DESCRIPTION
*Disclaimer: This PR is part of a bigger refactoring. We had to make design compromises to accommodate both the old and the new processing systems at the same time. Once we completely switch to the new system, the design and code can be cleaned-up and ordered. Final touches are part of #407, and we'll do them before closing it.*

## What issue is this change attempting to solve?
This is a continuation of #407. The following changes were made:

* The old limiter is disabled in `carbonapi`;
* Timeout handling added to the top-level processing;
* Clean-up.

## How can we be sure this works as expected?
Tested locally and on live traffic.

## Additional notes
* The old limiter is still in place to avoid huge PRs.
* The `find` requests are not limited on the top level to give them higher priority.
* Some benchmark were removed as non-indicative for the current system.
