### PR TITLE
Removed the TLD cache counter per domain.

### DIFF
--- a/pkg/app/zipper/metrics.go
+++ b/pkg/app/zipper/metrics.go
@@ -38,9 +38,8 @@ type PrometheusMetrics struct {
 
 	TimeInQueueSeconds *prometheus.HistogramVec
 
-	TLDCacheProbeReqTotal  prometheus.Counter
-	TLDCacheProbeErrors    prometheus.Counter
-	TLDCacheHostsPerDomain prometheus.GaugeVec
+	TLDCacheProbeReqTotal prometheus.Counter
+	TLDCacheProbeErrors   prometheus.Counter
 
 	PathCacheFilteredRequests prometheus.Counter
 }
@@ -249,14 +248,6 @@ func NewPrometheusMetrics(config cfg.Zipper, ns string) *PrometheusMetrics {
 				Help:      "The total number of failed find requests sent by TLD cache as probes.",
 			},
 		),
-		TLDCacheHostsPerDomain: *prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: ns,
-				Name:      "tldcache_num_hosts_per_domain",
-				Help:      "The number of hosts per top-level domain.",
-			},
-			[]string{"domain"},
-		),
 		PathCacheFilteredRequests: prometheus.NewCounter(
 			prometheus.CounterOpts{
 				Namespace: ns,
@@ -303,7 +294,6 @@ func metricsServer(app *App, serve bool) *http.Server {
 	prometheus.MustRegister(app.Metrics.BackendSemaphoreSaturation)
 	prometheus.MustRegister(app.Metrics.BackendTimeInQSec)
 
-	prometheus.MustRegister(app.Metrics.TLDCacheHostsPerDomain)
 	prometheus.MustRegister(app.Metrics.TLDCacheProbeErrors)
 	prometheus.MustRegister(app.Metrics.TLDCacheProbeReqTotal)
 

--- a/pkg/app/zipper/tldcache.go
+++ b/pkg/app/zipper/tldcache.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/dgryski/go-expirecache"
 	"github.com/pkg/errors"
@@ -38,11 +37,6 @@ func probeTopLevelDomains(TLDCache *expirecache.Cache, TLDPrefixes []tldPrefix, 
 				for _, topLevelDomain := range topLevelDomains {
 					topLevelDomainCache[topLevelDomain] = append(topLevelDomainCache[topLevelDomain], bs[i])
 				}
-			}
-		}
-		for tld, num := range topLevelDomainCache {
-			if utf8.ValidString(tld) {
-				ms.TLDCacheHostsPerDomain.WithLabelValues(tld).Set(float64(len(num)))
 			}
 		}
 		TLDCache.Set("tlds", topLevelDomainCache, 0, 2*period)


### PR DESCRIPTION
The metric can easily explode when using sub-domains. This would cause scraping overload and loss of visibility. Also, the metric is less valuable after introduction of sub-domains.