### PR TITLE
Processing redesign: Temporarily bring back the limiter to apply the changes in smaller stages.

### DIFF
--- a/pkg/app/carbonapi/app.go
+++ b/pkg/app/carbonapi/app.go
@@ -156,7 +156,6 @@ func (app *App) registerPrometheusMetrics() {
 	prometheus.MustRegister(app.ms.UpstreamEnqueuedRequests)
 	prometheus.MustRegister(app.ms.UpstreamSubRenderNum)
 	prometheus.MustRegister(app.ms.UpstreamTimeInQSec)
-	prometheus.MustRegister(app.ms.UpstreamTimeouts)
 
 	prometheus.MustRegister(app.ms.TimeInQueueExp)
 	prometheus.MustRegister(app.ms.TimeInQueueLin)
@@ -367,7 +366,7 @@ func initBackend(config cfg.API, logger *zap.Logger, activeUpstreamRequests, wai
 		Address:            host,
 		Client:             client,
 		Timeout:            config.Timeouts.AfterStarted,
-		Limit:              0, // the old limiter is DISABLED now. TODO: Cleanup.
+		Limit:              config.ConcurrencyLimitPerServer, // the old limiter stays enabled for carbonapi
 		PathCacheExpirySec: uint32(config.ExpireDelaySec),
 		Logger:             logger,
 		ActiveRequests:     activeUpstreamRequests,

--- a/pkg/app/carbonapi/app.go
+++ b/pkg/app/carbonapi/app.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bookingcom/carbonapi/pkg/carbonapipb"
 	"github.com/bookingcom/carbonapi/pkg/cfg"
 	"github.com/bookingcom/carbonapi/pkg/parser"
+	"github.com/bookingcom/carbonapi/pkg/prioritylimiter"
 	"github.com/bookingcom/carbonapi/pkg/trace"
 
 	"github.com/facebookgo/grace/gracehttp"
@@ -53,7 +54,8 @@ type App struct {
 	ms PrometheusMetrics
 	Lg *zap.Logger
 
-	Zipper *zipper.App
+	Zipper        *zipper.App
+	ZipperLimiter *prioritylimiter.Limiter
 }
 
 // New creates a new app
@@ -75,7 +77,9 @@ func New(config cfg.API, lg *zap.Logger, buildVersion string) (*App, error) {
 	}
 	app.requestBlocker.ReloadRules()
 
-	backend, err := initBackend(app.config, lg)
+	backend, err := initBackend(app.config, lg,
+		app.ms.ActiveUpstreamRequests, app.ms.WaitingUpstreamRequests,
+		app.ms.UpstreamLimiterEnters, app.ms.UpstreamLimiterExits)
 	if err != nil {
 		lg.Fatal("couldn't initialize backends", zap.Error(err))
 	}
@@ -87,6 +91,9 @@ func New(config cfg.API, lg *zap.Logger, buildVersion string) (*App, error) {
 		lg.Info("starting embedded zipper")
 		var zlg *zap.Logger
 		app.Zipper, zlg = zipper.Setup(config.ZipperConfig, BuildVersion, "zipper", lg)
+		app.ZipperLimiter = prioritylimiter.New(config.ConcurrencyLimitPerServer,
+			prioritylimiter.WithMetrics(app.ms.ActiveUpstreamRequests, app.ms.WaitingUpstreamRequests,
+				app.ms.UpstreamLimiterEnters, app.ms.UpstreamLimiterExits))
 		go app.Zipper.Start(false, zlg)
 	}
 
@@ -153,6 +160,10 @@ func (app *App) registerPrometheusMetrics() {
 
 	prometheus.MustRegister(app.ms.TimeInQueueExp)
 	prometheus.MustRegister(app.ms.TimeInQueueLin)
+	prometheus.MustRegister(app.ms.ActiveUpstreamRequests)
+	prometheus.MustRegister(app.ms.WaitingUpstreamRequests)
+	prometheus.MustRegister(app.ms.UpstreamLimiterEnters)
+	prometheus.MustRegister(app.ms.UpstreamLimiterExits)
 
 	prometheus.MustRegister(app.ms.CacheRequests)
 	prometheus.MustRegister(app.ms.CacheRespRead)
@@ -335,7 +346,8 @@ func (app *App) bucketRequestTimes(req *http.Request, t time.Duration) {
 	}
 }
 
-func initBackend(config cfg.API, logger *zap.Logger) (backend.Backend, error) {
+func initBackend(config cfg.API, logger *zap.Logger, activeUpstreamRequests, waitingUpstreamRequests prometheus.Gauge,
+	limiterEnters prometheus.Counter, limiterExits *prometheus.CounterVec) (backend.Backend, error) {
 	client := &http.Client{}
 	client.Transport = &http.Transport{
 		MaxIdleConnsPerHost: config.MaxIdleConnsPerHost,
@@ -358,6 +370,10 @@ func initBackend(config cfg.API, logger *zap.Logger) (backend.Backend, error) {
 		Limit:              0, // the old limiter is DISABLED now. TODO: Cleanup.
 		PathCacheExpirySec: uint32(config.ExpireDelaySec),
 		Logger:             logger,
+		ActiveRequests:     activeUpstreamRequests,
+		WaitingRequests:    waitingUpstreamRequests,
+		LimiterEnters:      limiterEnters,
+		LimiterExits:       limiterExits,
 	})
 
 	if err != nil {

--- a/pkg/app/carbonapi/http_handlers.go
+++ b/pkg/app/carbonapi/http_handlers.go
@@ -552,8 +552,11 @@ func (app *App) sendRenderRequest(ctx context.Context, path string, from, until 
 	var err error
 	var metrics []dataTypes.Metric
 	if app.Zipper != nil {
+		// TODO: Cleanup the limiter.
+		_ = app.ZipperLimiter.Enter(ctx, util.GetPriority(ctx), util.GetUUID(ctx))
 		app.ms.UpstreamRequests.WithLabelValues("render").Inc()
 		metrics, err = zipper.Render(app.Zipper, ctx, path, int64(from), int64(until), app.Zipper.Metrics, app.Zipper.Lg)
+		app.ZipperLimiter.Leave()
 	} else {
 		metrics, err = app.backend.Render(ctx, request)
 	}
@@ -777,8 +780,10 @@ func (app *App) resolveGlobs(ctx context.Context, metric string, useCache bool, 
 	var matches dataTypes.Matches
 
 	if app.Zipper != nil {
+		_ = app.ZipperLimiter.Enter(ctx, util.GetPriority(ctx), util.GetUUID(ctx))
 		app.ms.UpstreamRequests.WithLabelValues("find").Inc()
 		matches, err = zipper.Find(app.Zipper, ctx, request.Query, app.Zipper.Metrics, app.Zipper.Lg)
+		app.ZipperLimiter.Leave()
 	} else {
 		matches, err = app.backend.Find(ctx, request)
 	}

--- a/pkg/app/carbonapi/http_handlers.go
+++ b/pkg/app/carbonapi/http_handlers.go
@@ -442,11 +442,6 @@ func (app *App) getTargetData(ctx context.Context, target string, exp parser.Exp
 
 				Results: rch,
 			}
-			// TODO: Don't rely on context in the final solution.
-			if dl, ok := ctx.Deadline(); ok {
-				// we use microseconds to avoid undefined zero-time behaviour of UnixNano
-				req.DeadlineMicro = dl.UnixMicro()
-			}
 
 			if subrequestCount > app.config.LargeReqSize {
 				app.slowQ <- req

--- a/pkg/app/carbonapi/metrics.go
+++ b/pkg/app/carbonapi/metrics.go
@@ -37,6 +37,10 @@ type PrometheusMetrics struct {
 	TimeInQueueLin prometheus.Histogram
 
 	UpstreamRequests        *prometheus.CounterVec
+	ActiveUpstreamRequests  prometheus.Gauge
+	WaitingUpstreamRequests prometheus.Gauge
+	UpstreamLimiterEnters   prometheus.Counter
+	UpstreamLimiterExits    *prometheus.CounterVec
 
 	CacheRequests *prometheus.CounterVec
 	CacheRespRead *prometheus.CounterVec
@@ -249,6 +253,26 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 					config.Zipper.Common.Monitoring.TimeInQueueLinHistogram.BucketsNum),
 			},
 		),
+		ActiveUpstreamRequests: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "active_upstream_requests",
+				Help: "Number of in-flight upstream requests",
+			},
+		),
+		WaitingUpstreamRequests: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "waiting_upstream_requests",
+				Help: "Number of upstream requests waiting on the limiter",
+			},
+		),
+		UpstreamLimiterEnters: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "upstream_limiter_enters",
+			Help: "The counter of requests that entered the upstream limiter",
+		}),
+		UpstreamLimiterExits: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "upstream_limiter_exits",
+			Help: "The counter of requests that exit the limiter by status",
+		}, []string{"status"}),
 		CacheRequests: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "cache_requests",

--- a/pkg/app/carbonapi/metrics.go
+++ b/pkg/app/carbonapi/metrics.go
@@ -31,7 +31,6 @@ type PrometheusMetrics struct {
 	UpstreamEnqueuedRequests    *prometheus.CounterVec
 	UpstreamSubRenderNum        prometheus.Histogram
 	UpstreamTimeInQSec          *prometheus.HistogramVec
-	UpstreamTimeouts            *prometheus.CounterVec
 
 	TimeInQueueExp prometheus.Histogram
 	TimeInQueueLin prometheus.Histogram
@@ -228,10 +227,6 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 				config.UpstreamTimeInQSecHistParams.BucketsNum,
 			),
 		}, []string{"queue"}),
-		UpstreamTimeouts: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "upstream_timedout_requests",
-			Help: "The counter of upstream requests that were never sent upstream because of timeout.",
-		}, []string{"queue", "request"}),
 
 		TimeInQueueExp: prometheus.NewHistogram(
 			prometheus.HistogramOpts{

--- a/pkg/app/zipper/app.go
+++ b/pkg/app/zipper/app.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	bnet "github.com/bookingcom/carbonapi/pkg/backend/net"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/dgryski/go-expirecache"
 
@@ -79,6 +81,10 @@ func InitBackends(config cfg.Zipper, ms *PrometheusMetrics, logger *zap.Logger) 
 		var b backend.Backend
 		var err error
 
+		limiterExits, err := ms.BackendLimiterExits.CurryWith(prometheus.Labels{"backend": host.Http})
+		if err != nil {
+			return nil, errors.Wrap(err, "currying the metric for LimiterExits failed")
+		}
 		bConf := bnet.Config{
 			Address:            host.Http,
 			DC:                 dc,
@@ -90,6 +96,10 @@ func InitBackends(config cfg.Zipper, ms *PrometheusMetrics, logger *zap.Logger) 
 			QHist:              ms.TimeInQueueSeconds,
 			Responses:          ms.BackendResponses,
 			Logger:             logger,
+			ActiveRequests:     ms.ActiveUpstreamRequests.WithLabelValues(host.Http),
+			WaitingRequests:    ms.WaitingUpstreamRequests.WithLabelValues(host.Http),
+			LimiterEnters:      ms.BackendLimiterEnters.WithLabelValues(host.Http),
+			LimiterExits:       limiterExits,
 		}
 		var be backend.BackendImpl
 		if host.Grpc != "" {

--- a/pkg/prioritylimiter/prioritylimiter.go
+++ b/pkg/prioritylimiter/prioritylimiter.go
@@ -1,0 +1,232 @@
+package prioritylimiter
+
+import (
+	"container/heap"
+	"context"
+	"errors"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	indexStateActive    = -1
+	indexStateNew       = -2
+	indexStateCancelled = -3
+)
+
+type request struct {
+	priority int // less is more
+	canEnter chan struct{}
+	index    int
+	uuid     string
+}
+
+type requests []*request
+
+// Limiter does two things
+// a) limits the number of concurrent requests going upstream
+// b) prioritize the "waiting" requests
+// For prioritization we are using two variables:
+// "priority": that is request complexity, less complexity == more priority
+// "uuid": for requests of equal comlexity, process them ordered by uuid in order do minimize the number of "active" requests
+type Limiter struct {
+	requests      requests
+	limiter       chan struct{}
+	wantToEnter   chan *request
+	cancelRequest chan *request
+	loopCount     uint32
+
+	activeGauge  prometheus.Gauge
+	waitingGauge prometheus.Gauge
+
+	entersCount prometheus.Counter
+	exitsCount  *prometheus.CounterVec
+}
+
+type LimiterOption func(*Limiter)
+
+// New creates a new limiter that allows maximum "limit" requests to "Enter"
+func New(limit int, options ...LimiterOption) *Limiter {
+	ret := &Limiter{
+		limiter:       make(chan struct{}, limit),
+		wantToEnter:   make(chan *request),
+		cancelRequest: make(chan *request),
+		loopCount:     0,
+	}
+	for _, option := range options {
+		option(ret)
+	}
+
+	go ret.loop()
+
+	return ret
+}
+
+// WithMetrics adds prometheus metrics to the Limiter instanace
+func WithMetrics(activeGauge, waitingGauge prometheus.Gauge,
+	enterCount prometheus.Counter, exitCount *prometheus.CounterVec) LimiterOption {
+	return func(l *Limiter) {
+		l.activeGauge = activeGauge
+		l.waitingGauge = waitingGauge
+		l.entersCount = enterCount
+		l.exitsCount = exitCount
+	}
+}
+
+// Enter blocks this request until it's turn comes
+func (l *Limiter) Enter(ctx context.Context, priority int, uuid string) error {
+	if l.entersCount != nil {
+		l.entersCount.Inc()
+	}
+
+	canEnter := make(chan struct{})
+
+	req := &request{
+		priority: priority,
+		canEnter: canEnter,
+		uuid:     uuid,
+		index:    indexStateNew,
+	}
+
+	l.wantToEnter <- req
+
+	select {
+	// Check first if the ctx is not closed
+	case <-ctx.Done():
+		if l.exitsCount != nil {
+			l.exitsCount.WithLabelValues("ctx_cancel").Inc()
+		}
+		l.cancelRequest <- req
+		return ctx.Err()
+	default:
+		select {
+		case <-ctx.Done():
+			l.cancelRequest <- req
+			if l.exitsCount != nil {
+				l.exitsCount.WithLabelValues("ctx_cancel").Inc()
+			}
+			return ctx.Err()
+		case <-canEnter:
+			if l.exitsCount != nil {
+				l.exitsCount.WithLabelValues("ok").Inc()
+			}
+			return nil
+		}
+	}
+}
+
+// Leave marks a request as complete
+func (l *Limiter) Leave() error {
+	select {
+	case <-l.limiter:
+		// fallthrough
+	default:
+		// this should never happen, but let's not block forever if it does
+		return errors.New("Unable to return value to limiter")
+	}
+	return nil
+}
+
+// Active returns the number of in progress requests
+func (l *Limiter) Active() int {
+	return len(l.limiter)
+}
+
+func (l *Limiter) loop() {
+	for {
+		if len(l.requests) == 0 {
+			select {
+			case req := <-l.wantToEnter:
+				if req.index != indexStateCancelled {
+					heap.Push(&l.requests, req)
+				}
+			case req := <-l.cancelRequest:
+				index := req.index
+				if index >= 0 {
+					heap.Remove(&l.requests, index)
+				}
+				if index == indexStateActive {
+					// If we are receiving a cancel request at this point,
+					// it means Enter() returned with error, and the caller will not Leave()
+					l.Leave()
+				}
+				req.index = indexStateCancelled
+			}
+		} else {
+			select {
+			case req := <-l.wantToEnter:
+				if req.index != indexStateCancelled {
+					heap.Push(&l.requests, req)
+				}
+			case req := <-l.cancelRequest:
+				index := req.index
+				if index >= 0 {
+					heap.Remove(&l.requests, index)
+				}
+				if index == indexStateActive {
+					// If we are receiving a cancel request at this point,
+					// it means Enter() returned with error, and the caller will not Leave()
+					l.Leave()
+				}
+				req.index = indexStateCancelled
+			case l.limiter <- struct{}{}:
+				req := heap.Pop(&l.requests).(*request)
+				close(req.canEnter)
+			}
+		}
+		atomic.AddUint32(&l.loopCount, 1)
+		if l.activeGauge != nil {
+			l.activeGauge.Set(float64(len(l.limiter)))
+		}
+		if l.waitingGauge != nil {
+			l.waitingGauge.Set(float64(len(l.requests)))
+		}
+	}
+}
+
+// used in tests to ensure that loop() processed all the pending messages
+func (l *Limiter) waitLoopCount(i int) {
+	for {
+		count := int(atomic.LoadUint32(&l.loopCount))
+		if count >= i {
+			return
+		}
+		time.Sleep(time.Millisecond * 50)
+	}
+}
+
+func (r requests) Len() int {
+	return len(r)
+}
+
+func (r requests) Less(i, j int) bool {
+	if r[i].priority == r[j].priority {
+		return r[i].uuid < r[j].uuid
+	}
+	return r[i].priority < r[j].priority
+}
+
+func (r requests) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+	r[i].index = i
+	r[j].index = j
+}
+
+func (r *requests) Push(x interface{}) {
+	req := x.(*request)
+	idx := len(*r)
+	req.index = idx
+	*r = append(*r, req)
+}
+
+func (r *requests) Pop() interface{} {
+	old := *r
+	n := len(old)
+	req := old[n-1]
+	req.index = indexStateActive
+	old[n-1] = nil // avoid memory leak
+	*r = old[0 : n-1]
+	return req
+}

--- a/pkg/prioritylimiter/prioritylimiter_test.go
+++ b/pkg/prioritylimiter/prioritylimiter_test.go
@@ -1,0 +1,214 @@
+package prioritylimiter
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSimple(t *testing.T) {
+	limiter := New(3)
+	ctx := context.TODO()
+
+	err := limiter.Enter(ctx, 1, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = limiter.Enter(ctx, 1, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if limiter.Active() != 2 {
+		t.Fatal("active")
+	}
+
+	err = limiter.Leave()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if limiter.Active() != 1 {
+		t.Fatal("active")
+	}
+
+	err = limiter.Leave()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if limiter.Active() != 0 {
+		t.Fatal("active")
+	}
+}
+
+func TestFail(t *testing.T) {
+	limiter := New(2)
+	ctx := context.TODO()
+
+	err := limiter.Enter(ctx, 1, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if limiter.Active() != 1 {
+		t.Fatal("active")
+	}
+
+	err = limiter.Leave()
+	if err != nil {
+		t.Fatal("Err is nil")
+	}
+	if limiter.Active() != 0 {
+		t.Fatal("active")
+	}
+
+	err = limiter.Leave()
+	if err == nil {
+		t.Fatal("Err is nil")
+	}
+}
+
+func TestCancelActive(t *testing.T) {
+	limiter := New(2)
+	ctx, cancel := context.WithCancel(context.Background())
+	err := limiter.Enter(ctx, 1, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	if limiter.Active() != 1 {
+		t.Fatal("active")
+	}
+	err = limiter.Leave()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if limiter.Active() != 0 {		
+		t.Fatal("active")
+	}
+}
+
+func TestCancelBefore(t *testing.T) {
+	limiter := New(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := limiter.Enter(ctx, 1, "1")
+	if err == nil {
+		t.Fatal("err")
+	}
+	limiter.waitLoopCount(1)
+	if limiter.Active() != 0 {
+		// we can either process the cancel(1 op) or the create request first(3 ops)
+		limiter.waitLoopCount(3)
+		if limiter.Active() != 0 {
+			t.Fatal("active")
+		}
+	}
+}
+
+func TestCancelWaiting(t *testing.T) {
+	limiter := New(1)
+
+	err := limiter.Enter(context.TODO(), 1, "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go limiter.Enter(ctx, 1, "1")
+	limiter.waitLoopCount(3)
+
+	cancel()
+
+	limiter.waitLoopCount(4)
+
+	err = limiter.Leave()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if limiter.Active() != 0 {
+		t.Fatal("active")
+	}
+}
+
+func TestPrio(t *testing.T) {
+	limiter := New(1)
+	var got []int
+	limiter.Enter(context.TODO(), 0, "0")
+	enterwg := sync.WaitGroup{}
+	wg := sync.WaitGroup{}
+	lock := sync.Mutex{}
+	enter := func(i int) {
+		limiter.Enter(context.TODO(), i, "1")
+		lock.Lock()
+		got = append(got, i)
+		lock.Unlock()
+		wg.Done()
+	}
+
+	for i := 5; i > 0; i-- {
+		wg.Add(1)
+		enterwg.Add(1)
+		go enter(i)
+	}
+	todo := 6
+	for todo > 0 {
+		time.Sleep(time.Millisecond * 50)
+		if limiter.Active() > 0 {
+			limiter.Leave()
+			todo--
+		}
+	}
+
+	wg.Wait()
+	want := []int{1, 2, 3, 4, 5}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("-want +got:\n%s", diff)
+	}
+}
+
+func TestPrioUUID(t *testing.T) {
+	limiter := New(1)
+	var got []int
+	limiter.Enter(context.TODO(), 0, "0")
+	enterwg := sync.WaitGroup{}
+	wg := sync.WaitGroup{}
+	lock := sync.Mutex{}
+	enter := func(i int) {
+		limiter.Enter(context.TODO(), 0, fmt.Sprint(i))
+		lock.Lock()
+		got = append(got, i)
+		lock.Unlock()
+		wg.Done()
+	}
+
+	for i := 5; i > 0; i-- {
+		wg.Add(1)
+		enterwg.Add(1)
+		go enter(i)
+	}
+	todo := 6
+	for todo > 0 {
+		time.Sleep(time.Millisecond * 50)
+		if limiter.Active() > 0 {
+			limiter.Leave()
+			todo--
+		}
+	}
+
+	wg.Wait()
+	want := []int{1, 2, 3, 4, 5}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("-want +got:\n%s", diff)
+	}
+}


### PR DESCRIPTION
## What issue is this change attempting to solve?
This PR reverts part of the big recent changes to apply them in smaller steps and allow for additional improvements.

Also:
* Removed recently added req cancellation metric as non-indicative.
* Disabled additional cancellation during processing via timestamps. We will rely on context instead.

Part of #407 

## How can we be sure this works as expected?
Tested locally and on live traffic.
