### PR TITLE
Added request tracing with logs.

### DIFF
--- a/pkg/app/carbonapi/logtrace.go
+++ b/pkg/app/carbonapi/logtrace.go
@@ -1,0 +1,12 @@
+package carbonapi
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func Trace(lg *zap.Logger, msg string, fields ...zapcore.Field) {
+	if l := lg.Check(zapcore.DebugLevel, msg); l != nil {
+		l.Write(fields...)
+	}
+}

--- a/pkg/app/zipper/http_handlers.go
+++ b/pkg/app/zipper/http_handlers.go
@@ -57,12 +57,6 @@ func (app *App) findHandler(w http.ResponseWriter, req *http.Request, ms *Promet
 	defer cancel()
 	span := trace.SpanFromContext(ctx)
 
-	if ce := logger.Check(zap.DebugLevel, "got find request"); ce != nil {
-		ce.Write(
-			zap.String("request", req.URL.RequestURI()),
-		)
-	}
-
 	originalQuery := req.FormValue("query")
 	format := req.FormValue("format")
 
@@ -146,10 +140,6 @@ func (app *App) renderHandler(w http.ResponseWriter, req *http.Request, ms *Prom
 	ctx, cancel := context.WithTimeout(req.Context(), app.Config.Timeouts.Global)
 	defer cancel()
 	span := trace.SpanFromContext(ctx)
-
-	if ce := logger.Check(zap.DebugLevel, "got render request"); ce != nil {
-		ce.Write(zap.String("request", req.URL.RequestURI()))
-	}
 
 	app.Metrics.Requests.Inc()
 
@@ -314,8 +304,6 @@ func (app *App) infoHandler(w http.ResponseWriter, req *http.Request, ms *Promet
 
 	lg = lg.With(zap.String("handler", "info"), zap.String("carbonapi_uuid", util.GetUUID(ctx)))
 
-	lg.Debug("request", zap.String("request", req.URL.RequestURI()))
-
 	app.Metrics.Requests.Inc()
 
 	err := req.ParseForm()
@@ -419,10 +407,6 @@ func (app *App) infoHandler(w http.ResponseWriter, req *http.Request, ms *Promet
 
 func (app *App) lbCheckHandler(w http.ResponseWriter, req *http.Request, ms *PrometheusMetrics, logger *zap.Logger) {
 	t0 := time.Now()
-
-	if ce := logger.Check(zap.DebugLevel, "loadbalancer"); ce != nil {
-		ce.Write(zap.String("request", req.URL.RequestURI()))
-	}
 
 	app.Metrics.Requests.Inc()
 

--- a/pkg/blocker/requestblocker.go
+++ b/pkg/blocker/requestblocker.go
@@ -62,7 +62,7 @@ func (rl *RequestBlocker) ScheduleRuleReload() bool {
 func (rl *RequestBlocker) ReloadRules() {
 	fileData, err := rl.config.load()
 	if err != nil {
-		rl.logger.Debug("failed to load header block rules", zap.Error(err))
+		rl.logger.Info("failed to load header block rules", zap.Error(err))
 		rl.rules.Store(RuleConfig{})
 		return
 	}

--- a/pkg/cfg/common.go
+++ b/pkg/cfg/common.go
@@ -164,11 +164,15 @@ func GetDefaultLoggerConfig() zap.Config {
 			StacktraceKey:  "stacktrace",
 			LineEnding:     zapcore.DefaultLineEnding,
 			EncodeLevel:    zapcore.CapitalLevelEncoder,
-			EncodeTime:     zapcore.ISO8601TimeEncoder,
+			EncodeTime:     DateNanoEncoder,
 			EncodeDuration: zapcore.SecondsDurationEncoder,
 			EncodeCaller:   zapcore.ShortCallerEncoder,
 		},
 	}
+}
+
+func DateNanoEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+	enc.AppendString(t.Format("2006-01-02T15:04:05.000000000Z0700"))
 }
 
 // Common is the configuration shared by carbonapi and carbonzipper


### PR DESCRIPTION
## What issue is this change attempting to solve?
Fixes #419 

## How can we be sure this works as expected?
Tested locally and on live traffic.

## Please note:
1. The traces have the `DEBUG` log level and will be turned off by default.
2. Traces are intentionally only present in `carbonapi` before the request is broken into sub-requests to prevent logs overflow.