### PR TITLE
Stabilize the set of connections to zipper. Disable closing connection after 1s of inactivity.

### DIFF
--- a/pkg/app/zipper/app.go
+++ b/pkg/app/zipper/app.go
@@ -48,7 +48,6 @@ func (app *App) Start(serve bool, lg *zap.Logger) {
 		err = gracehttp.Serve(&http.Server{
 			Addr:         app.Config.Listen,
 			Handler:      handler,
-			ReadTimeout:  1 * time.Second,
 			WriteTimeout: app.Config.Timeouts.Global * 2, // It has to be greater than Timeout.Global because we use that value as per-request context timeout
 		}, metricsServer)
 	}


### PR DESCRIPTION
## What issue is this change attempting to solve?
Currently, we close connections to zipper after 1s of inactivity. This results in connections thrashing and multiple connections hanging in `TIME_WAIT` state.

This change guarantees a stable set of connections between `carbonapi` and `zipper`, which is more efficient than the current constant connection recreation. Also, we get rid of thousands of connections hanging in `TIME_WAIT` state.

## How can we be sure this works as expected?
Tested on live traffic.
