### PR TITLE
Misc metrics improvements and refactoring.

### DIFF
--- a/pkg/app/carbonapi/http_handlers.go
+++ b/pkg/app/carbonapi/http_handlers.go
@@ -46,10 +46,6 @@ const (
 	completerFormat = "completer"
 )
 
-// for testing
-// TODO (grzkv): Clean up
-var timeNow = time.Now
-
 func (app *App) validateRequest(h handlerlog.HandlerWithLogger, handler string, logger *zap.Logger) http.HandlerFunc {
 	t0 := time.Now()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -638,8 +634,8 @@ func (app *App) renderHandlerProcessForm(r *http.Request, accessLogDetails *carb
 	// normalize from and until values
 	res.qtz = r.FormValue("tz")
 	var errFrom, errUntil error
-	res.from32, errFrom = date.DateParamToEpoch(res.from, res.qtz, timeNow().Add(-24*time.Hour).Unix(), app.defaultTimeZone)
-	res.until32, errUntil = date.DateParamToEpoch(res.until, res.qtz, timeNow().Unix(), app.defaultTimeZone)
+	res.from32, errFrom = date.DateParamToEpoch(res.from, res.qtz, time.Now().Add(-24*time.Hour).Unix(), app.defaultTimeZone)
+	res.until32, errUntil = date.DateParamToEpoch(res.until, res.qtz, time.Now().Unix(), app.defaultTimeZone)
 
 	accessLogDetails.UseCache = res.useCache
 	accessLogDetails.FromRaw = res.from
@@ -758,7 +754,6 @@ func (app *App) resolveGlobs(ctx context.Context, metric string, useCache bool, 
 	accessLogDetails.ZipperRequests++
 
 	request := dataTypes.NewFindRequest(metric)
-	request.IncCall()
 
 	var err error
 	var matches dataTypes.Matches
@@ -1087,9 +1082,6 @@ func (app *App) infoHandler(w http.ResponseWriter, r *http.Request, lg *zap.Logg
 		toLog.Reason = "no target specified"
 		return
 	}
-
-	request := dataTypes.NewInfoRequest(query)
-	request.IncCall()
 
 	var infos []dataTypes.Info
 	var err error

--- a/pkg/app/carbonapi/metrics.go
+++ b/pkg/app/carbonapi/metrics.go
@@ -15,6 +15,7 @@ type PrometheusMetrics struct {
 	DurationTotal      *prometheus.HistogramVec
 	UpstreamDuration   *prometheus.HistogramVec
 	UpstreamTimeInQSec *prometheus.HistogramVec
+	BackendDuration    *prometheus.HistogramVec
 
 	RenderDurationExp        prometheus.Histogram
 	RenderDurationLinSimple  prometheus.Histogram
@@ -37,6 +38,28 @@ type PrometheusMetrics struct {
 	CacheTimeouts *prometheus.CounterVec
 
 	Version *prometheus.GaugeVec
+}
+
+type ZipperPrometheusMetrics struct {
+	RenderMismatches          prometheus.Counter
+	RenderFixedMismatches     prometheus.Counter
+	RenderMismatchedResponses prometheus.Counter
+	Renders                   prometheus.Counter
+
+	BackendResponses *prometheus.CounterVec
+
+	RenderOutDurationExp *prometheus.HistogramVec
+	FindOutDuration      *prometheus.HistogramVec
+
+	BackendEnqueuedRequests    *prometheus.CounterVec
+	BackendRequestsInQueue     *prometheus.GaugeVec
+	BackendSemaphoreSaturation prometheus.Gauge
+	BackendTimeInQSec          *prometheus.HistogramVec
+
+	TLDCacheProbeReqTotal prometheus.Counter
+	TLDCacheProbeErrors   prometheus.Counter
+
+	PathCacheFilteredRequests prometheus.Counter
 }
 
 func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
@@ -208,6 +231,19 @@ func newPrometheusMetrics(config cfg.API) PrometheusMetrics {
 				config.UpstreamTimeInQSecHistParams.BucketsNum,
 			),
 		}, []string{"queue"}),
+		BackendDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name: "backend_request_duration_seconds",
+				Help: "The durations of requests sent to backends.",
+				Buckets: prometheus.ExponentialBuckets(
+					// TODO (grzkv) Do we need a separate config?
+					// The buckets should be of comparable size.
+					config.Monitoring.RenderDurationExp.Start,
+					config.Monitoring.RenderDurationExp.BucketSize,
+					config.Monitoring.RenderDurationExp.BucketsNum),
+			},
+			[]string{"dc", "cluster", "request"},
+		),
 		CacheRequests: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "cache_requests",
@@ -264,6 +300,7 @@ func registerPrometheusMetrics(ms *PrometheusMetrics, zms *ZipperPrometheusMetri
 	prometheus.MustRegister(ms.UpstreamEnqueuedRequests)
 	prometheus.MustRegister(ms.UpstreamSubRenderNum)
 	prometheus.MustRegister(ms.UpstreamTimeInQSec)
+	prometheus.MustRegister(ms.BackendDuration)
 
 	prometheus.MustRegister(ms.CacheRequests)
 	prometheus.MustRegister(ms.CacheRespRead)
@@ -285,28 +322,6 @@ func registerPrometheusMetrics(ms *PrometheusMetrics, zms *ZipperPrometheusMetri
 	prometheus.MustRegister(zms.TLDCacheProbeErrors)
 	prometheus.MustRegister(zms.TLDCacheProbeReqTotal)
 	prometheus.MustRegister(zms.PathCacheFilteredRequests)
-}
-
-type ZipperPrometheusMetrics struct {
-	RenderMismatches          prometheus.Counter
-	RenderFixedMismatches     prometheus.Counter
-	RenderMismatchedResponses prometheus.Counter
-	Renders                   prometheus.Counter
-
-	BackendResponses *prometheus.CounterVec
-
-	RenderOutDurationExp *prometheus.HistogramVec
-	FindOutDuration      *prometheus.HistogramVec
-
-	BackendEnqueuedRequests    *prometheus.CounterVec
-	BackendRequestsInQueue     *prometheus.GaugeVec
-	BackendSemaphoreSaturation prometheus.Gauge
-	BackendTimeInQSec          *prometheus.HistogramVec
-
-	TLDCacheProbeReqTotal prometheus.Counter
-	TLDCacheProbeErrors   prometheus.Counter
-
-	PathCacheFilteredRequests prometheus.Counter
 }
 
 func NewZipperPrometheusMetrics(config cfg.Zipper) *ZipperPrometheusMetrics {

--- a/pkg/app/carbonapi/upstream.go
+++ b/pkg/app/carbonapi/upstream.go
@@ -52,7 +52,6 @@ func Render(cache *expirecache.Cache, TLDPrefixes []tldcache.TopLevelDomainPrefi
 	ms *ZipperPrometheusMetrics, lg *zap.Logger) ([]types.Metric, error) {
 
 	request := types.NewRenderRequest([]string{target}, int32(from), int32(until))
-	request.Trace.OutDuration = ms.RenderOutDurationExp
 	bs := tldcache.FilterBackendByTopLevelDomain(cache, TLDPrefixes, backends, request.Targets)
 	var filteredByPathCache bool
 	bs, filteredByPathCache = backend.Filter(bs, request.Targets)

--- a/pkg/backend/benchmark_test.go
+++ b/pkg/backend/benchmark_test.go
@@ -62,7 +62,7 @@ func BenchmarkRenders(b *testing.B) {
 
 	backends := make([]Backend, 0)
 	for i := 0; i < 3; i++ {
-		backends = append(backends, NewBackend(bk, 0, 0, nil, nil, nil, nil))
+		backends = append(backends, NewBackend(bk, 0, 0, nil, nil, nil, nil, nil))
 	}
 
 	ctx := context.Background()
@@ -182,7 +182,7 @@ func BenchmarkRendersStorm(b *testing.B) {
 			b.Fatal(err)
 		}
 
-		backends = append(backends, NewBackend(bk, 0, 0, nil, nil, nil, nil))
+		backends = append(backends, NewBackend(bk, 0, 0, nil, nil, nil, nil, nil))
 	}
 
 	ctx := context.Background()
@@ -286,7 +286,7 @@ func BenchmarkRendersMismatchStorm(b *testing.B) {
 			b.Fatal(err)
 		}
 
-		backends = append(backends, NewBackend(bk, 0, 0, nil, nil, nil, nil))
+		backends = append(backends, NewBackend(bk, 0, 0, nil, nil, nil, nil, nil))
 	}
 
 	ctx := context.Background()

--- a/pkg/backend/net/grpc.go
+++ b/pkg/backend/net/grpc.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"strconv"
-	"time"
 
 	capi_v2_grpc "github.com/go-graphite/protocol/carbonapi_v2_grpc"
 	"github.com/go-graphite/protocol/carbonapi_v2_pb"
@@ -68,10 +67,8 @@ func makeMultiFetchRequestFromRenderRequest(request types.RenderRequest) *carbon
 
 // Render fetches raw metrics from a backend.
 func (gb *GrpcBackend) Render(ctx context.Context, request types.RenderRequest) ([]types.Metric, error) {
-	t0 := time.Now()
 	ctx = util.MarshalGrpcCtx(ctx)
 	multiFetchRequest := makeMultiFetchRequestFromRenderRequest(request)
-	request.Trace.AddMarshal(t0)
 
 	ctx, cancel := gb.setTimeout(ctx)
 	defer cancel()
@@ -114,12 +111,10 @@ func (gb *GrpcBackend) Render(ctx context.Context, request types.RenderRequest) 
 
 // Find resolves globs and finds metrics in a backend.
 func (gb *GrpcBackend) Find(ctx context.Context, request types.FindRequest) (types.Matches, error) {
-	t0 := time.Now()
 	ctx = util.MarshalGrpcCtx(ctx)
 	globRequest := &carbonapi_v2_pb.GlobRequest{
 		Query: request.Query,
 	}
-	request.Trace.AddMarshal(t0)
 
 	ctx, cancel := gb.setTimeout(ctx)
 	defer cancel()
@@ -157,12 +152,10 @@ func (gb *GrpcBackend) Find(ctx context.Context, request types.FindRequest) (typ
 }
 
 func (gb *GrpcBackend) Info(ctx context.Context, request types.InfoRequest) ([]types.Info, error) {
-	t0 := time.Now()
 	ctx = util.MarshalGrpcCtx(ctx)
 	infoRequest := &carbonapi_v2_pb.InfoRequest{
 		Name: request.Target,
 	}
-	request.Trace.AddMarshal(t0)
 
 	ctx, cancel := gb.setTimeout(ctx)
 	defer cancel()

--- a/pkg/backend/net/net_test.go
+++ b/pkg/backend/net/net_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bookingcom/carbonapi/pkg/types"
-
 	"github.com/dgryski/go-expirecache"
 )
 
@@ -103,7 +101,7 @@ func TestCall(t *testing.T) {
 		return
 	}
 
-	_, got, err := b.call(context.Background(), types.NewTrace(), b.url("/render"), "render")
+	_, got, err := b.call(context.Background(), b.url("/render"), "render")
 	if err != nil {
 		t.Error(err)
 	}
@@ -128,7 +126,7 @@ func TestCallServerError(t *testing.T) {
 		return
 	}
 
-	_, _, err = b.call(context.Background(), types.NewTrace(), b.url("/render"), "render")
+	_, _, err = b.call(context.Background(), b.url("/render"), "render")
 	if err == nil {
 		t.Error("Expected error")
 	}
@@ -147,7 +145,7 @@ func TestCallTimeout(t *testing.T) {
 		return
 	}
 
-	_, _, err = b.call(context.Background(), types.NewTrace(), b.url("/render"), "render")
+	_, _, err = b.call(context.Background(), b.url("/render"), "render")
 	if err == nil {
 		t.Error("Expected error")
 	}
@@ -175,7 +173,7 @@ func TestDo(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, got, err := b.do(types.NewTrace(), req, "")
+	_, got, err := b.do(req, "")
 	if err != nil {
 		t.Error(err)
 	}
@@ -210,7 +208,7 @@ func TestDoHTTPTimeout(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, _, err = b.do(types.NewTrace(), req, "")
+	_, _, err = b.do(req, "")
 	if err == nil {
 		t.Errorf("Expected error")
 	}
@@ -236,7 +234,7 @@ func TestDoHTTPError(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, _, err = b.do(types.NewTrace(), req, "")
+	_, _, err = b.do(req, "")
 	if err == nil {
 		t.Errorf("Expected error")
 	}

--- a/pkg/backend/rpc.go
+++ b/pkg/backend/rpc.go
@@ -24,7 +24,6 @@ func Renders(ctx context.Context, backends []Backend, request types.RenderReques
 	msgCh := make(chan []types.Metric, len(backends))
 	errCh := make(chan error, len(backends))
 	for _, backend := range backends {
-		request.IncCall()
 		backend.SendRender(ctx, request, msgCh, errCh)
 	}
 
@@ -52,7 +51,6 @@ func Infos(ctx context.Context, backends []Backend, request types.InfoRequest) (
 	msgCh := make(chan []types.Info, len(backends))
 	errCh := make(chan error, len(backends))
 	for _, backend := range backends {
-		request.IncCall()
 		backend.SendInfo(ctx, request, msgCh, errCh)
 	}
 
@@ -79,7 +77,6 @@ func Finds(ctx context.Context, backends []Backend, request types.FindRequest, d
 	msgCh := make(chan types.Matches, len(backends))
 	errCh := make(chan error, len(backends))
 	for _, backend := range backends {
-		request.IncCall()
 		backend.SendFind(ctx, request, msgCh, errCh, durationHist)
 	}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -12,12 +12,9 @@ import (
 	"errors"
 	"math"
 	"sort"
-	"sync/atomic"
-	"time"
 
 	"github.com/bookingcom/carbonapi/pkg/cfg"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
 
@@ -39,25 +36,21 @@ func (err ErrNotFound) Error() string {
 
 type FindRequest struct {
 	Query string
-	Trace
 }
 
 func NewFindRequest(query string) FindRequest {
 	return FindRequest{
 		Query: query,
-		Trace: NewTrace(),
 	}
 }
 
 type InfoRequest struct {
 	Target string
-	Trace
 }
 
 func NewInfoRequest(target string) InfoRequest {
 	return InfoRequest{
 		Target: target,
-		Trace:  NewTrace(),
 	}
 }
 
@@ -65,7 +58,6 @@ type RenderRequest struct {
 	Targets []string
 	From    int32
 	Until   int32
-	Trace
 }
 
 func NewRenderRequest(targets []string, from int32, until int32) RenderRequest {
@@ -73,81 +65,6 @@ func NewRenderRequest(targets []string, from int32, until int32) RenderRequest {
 		Targets: targets,
 		From:    from,
 		Until:   until,
-		Trace:   NewTrace(),
-	}
-}
-
-// TODO: Remove.
-type Trace struct {
-	callCount     *int64
-	inMarshalNS   *int64
-	inLimiterNS   *int64
-	inHTTPCallNS  *int64
-	inReadBodyNS  *int64
-	inUnmarshalNS *int64
-	OutDuration   *prometheus.HistogramVec
-}
-
-func (t Trace) ObserveOutDuration(ti time.Duration, dc string, cluster string) {
-	if t.OutDuration != nil {
-		(*t.OutDuration).With(prometheus.Labels{"cluster": cluster, "dc": dc}).Observe(ti.Seconds())
-	}
-}
-
-func (t Trace) Report() []int64 {
-	n := int64(1)
-	c := *t.callCount
-	if c > 0 {
-		n = c
-	}
-
-	return []int64{
-		c,
-		*t.inMarshalNS / n,
-		*t.inLimiterNS / n,
-		*t.inHTTPCallNS / n,
-		*t.inReadBodyNS / n,
-		*t.inUnmarshalNS / n,
-	}
-}
-
-func (t Trace) IncCall() {
-	atomic.AddInt64(t.callCount, 1)
-}
-
-func (t Trace) AddMarshal(start time.Time) {
-	d := time.Since(start)
-	atomic.AddInt64(t.inMarshalNS, int64(d))
-}
-
-func (t Trace) AddLimiter(start time.Time) {
-	d := time.Since(start)
-	atomic.AddInt64(t.inLimiterNS, int64(d))
-}
-
-func (t Trace) AddHTTPCall(start time.Time) {
-	d := time.Since(start)
-	atomic.AddInt64(t.inHTTPCallNS, int64(d))
-}
-
-func (t Trace) AddReadBody(start time.Time) {
-	d := time.Since(start)
-	atomic.AddInt64(t.inReadBodyNS, int64(d))
-}
-
-func (t Trace) AddUnmarshal(start time.Time) {
-	d := time.Since(start)
-	atomic.AddInt64(t.inUnmarshalNS, int64(d))
-}
-
-func NewTrace() Trace {
-	return Trace{
-		callCount:     new(int64),
-		inMarshalNS:   new(int64),
-		inLimiterNS:   new(int64),
-		inHTTPCallNS:  new(int64),
-		inReadBodyNS:  new(int64),
-		inUnmarshalNS: new(int64),
 	}
 }
 


### PR DESCRIPTION
Improved backend duration counting. Added duration counting for the find backend requests. Cleaned-up unused, duplicated (and sometimes wrong) metric counting with the Trace abstraction. Misc small cleanups.

Contributes to #436 #433 

## How can we be sure this works as expected?
Tested locally and on live traffic.
