### PR TITLE
carbonapi: wrong expandable implementation in find

### DIFF
--- a/pkg/types/encoding/json/encoding.go
+++ b/pkg/types/encoding/json/encoding.go
@@ -56,9 +56,6 @@ func matchesToJSONMatches(matches types.Matches) []jsonMatch {
 			jm.Leaf = 1
 		} else {
 			jm.AllowChildren = 1
-		}
-
-		if !m.IsLeaf || strings.ContainsRune(jm.ID, '*') {
 			jm.Expandable = 1
 		}
 

--- a/pkg/types/encoding/json/encoding_test.go
+++ b/pkg/types/encoding/json/encoding_test.go
@@ -29,7 +29,7 @@ func TestFindMatchesJSONEncoding(t *testing.T) {
 				{
 					AllowChildren: 0,
 					Leaf:          1,
-					Expandable:    1,
+					Expandable:    0,
 					Context:       make(map[string]int),
 					ID:            "*.sin",
 					Text:          "sin",
@@ -59,7 +59,7 @@ func TestFindMatchesJSONEncoding(t *testing.T) {
 				{
 					AllowChildren: 0,
 					Leaf:          1,
-					Expandable:    1,
+					Expandable:    0,
 					Context:       make(map[string]int),
 					ID:            "a.*.1",
 					Text:          "1",


### PR DESCRIPTION
## What issue is this change attempting to solve?
We're not setting `expandable` parameter in treejson same way as graphite-web does.
Currently we have [this code](https://github.com/bookingcom/carbonapi/blob/cc3581e0659bed151e3d5aa89b2be1b2824dc81a/pkg/types/encoding/json/encoding.go#L55-L63):
```go
		if m.IsLeaf {
			jm.Leaf = 1
		} else {
			jm.AllowChildren = 1
		}

		if !m.IsLeaf || strings.ContainsRune(jm.ID, '*') {
			jm.Expandable = 1
		}
```
I.e. we set expandable to true if it's not leaf and contain glob. Unfortunately, this implementation is logical, but wrong.
In graphite-web it's very simple - if it's leaf - then Leaf is true, else  AllowChildren and Expandable are true. See for example [this](https://github.com/graphite-project/graphite-web/blob/02bc0c836269e07b38175fbfe3b5689afc87b4fa/webapp/graphite/browser/views.py#L86-L95) and [this](https://github.com/graphite-project/graphite-web/blob/02bc0c836269e07b38175fbfe3b5689afc87b4fa/webapp/graphite/metrics/views.py#L315-L324) code.

## How does this change solve the problem? Why is this the best approach?
Now we're doing the same thing as graphite-web and [go-carbon carbonapi](https://github.com/go-graphite/carbonapi/blob/0bb2584f923da446b2fbbc96ab1e338a8b5294f0/cmd/carbonapi/http/find_handlers.go) 

## How can we be sure this works as expected?
I tested that on local Grafana.
W/o fix:
![Screenshot 2022-12-16 at 16 52 25](https://user-images.githubusercontent.com/1227222/208138113-6540a78f-fbdf-4f9c-aaed-cc5122b7b25a.png)
With this fix:
![Screenshot 2022-12-16 at 16 52 42](https://user-images.githubusercontent.com/1227222/208138205-c4034ae2-c2af-4867-8a82-17c1de436e6d.png)


