### PR TITLE
Revert "fix(find): set expandable parameter same as graphite-web does"

### DIFF
--- a/pkg/types/encoding/json/encoding.go
+++ b/pkg/types/encoding/json/encoding.go
@@ -56,6 +56,9 @@ func matchesToJSONMatches(matches types.Matches) []jsonMatch {
 			jm.Leaf = 1
 		} else {
 			jm.AllowChildren = 1
+		}
+
+		if !m.IsLeaf || strings.ContainsRune(jm.ID, '*') {
 			jm.Expandable = 1
 		}
 

--- a/pkg/types/encoding/json/encoding_test.go
+++ b/pkg/types/encoding/json/encoding_test.go
@@ -29,7 +29,7 @@ func TestFindMatchesJSONEncoding(t *testing.T) {
 				{
 					AllowChildren: 0,
 					Leaf:          1,
-					Expandable:    0,
+					Expandable:    1,
 					Context:       make(map[string]int),
 					ID:            "*.sin",
 					Text:          "sin",
@@ -59,7 +59,7 @@ func TestFindMatchesJSONEncoding(t *testing.T) {
 				{
 					AllowChildren: 0,
 					Leaf:          1,
-					Expandable:    0,
+					Expandable:    1,
 					Context:       make(map[string]int),
 					ID:            "a.*.1",
 					Text:          "1",


### PR DESCRIPTION
This reverts commit 1065ff97792a75f75644018a295dac497e0a488b.

## What issue is this change attempting to solve?
Reverting bugged bugfix. Need more investigation.

## How does this change solve the problem? Why is this the best approach?

## How can we be sure this works as expected?

