### PR TITLE
refactor(find): use writeResponse for writing dada

### DIFF
--- a/tests/experimental/hurl/12-find.hurl
+++ b/tests/experimental/hurl/12-find.hurl
@@ -8,7 +8,7 @@ until:now
 format:raw
 
 HTTP/* 200
-Content-Type: raw
+Content-Type: text/plain
 [Asserts]
 body contains "some.test."
 body contains "some.test2."

--- a/tests/experimental/hurl/13-find.hurl
+++ b/tests/experimental/hurl/13-find.hurl
@@ -9,7 +9,7 @@ until:now
 format:completer
 
 HTTP/* 200
-Content-Type: json
+Content-Type: application/json
 [Asserts]
 jsonpath "$[*]" count == 2
 jsonpath "$.metrics[0].path" == "some.test."

--- a/tests/experimental/hurl/16-find.hurl
+++ b/tests/experimental/hurl/16-find.hurl
@@ -1,0 +1,16 @@
+# testing find w/default format
+# should be same as format=json
+GET http://localhost:8081/metrics/find
+[QueryStringParams]
+query:some.test.metric
+from:-10m
+until:now
+noCache:1
+
+HTTP/* 200
+Content-Type: application/json
+[Asserts]
+jsonpath "$[0].text" == "metric"
+jsonpath "$[0].leaf" == 1
+jsonpath "$[0].expandable" == 0
+jsonpath "$[0].allowChildren" == 0

--- a/tests/experimental/hurl/17-find.hurl
+++ b/tests/experimental/hurl/17-find.hurl
@@ -1,0 +1,17 @@
+# testing find w/treejson format
+# should be same as format=json
+GET http://localhost:8081/metrics/find
+[QueryStringParams]
+query:some.test.metric
+from:-10m
+until:now
+format:treejson
+noCache:1
+
+HTTP/* 200
+Content-Type: application/json
+[Asserts]
+jsonpath "$[0].text" == "metric"
+jsonpath "$[0].leaf" == 1
+jsonpath "$[0].expandable" == 0
+jsonpath "$[0].allowChildren" == 0


### PR DESCRIPTION
## What issue is this change attempting to solve?
Did same refactor as [before](https://github.com/bookingcom/carbonapi/pull/449/commits/1b65927d3b68cd2cebda1ebc4226e9f6b2fd42b6), but with tests now, so, should work properly.

Please note following:
1. In graphite-web find API [supports](https://graphite.readthedocs.io/en/latest/metrics_api.html#metrics-find) only `treejson` and `completer` format. So, we extended this to almost the same level of support as /render has - we have protobuf, raw and pickle formats. This is not graphite-web compatible, that's a new thing introduced in carbonapi before.
2. Before raw format produces `Content-Type: raw` and json format produces `Content-Type: json` header, which was not compatible with existing [standard](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types). Now it produces proper `Content-Type: text/plain` and `Content-Type: application/json` respectively.  Although it's a fix but we're changing existing behaviour. I tested Grafana, it works fine with these changes.

## How can we be sure this works as expected?
I added couple more hurl tests to properly test issue with previous refactor.

