### PR TITLE
Add gRPC gzip compression

### DIFF
--- a/docker/go-carbon/Dockerfile
+++ b/docker/go-carbon/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.19
 RUN mkdir -p /data/graphite/whisper/
 COPY ./docker/go-carbon/*.conf /etc/
 
-RUN go install github.com/go-graphite/go-carbon@master
+RUN go install github.com/go-graphite/go-carbon@HEAD
 
 EXPOSE 2003 2004 7002 7004 7007 2003/udp
 

--- a/pkg/backend/net/grpc.go
+++ b/pkg/backend/net/grpc.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 
@@ -85,7 +86,9 @@ func (gb *GrpcBackend) Render(ctx context.Context, request types.RenderRequest) 
 	ctx, cancel := gb.setTimeout(ctx)
 	defer cancel()
 
-	stream, err := gb.carbonV2Client.Render(ctx, multiFetchRequest, grpc.MaxCallRecvMsgSize(gb.maxRecvMsgSize))
+	stream, err := gb.carbonV2Client.Render(ctx, multiFetchRequest,
+		grpc.MaxCallRecvMsgSize(gb.maxRecvMsgSize),
+		grpc.UseCompressor(gzip.Name))
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +134,9 @@ func (gb *GrpcBackend) Find(ctx context.Context, request types.FindRequest) (typ
 	ctx, cancel := gb.setTimeout(ctx)
 	defer cancel()
 
-	globResponse, err := gb.carbonV2Client.Find(ctx, globRequest, grpc.MaxCallRecvMsgSize(gb.maxRecvMsgSize))
+	globResponse, err := gb.carbonV2Client.Find(ctx, globRequest,
+		grpc.MaxCallRecvMsgSize(gb.maxRecvMsgSize),
+		grpc.UseCompressor(gzip.Name))
 	gb.countResponse(err, "find")
 	if err != nil {
 		if code := status.Code(err); code == codes.NotFound {
@@ -172,7 +177,9 @@ func (gb *GrpcBackend) Info(ctx context.Context, request types.InfoRequest) ([]t
 	ctx, cancel := gb.setTimeout(ctx)
 	defer cancel()
 
-	resp, err := gb.carbonV2Client.Info(ctx, infoRequest, grpc.MaxCallRecvMsgSize(gb.maxRecvMsgSize))
+	resp, err := gb.carbonV2Client.Info(ctx, infoRequest,
+		grpc.MaxCallRecvMsgSize(gb.maxRecvMsgSize),
+		grpc.UseCompressor(gzip.Name))
 	gb.countResponse(err, "info")
 	if err != nil {
 		if code := status.Code(err); code == codes.NotFound {

--- a/vendor/google.golang.org/grpc/encoding/gzip/gzip.go
+++ b/vendor/google.golang.org/grpc/encoding/gzip/gzip.go
@@ -1,0 +1,133 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package gzip implements and registers the gzip compressor
+// during the initialization.
+//
+// # Experimental
+//
+// Notice: This package is EXPERIMENTAL and may be changed or removed in a
+// later release.
+package gzip
+
+import (
+	"compress/gzip"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"sync"
+
+	"google.golang.org/grpc/encoding"
+)
+
+// Name is the name registered for the gzip compressor.
+const Name = "gzip"
+
+func init() {
+	c := &compressor{}
+	c.poolCompressor.New = func() interface{} {
+		return &writer{Writer: gzip.NewWriter(ioutil.Discard), pool: &c.poolCompressor}
+	}
+	encoding.RegisterCompressor(c)
+}
+
+type writer struct {
+	*gzip.Writer
+	pool *sync.Pool
+}
+
+// SetLevel updates the registered gzip compressor to use the compression level specified (gzip.HuffmanOnly is not supported).
+// NOTE: this function must only be called during initialization time (i.e. in an init() function),
+// and is not thread-safe.
+//
+// The error returned will be nil if the specified level is valid.
+func SetLevel(level int) error {
+	if level < gzip.DefaultCompression || level > gzip.BestCompression {
+		return fmt.Errorf("grpc: invalid gzip compression level: %d", level)
+	}
+	c := encoding.GetCompressor(Name).(*compressor)
+	c.poolCompressor.New = func() interface{} {
+		w, err := gzip.NewWriterLevel(ioutil.Discard, level)
+		if err != nil {
+			panic(err)
+		}
+		return &writer{Writer: w, pool: &c.poolCompressor}
+	}
+	return nil
+}
+
+func (c *compressor) Compress(w io.Writer) (io.WriteCloser, error) {
+	z := c.poolCompressor.Get().(*writer)
+	z.Writer.Reset(w)
+	return z, nil
+}
+
+func (z *writer) Close() error {
+	defer z.pool.Put(z)
+	return z.Writer.Close()
+}
+
+type reader struct {
+	*gzip.Reader
+	pool *sync.Pool
+}
+
+func (c *compressor) Decompress(r io.Reader) (io.Reader, error) {
+	z, inPool := c.poolDecompressor.Get().(*reader)
+	if !inPool {
+		newZ, err := gzip.NewReader(r)
+		if err != nil {
+			return nil, err
+		}
+		return &reader{Reader: newZ, pool: &c.poolDecompressor}, nil
+	}
+	if err := z.Reset(r); err != nil {
+		c.poolDecompressor.Put(z)
+		return nil, err
+	}
+	return z, nil
+}
+
+func (z *reader) Read(p []byte) (n int, err error) {
+	n, err = z.Reader.Read(p)
+	if err == io.EOF {
+		z.pool.Put(z)
+	}
+	return n, err
+}
+
+// RFC1952 specifies that the last four bytes "contains the size of
+// the original (uncompressed) input data modulo 2^32."
+// gRPC has a max message size of 2GB so we don't need to worry about wraparound.
+func (c *compressor) DecompressedSize(buf []byte) int {
+	last := len(buf)
+	if last < 4 {
+		return -1
+	}
+	return int(binary.LittleEndian.Uint32(buf[last-4 : last]))
+}
+
+func (c *compressor) Name() string {
+	return Name
+}
+
+type compressor struct {
+	poolCompressor   sync.Pool
+	poolDecompressor sync.Pool
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,6 +214,7 @@ google.golang.org/grpc/connectivity
 google.golang.org/grpc/credentials
 google.golang.org/grpc/credentials/insecure
 google.golang.org/grpc/encoding
+google.golang.org/grpc/encoding/gzip
 google.golang.org/grpc/encoding/proto
 google.golang.org/grpc/grpclog
 google.golang.org/grpc/internal


### PR DESCRIPTION
go-carbon carbonserver http already uses gzip compression. This PR adds the same compression to gRPC calls to carbonserver.