### PR TITLE
Add gRPC large init window size

### DIFF
--- a/pkg/backend/net/grpc.go
+++ b/pkg/backend/net/grpc.go
@@ -49,7 +49,9 @@ func NewGrpc(cfg GrpcConfig) (*GrpcBackend, error) {
 			PermitWithoutStream: true,
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithNoProxy())
+		grpc.WithNoProxy(),
+		grpc.WithInitialWindowSize(4*1024*1024),
+		grpc.WithInitialConnWindowSize(4*1024*1024))
 	conn, err := grpc.Dial(cfg.GrpcAddress, opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is related to https://github.com/go-graphite/go-carbon/pull/514.

The motivation is described there, however, It should have been applied mainly to carbonapi.