### PR TITLE
Add config to respond 404 when TLD cache miss

### DIFF
--- a/pkg/app/carbonapi/app.go
+++ b/pkg/app/carbonapi/app.go
@@ -41,10 +41,11 @@ type App struct {
 	config       cfg.API
 	ZipperConfig cfg.Zipper
 
-	queryCache             cache.BytesCache
-	findCache              cache.BytesCache
-	TopLevelDomainCache    *expirecache.Cache
-	TopLevelDomainPrefixes []tldcache.TopLevelDomainPrefix
+	queryCache               cache.BytesCache
+	findCache                cache.BytesCache
+	TopLevelDomainCache      *expirecache.Cache
+	TopLevelDomainPrefixes   []tldcache.TopLevelDomainPrefix
+	NotFoundWhenTLDCacheMiss bool
 
 	requestBlocker *blocker.RequestBlocker
 
@@ -85,6 +86,7 @@ func New(config cfg.API, lg *zap.Logger, buildVersion string) (*App, error) {
 	setUpConfig(app, lg)
 
 	app.ZipperConfig, app.Backends, app.TopLevelDomainCache, app.TopLevelDomainPrefixes, app.ZipperMetrics = SetupZipper(config.ZipperConfig, BuildVersion, &ms, lg)
+	app.NotFoundWhenTLDCacheMiss = app.ZipperConfig.NotFoundWhenTLDCacheMiss
 	go tldcache.ProbeTopLevelDomains(app.TopLevelDomainCache, app.TopLevelDomainPrefixes, app.Backends, app.ZipperConfig.InternalRoutingCache,
 		app.ZipperMetrics.TLDCacheProbeReqTotal, app.ZipperMetrics.TLDCacheProbeErrors)
 

--- a/pkg/app/carbonapi/http_handlers.go
+++ b/pkg/app/carbonapi/http_handlers.go
@@ -559,7 +559,7 @@ func sendRenderRequest(app *App, ctx context.Context, path string, from, until i
 
 	app.ms.UpstreamRequests.WithLabelValues("render").Inc()
 	t0 := time.Now()
-	metrics, err = Render(app.TopLevelDomainCache, app.TopLevelDomainPrefixes, app.Backends,
+	metrics, err = Render(app.TopLevelDomainCache, app.TopLevelDomainPrefixes, app.NotFoundWhenTLDCacheMiss, app.Backends,
 		app.ZipperConfig.RenderReplicaMismatchConfig, ctx, path, int64(from), int64(until), app.ZipperMetrics, lg)
 	app.ms.UpstreamDuration.WithLabelValues("render").Observe(time.Since(t0).Seconds())
 
@@ -774,7 +774,7 @@ func (app *App) resolveGlobs(ctx context.Context, metric string, useCache bool, 
 	Trace(lg, "sending find request upstream")
 	app.ms.UpstreamRequests.WithLabelValues("find").Inc()
 	t0 := time.Now()
-	matches, err = Find(app.TopLevelDomainCache, app.TopLevelDomainPrefixes, app.Backends, ctx, request.Query, app.ZipperMetrics, lg)
+	matches, err = Find(app.TopLevelDomainCache, app.TopLevelDomainPrefixes, app.NotFoundWhenTLDCacheMiss, app.Backends, ctx, request.Query, app.ZipperMetrics, lg)
 	app.ms.UpstreamDuration.WithLabelValues("find").Observe(time.Since(t0).Seconds())
 
 	if err != nil {
@@ -1199,7 +1199,7 @@ func (app *App) infoHandler(w http.ResponseWriter, r *http.Request, lg *zap.Logg
 	var infos []dataTypes.Info
 	var err error
 	app.ms.UpstreamRequests.WithLabelValues("info").Inc()
-	infos, err = Info(app.TopLevelDomainCache, app.TopLevelDomainPrefixes, app.Backends, ctx, query, app.ZipperMetrics, lg)
+	infos, err = Info(app.TopLevelDomainCache, app.TopLevelDomainPrefixes, app.NotFoundWhenTLDCacheMiss, app.Backends, ctx, query, app.ZipperMetrics, lg)
 	// not counting the duration for info requests to reduce the number of exposed metrics
 
 	if err != nil {

--- a/pkg/cfg/common.go
+++ b/pkg/cfg/common.go
@@ -191,9 +191,11 @@ type Common struct {
 	BackendQueueSize             int `yaml:"backendQueueSize"`
 	BackendMaxConcurrentRequests int `yaml:"backendMaxConcurrentRequests"`
 
-	ExpireDelaySec        int32    `yaml:"expireDelaySec"`
-	InternalRoutingCache  int32    `yaml:"internalRoutingCache"`
-	TLDCacheExtraPrefixes []string `yaml:"tldCacheExtraPrefixes"`
+	ExpireDelaySec           int32    `yaml:"expireDelaySec"`
+	InternalRoutingCache     int32    `yaml:"internalRoutingCache"`
+	TLDCacheExtraPrefixes    []string `yaml:"tldCacheExtraPrefixes"`
+	NotFoundWhenTLDCacheMiss bool     `yaml:"notFoundWhenTLDCacheMiss"`
+
 	// Enable compatibility with graphite-web 0.9
 	// This will affect graphite-web 1.0+ with multiple cluster_servers
 	GraphiteWeb09Compatibility bool `yaml:"graphite09compat"`


### PR DESCRIPTION
To avoid request fanout to all backends when a target is not in tld cache.
