### PR TITLE
Verbose error message for moving window functions

### DIFF
--- a/pkg/expr/functions/moving/function.go
+++ b/pkg/expr/functions/moving/function.go
@@ -87,7 +87,7 @@ func (f *moving) Do(ctx context.Context, e parser.Expr, from, until int32, value
 		r := *a
 		r.Name = fmt.Sprintf("%s(%s,%s)", e.Target(), a.Name, argstr)
 		if len(a.Values)-offset < 0 {
-			return nil, parser.ErrInvalidArgumentValue
+			return nil, parser.ErrMovingWindowSizeLessThanRetention
 		}
 		r.Values = make([]float64, len(a.Values)-offset)
 		r.IsAbsent = make([]bool, len(a.Values)-offset)

--- a/pkg/expr/functions/movingMedian/function.go
+++ b/pkg/expr/functions/movingMedian/function.go
@@ -85,6 +85,9 @@ func (f *movingMedian) Do(ctx context.Context, e parser.Expr, from, until int32,
 	for _, a := range arg {
 		r := *a
 		r.Name = fmt.Sprintf("movingMedian(%s,%s)", a.Name, argstr)
+		if len(a.Values)-offset < 0 {
+			return nil, parser.ErrMovingWindowSizeLessThanRetention
+		}
 		r.Values = make([]float64, len(a.Values)-offset)
 		r.IsAbsent = make([]bool, len(a.Values)-offset)
 		r.StartTime = from

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -65,6 +65,8 @@ var (
 	ErrDifferentCountMetrics = ParseError("both arguments must have the same number of metrics")
 	// ErrInvalidArgumentValue is an eval error returned when a function received an argument that has the right type but invalid value
 	ErrInvalidArgumentValue = ParseError("invalid function argument value")
+	// ErrMovingWindowSizeLessThanRetention is an eval error returned when a function received a moving window size bigger than the metrics retention
+	ErrMovingWindowSizeLessThanRetention = ParseError("moving window is bigger than the metrics retention")
 )
 
 // ParseError is a type of errors returned from the parser


### PR DESCRIPTION
for moving window functions there will be verbose error if the window size is bigger than the metrics retention

