### PR TITLE
Limit pixelratio below  cairo limits

### DIFF
--- a/pkg/expr/functions/cairo/png/cairo.go
+++ b/pkg/expr/functions/cairo/png/cairo.go
@@ -971,11 +971,14 @@ func marshalCairo(p PictureParams, results []*types.MetricData, backend cairoBac
 	// See https://github.com/Automattic/node-canvas/issues/1374#issuecomment-467918480
 	// and https://github.com/freedesktop/cairo/blob/929262dd54ffae81721ffe9b2c59faa7b045c663/src/cairo-image-surface.c#L59-L62
 	maxImageSize := float64(32767)
-	if params.width > maxImageSize {
-		return nil, fmt.Errorf("Invalid picture width %g, should be =< %g", params.width, maxImageSize)
+	if params.width >= maxImageSize {
+		return nil, fmt.Errorf("Invalid picture width %g, should be < %g", params.width, maxImageSize)
 	}
-	if params.height > maxImageSize {
-		return nil, fmt.Errorf("Invalid picture height %g, should be =< %g", params.height, maxImageSize)
+	if params.height >= maxImageSize {
+		return nil, fmt.Errorf("Invalid picture height %g, should be < %g", params.height, maxImageSize)
+	}
+	if params.pixelRatio >= maxImageSize {
+		return nil, fmt.Errorf("Invalid picture pixelRatio %g, should be < %g", params.pixelRatio, maxImageSize)
 	}
 
 	margin := float64(params.margin)


### PR DESCRIPTION
FIxing panic in carbonapi.

## What issue is this change attempting to solve?
`http: panic serving 127.0.0.1:53106: invalid value (typically too big) for the size of the input (surface, pattern, etc.)`

## How does this change solve the problem? Why is this the best approach?
I did previous change (see #400 ) for height and width, but looks like not enough. 

