### PR TITLE
Add source clusters to render logs

### DIFF
--- a/pkg/backend/net/grpc.go
+++ b/pkg/backend/net/grpc.go
@@ -225,3 +225,7 @@ func (gb *GrpcBackend) countResponse(err error, request string) {
 		gb.responsesCount.WithLabelValues(strconv.Itoa(int(code)), request).Inc()
 	}
 }
+
+func (gb *GrpcBackend) BackendInfo() (addr string, cluster string, dc string) {
+	return gb.GrpcAddress, gb.cluster, gb.dc
+}

--- a/pkg/backend/net/net.go
+++ b/pkg/backend/net/net.go
@@ -396,3 +396,7 @@ func carbonapiV2FindEncoder(u *url.URL, query string) *url.URL {
 
 	return u
 }
+
+func (b NetBackend) BackendInfo() (addr string, cluster string, dc string) {
+	return b.address, b.cluster, b.dc
+}

--- a/pkg/carbonapipb/carbonapi.pb.go
+++ b/pkg/carbonapipb/carbonapi.pb.go
@@ -47,6 +47,7 @@ type AccessLogDetails struct {
 	ZipperRequests                int64             `json:"zipper_requests,omitempty"`
 	TotalMetricCount              int64             `json:"total_metric_count"`
 	CacheErrs                     string            `json:"cache_errs"`
+	Clusters                      []string          `json:"clusters"`
 }
 
 func splitAddr(addr string) (string, string) {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -104,6 +104,8 @@ type Metric struct {
 	StepTime  int32
 	Values    []float64
 	IsAbsent  []bool
+
+	SourceClusters []string
 }
 
 // MetricRenderStats represents the stats of rendering and merging metrics.
@@ -298,8 +300,20 @@ func mergeMetrics(metrics []Metric, replicaMismatchConfig cfg.RenderReplicaMisma
 	sort.Sort(byStepTime(metrics))
 	healed := 0
 
+	clusterMap := make(map[string]bool)
+	for _, m := range metrics {
+		for _, cl := range m.SourceClusters {
+			clusterMap[cl] = true
+		}
+	}
+	clusters := make([]string, 0, len(clusterMap))
+	for cl := range clusterMap {
+		clusters = append(clusters, cl)
+	}
+	sort.Strings(clusters)
 	// metrics[0] has the highest resolution of metrics
 	metric = metrics[0]
+	metric.SourceClusters = clusters
 	valuesForPoint := make([]float64, 0, len(metrics))
 	isMismatchFindConfig := replicaMatchMode != cfg.ReplicaMatchModeNormal
 	for i := range metric.Values {


### PR DESCRIPTION
This PR adds a SourceClusters to metrics to identify the cluster the metric originated from. When merging the metrics from multiple upstreams, the result metric contains all of the backends involved for that metric in its SourceClusters. In the end, carbonapi, logs the request with all of the source clusters who contributed for gathering the metrics.

