### PR TITLE
Replace panics in cairo with proper errors

### DIFF
--- a/pkg/expr/functions/cairo/png/cairo.go
+++ b/pkg/expr/functions/cairo/png/cairo.go
@@ -1543,13 +1543,13 @@ func setupTwoYAxes(cr *cairoSurfaceContext, params *Params) (err error) {
 	params.yTopR = params.yStepR * math.Ceil(yMaxValueR/params.yStepR)
 
 	if params.logBase != 0 {
-		if yMinValueL > 0 && yMaxValueL > 0 {
+		if yMinValueL > 0 && yMinValueR > 0 {
 			params.yBottomL = math.Pow(params.logBase, math.Floor(math.Log(yMinValueL)/math.Log(params.logBase)))
 			params.yTopL = math.Pow(params.logBase, math.Ceil(math.Log(yMaxValueL/math.Log(params.logBase))))
 			params.yBottomR = math.Pow(params.logBase, math.Floor(math.Log(yMinValueR)/math.Log(params.logBase)))
 			params.yTopR = math.Pow(params.logBase, math.Ceil(math.Log(yMaxValueR/math.Log(params.logBase))))
 		} else {
-			return fmt.Errorf("logscale with minvalue '%g' or maxvalue '%g' <= 0", yMinValueL, yMaxValueL)
+			return fmt.Errorf("logscale with yMinValueL '%g' or yMinValueR '%g' <= 0", yMinValueL, yMinValueR)
 		}
 	}
 


### PR DESCRIPTION
## What issue is this change attempting to solve?
```
http: panic serving 127.0.0.1:52522: logscale with minvalue <= 0
goroutine 1028267222 [running]:
net/http.(*conn).serve.func1()
         /usr/lib64/go/src/net/http/server.go:1850 +0xbf
 panic({0xc77d60, 0xeda080})
        /usr/lib64/go/src/runtime/panic.go:890 +0x262
github.com/bookingcom/carbonapi/pkg/expr/functions/cairo/png.setupYAxis(0xc0e0967070, 0xc0de658480, {0xc0e34f2738
```

## How does this change solve the problem? Why is this the best approach?
I replaced all panics in cairo module with proper errors which will be returned to user as HTTP 400 instead of 500

