### PR TITLE
fix panic because integer overflow in valuesPerPoint

### DIFF
--- a/pkg/app/carbonapi/http_handlers.go
+++ b/pkg/app/carbonapi/http_handlers.go
@@ -704,7 +704,7 @@ func (app *App) renderWriteBody(results []*types.MetricData, form renderForm, r 
 
 	switch form.format {
 	case jsonFormat:
-		if maxDataPoints, _ := strconv.Atoi(r.FormValue("maxDataPoints")); maxDataPoints != 0 {
+		if maxDataPoints, _ := strconv.Atoi(r.FormValue("maxDataPoints")); maxDataPoints > 0 {
 			results = types.ConsolidateJSON(maxDataPoints, results)
 		}
 

--- a/pkg/expr/types/types.go
+++ b/pkg/expr/types/types.go
@@ -269,7 +269,7 @@ func MarshalRaw(results []*MetricData) []byte {
 // Consolidate returns a consolidated copy of this MetricData.
 func (r *MetricData) Consolidate(valuesPerPoint int) *MetricData {
 	ret := *r
-	if valuesPerPoint == 1 || valuesPerPoint == 0 {
+	if valuesPerPoint == 1 || valuesPerPoint <= 0 {
 		ret.ValuesPerPoint = 1
 		ret.Values = make([]float64, len(r.Values))
 		ret.IsAbsent = make([]bool, len(r.IsAbsent))

--- a/pkg/expr/types/types_test.go
+++ b/pkg/expr/types/types_test.go
@@ -74,6 +74,20 @@ func TestConsolidate(t *testing.T) {
 			6,
 			nil,
 		},
+		{"zero vpp, no consolidation",
+			MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, 0),
+			0,
+			MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, 0),
+			6,
+			nil,
+		},
+		{"negative vpp, no consolidation",
+			MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, 0),
+			-9223372036854775808,
+			MakeMetricData("metric1", []float64{1, math.NaN(), math.NaN(), 3, 4, 12}, 1, 0),
+			6,
+			nil,
+		},
 		{"valuesPerPoint_2_none_values",
 			MakeMetricData("metric1", []float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}, 1, 0),
 			2,
@@ -122,7 +136,7 @@ func TestConsolidate(t *testing.T) {
 		if diff := cmp.Diff(test.expected.IsAbsent, got.IsAbsent); diff != "" {
 			t.Errorf("Consolidation IsAbsent for %s (-want +got):\n%s", test.name, diff)
 		}
-		if test.valuesPerPoint != got.ValuesPerPoint {
+		if test.valuesPerPoint > 0 && test.valuesPerPoint != got.ValuesPerPoint {
 			t.Errorf("Consolidation ValuesPerPoint for %s. Want: %d. Got: %d", test.name, test.valuesPerPoint, got.ValuesPerPoint)
 		}
 		if test.expectedEnd != got.StopTime {


### PR DESCRIPTION
## What issue is this change attempting to solve?
```
http: panic serving 127.0.0.1:44020: runtime error: slice bounds out of range [:-9223372036854775808]
goroutine 1134454440 [running]:
net/http.(*conn).serve.func1()
        /usr/lib64/go/src/net/http/server.go:1850 +0xbf
panic({0xd4bea0, 0xc3c0dc5b00})
        /usr/lib64/go/src/runtime/panic.go:890 +0x262
github.com/bookingcom/carbonapi/pkg/expr/types.(*MetricData).Consolidate(0xc076caf520, 0x8000000000000000)
        /usr/local/git_tree/gopath/src/github.com/bookingcom/carbonapi/pkg/expr/types/types.go:295 +0x6f0
github.com/bookingcom/carbonapi/pkg/expr/types.ConsolidateJSON(0x42b, {0xc1c75fbf00, 0xf, 0x2000100?})
        /usr/local/git_tree/gopath/src/github.com/bookingcom/carbonapi/pkg/expr/types/types.go:130 +0x190
github.com/bookingcom/carbonapi/pkg/app/carbonapi.(*App).renderWriteBody(0xc00025b800?, {0xc1c75fbf00?, 0xf, 0x10}, {{0xc35e47bf20, 0x3, 0x3}, {0xc066986052, 0xa}, {0xc066986063>
        /usr/local/git_tree/gopath/src/github.com/bookingcom/carbonapi/pkg/app/carbonapi/http_handlers.go:708 +0xcb
github.com/bookingcom/carbonapi/pkg/app/carbonapi.(*App).renderHandler(0xc00025b800, {0xee25b8, 0xc41a0dcf80}, 0xc304c82100, 0x1651240?)
```

## How does this change solve the problem? Why is this the best approach?
valuesPerPoint is calculated from maxDataPoints and from/until parameters. It is defined as `int` in many places, redefining or converting to uint would be quite hard. 
So, first, I denying maxDataPoints to be < 0, which is kinda logical, negative values was never supported, and we pretty much don't care about int overflow there either. 
Then I just assuming that if valuesPerPoint is negative (either because of int overflow or some other error in data) we can treat that case the same as valuesPerPoint is 0 or 1, i.e. not do any aggregation.
Not sure if best approach, though.

## How can we be sure this works as expected?
Tested on prod, didn't find any issues.
