### PR TITLE
Set total_metrics_count log entry after renders

### DIFF
--- a/pkg/app/carbonapi/http_handlers.go
+++ b/pkg/app/carbonapi/http_handlers.go
@@ -306,6 +306,8 @@ func (app *App) renderHandler(w http.ResponseWriter, r *http.Request, lg *zap.Lo
 	toLog.Clusters = clustersFromMetricMap(metricMap)
 	toLog.CarbonzipperResponseSizeBytes = int64(size * 8)
 
+	toLog.TotalMetricCount = int64(len(results))
+
 	if ctx.Err() != nil {
 		app.ms.RequestCancel.WithLabelValues("render", ctx.Err().Error()).Inc()
 	}
@@ -836,7 +838,6 @@ func (app *App) getRenderRequests(ctx context.Context, m parser.MetricRequest, u
 	}
 
 	glob, fromCache, err := app.resolveGlobs(ctx, m.Metric, useCache, toLog, lg)
-	toLog.TotalMetricCount += int64(len(glob.Matches))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The previous logic was not correct if there were some non-glob metrics in the render request. This commit fixes the issue by setting total_metrics_count after upstream rendering finishes.
