### PR TITLE
Added check for the image size before calling cairo.

### DIFF
--- a/pkg/expr/functions/cairo/png/cairo.go
+++ b/pkg/expr/functions/cairo/png/cairo.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bookingcom/carbonapi/pkg/expr/types"
 	"github.com/bookingcom/carbonapi/pkg/parser"
 	dataTypes "github.com/bookingcom/carbonapi/pkg/types"
+	"github.com/pkg/errors"
 
 	"github.com/evmar/gocairo/cairo"
 	"github.com/tebeka/strftime"
@@ -1000,7 +1001,10 @@ func marshalCairo(p PictureParams, results []*types.MetricData, backend cairoBac
 		s := svgSurfaceCreate(tmpfile.Name(), params.width, params.height, params.pixelRatio)
 		surface = s.Surface
 	case cairoPNG:
-		s := imageSurfaceCreate(cairo.FormatARGB32, params.width, params.height, params.pixelRatio)
+		s, err := imageSurfaceCreate(cairo.FormatARGB32, params.width, params.height, params.pixelRatio)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not create image surface via cairo")
+		}
 		surface = s.Surface
 	}
 	cr := createContext(surface, params.pixelRatio)


### PR DESCRIPTION
## What issue is this change attempting to solve?
Looks like `cairo.ImageSurfaceCreate` can be called with the image size larger than the one allowed.
The maximum can be looked up e.g. here https://github.com/ImageMagick/cairo/blob/main/src/cairo-image-surface.c#L62
It's also mentioned in the mailing lists https://cairo.cairographics.narkive.com/Mkjwvkep/32k-limit-with-image-surface The lists are old, but seems like the limitation is still in place.

## How does this change solve the problem? Why is this the best approach?
Added a check.
