### PR TITLE
Implement si and binary system for legendValue

### DIFF
--- a/pkg/expr/expr_test.go
+++ b/pkg/expr/expr_test.go
@@ -478,7 +478,7 @@ func TestEvalExpression(t *testing.T) {
 			map[parser.MetricRequest][]*types.MetricData{
 				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{1, 2, 3, 4, 5}, 1, now32)},
 			},
-			[]*types.MetricData{types.MakeMetricData("metric1 (sum: 15.000000) (avg: 3.000000)",
+			[]*types.MetricData{types.MakeMetricData("metric1 (sum: 15.000000, avg: 3.000000)",
 				[]float64{1, 2, 3, 4, 5}, 1, now32)},
 		},
 		{

--- a/pkg/expr/functions/legendValue/function.go
+++ b/pkg/expr/functions/legendValue/function.go
@@ -75,7 +75,7 @@ func (f *legendValue) Do(ctx context.Context, e parser.Expr, from, until int32, 
 			}
 			values = append(values, fmt.Sprintf("%s: %s", method, summary))
 		}
-		
+
 		r := *a
 		r.Name = fmt.Sprintf("%s (%s)", r.Name, strings.Join(values, ", "))
 		results = append(results, &r)

--- a/pkg/expr/functions/legendValue/function.go
+++ b/pkg/expr/functions/legendValue/function.go
@@ -3,6 +3,7 @@ package legendValue
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/bookingcom/carbonapi/pkg/expr/helper"
 	"github.com/bookingcom/carbonapi/pkg/expr/interfaces"
@@ -54,7 +55,7 @@ func (f *legendValue) Do(ctx context.Context, e parser.Expr, from, until int32, 
 	var results []*types.MetricData
 
 	for _, a := range arg {
-		r := *a
+		var values []string
 		for _, method := range methods {
 			summaryVal, _, err := helper.SummarizeValues(method, a.Values)
 			if err != nil {
@@ -72,9 +73,11 @@ func (f *legendValue) Do(ctx context.Context, e parser.Expr, from, until int32, 
 			} else {
 				return nil, fmt.Errorf("%s is not supported for system", system)
 			}
-			r.Name = fmt.Sprintf("%s (%s: %s)", r.Name, method, summary)
+			values = append(values, fmt.Sprintf("%s: %s", method, summary)
 		}
-
+		
+		r := *a
+		r.Name = fmt.Sprintf("%s (%s)", r.Name, strings.Join(values, ", "))
 		results = append(results, &r)
 	}
 	return results, nil

--- a/pkg/expr/functions/legendValue/function.go
+++ b/pkg/expr/functions/legendValue/function.go
@@ -73,7 +73,7 @@ func (f *legendValue) Do(ctx context.Context, e parser.Expr, from, until int32, 
 			} else {
 				return nil, fmt.Errorf("%s is not supported for system", system)
 			}
-			values = append(values, fmt.Sprintf("%s: %s", method, summary)
+			values = append(values, fmt.Sprintf("%s: %s", method, summary))
 		}
 		
 		r := *a

--- a/pkg/expr/functions/legendValue/function.go
+++ b/pkg/expr/functions/legendValue/function.go
@@ -37,7 +37,7 @@ func (f *legendValue) Do(ctx context.Context, e parser.Expr, from, until int32, 
 	}
 
 	var system string
-	methods := make([]string, len(e.Args())-1)
+	var methods []string
 	for i := 1; i < len(e.Args()); i++ {
 		method, err := e.GetStringArg(i)
 		if err != nil {
@@ -47,7 +47,7 @@ func (f *legendValue) Do(ctx context.Context, e parser.Expr, from, until int32, 
 		if method == "si" || method == "binary" {
 			system = method
 		} else {
-			methods[i-1] = method
+			methods = append(methods, method)
 		}
 	}
 

--- a/pkg/expr/functions/legendValue/function.go
+++ b/pkg/expr/functions/legendValue/function.go
@@ -66,7 +66,7 @@ func (f *legendValue) Do(ctx context.Context, e parser.Expr, from, until int32, 
 				sv, sf := humanize.ComputeSI(summaryVal)
 				summary = fmt.Sprintf("%.1f %s", sv, sf)
 			} else if system == "binary" {
-				summary = humanize.IBytes(summaryVal)
+				summary = humanize.IBytes(uint64(summaryVal))
 			} else if system == "" {
 				summary = fmt.Sprintf("%f", summaryVal)
 			} else {


### PR DESCRIPTION
Sometimes it is useful to print values (current, min, max, average) in the graph legend in human readable form.
Unfortunately, legendValue function of carbonapi is only able to print the raw values, because the systems "si" and "binary" are not implemented yet.

This PR implements the "si" and "binary" system for the legendValue function, it is currently running on my productive environment without any issues.

Please let me know if you have any questions or remarks.