### PR TITLE
Checking absent array size during marshaling

### DIFF
--- a/pkg/expr/types/types.go
+++ b/pkg/expr/types/types.go
@@ -166,7 +166,7 @@ func MarshalJSON(results []*MetricData) []byte {
 
 			b = append(b, '[')
 
-			if absent[i] || math.IsInf(v, 0) || math.IsNaN(v) {
+			if (i < len(absent) && absent[i]) || math.IsInf(v, 0) || math.IsNaN(v) {
 				b = append(b, "null"...)
 			} else {
 				b = strconv.AppendFloat(b, v, 'f', -1, 64)


### PR DESCRIPTION
## What issue is this change attempting to solve?

Recovered panic `index out of range [1] with length 1` when we have fewer elements in absent results than normal results:

`github.com/bookingcom/carbonapi/pkg/expr/types.MarshalJSON({0xc19c012c48, 0x3, 0x3?})
        /usr/local/git_tree/gopath/src/github.com/bookingcom/carbonapi/pkg/expr/types/types.go:169 +0x4bd`

## How does this change solve the problem? Why is this the best approach?

Let's check array size beforehand