### PR TITLE
TimeLagSeries function fix

### DIFF
--- a/pkg/expr/functions/timeLag/function_test.go
+++ b/pkg/expr/functions/timeLag/function_test.go
@@ -49,6 +49,36 @@ func TestTimeLagSeriesMultiReturn(t *testing.T) {
 				"timeLagSeries(metric2,metric2)": {types.MakeMetricData("timeLagSeries(metric2,metric2)", []float64{0, 0, 0, 0, 0}, 1, now32)},
 			},
 		},
+		{
+			"timeLagSeries(metric1,metric2)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{1, 30, 40, 60, 80, 100, 100, 100, 100, 100, 150, 200, 200, 200}, 1, now32),
+				},
+				{"metric2", 0, 1}: {
+					types.MakeMetricData("metric2", []float64{1, 100, 100, 100, 100, 100, 100, 100, 100, 200, 200, 200, 200, 200}, 1, now32),
+				},
+			},
+			"timeLagSeries",
+			map[string][]*types.MetricData{
+				"timeLagSeries(metric1,metric2)": {types.MakeMetricData("timeLagSeries(metric1,metric2)", []float64{0, 1, 2, 3, 4, 0, 0, 0, 0, 1, 2, 0, 0, 0}, 1, now32)},
+			},
+		},
+		{
+			"timeLagSeries(metric1,metric2)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {
+					types.MakeMetricData("metric1", []float64{50, 50, 50, 60, 70, 75, 80, 90, 90, 90}, 1, now32),
+				},
+				{"metric2", 0, 1}: {
+					types.MakeMetricData("metric2", []float64{50, 50, 50, 90, 90, 90, 90, 90, 90, 90}, 1, now32),
+				},
+			},
+			"timeLagSeries",
+			map[string][]*types.MetricData{
+				"timeLagSeries(metric1,metric2)": {types.MakeMetricData("timeLagSeries(metric1,metric2)", []float64{0, 0, 0, 1, 2, 3, 4, 0, 0, 0}, 1, now32)},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -58,7 +88,6 @@ func TestTimeLagSeriesMultiReturn(t *testing.T) {
 			th.TestMultiReturnEvalExpr(t, &tt)
 		})
 	}
-
 }
 
 func TestTimeLagSeries(t *testing.T) {
@@ -72,7 +101,16 @@ func TestTimeLagSeries(t *testing.T) {
 				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{2, math.NaN(), 3, math.NaN(), 5, 12}, 1, now32)},
 			},
 			[]*types.MetricData{types.MakeMetricData("timeLagSeries(metric1,metric2)",
-				[]float64{math.NaN(), math.NaN(), math.NaN(), 1, 2, 0}, 1, now32)},
+				[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0}, 1, now32)},
+		},
+		{
+			"timeLagSeries(metric1,metric2)",
+			map[parser.MetricRequest][]*types.MetricData{
+				{"metric1", 0, 1}: {types.MakeMetricData("metric1", []float64{4857060, 4857060, 4857060, 4857200, 4858101, 4859001, 4859901}, 1, now32)},
+				{"metric2", 0, 1}: {types.MakeMetricData("metric2", []float64{4857060, 4857060, 4857060, 4884065, 4884065, 4884065, 4884065}, 1, now32)},
+			},
+			[]*types.MetricData{types.MakeMetricData("timeLagSeries(metric1,metric2)",
+				[]float64{0, 0, 0, 1, 2, 3, 4}, 1, now32)},
 		},
 		{
 			"timeLagSeries(metric[12])",
@@ -83,7 +121,7 @@ func TestTimeLagSeries(t *testing.T) {
 				},
 			},
 			[]*types.MetricData{types.MakeMetricData("timeLagSeries(metric[12])",
-				[]float64{math.NaN(), math.NaN(), math.NaN(), 1, 2, 0}, 1, now32)},
+				[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN(), 0}, 1, now32)},
 		},
 		{
 			"timeLagSeries(metric1,metric2)",
@@ -108,6 +146,7 @@ func TestTimeLagSeries(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		testName := tt.Target
+
 		t.Run(testName, func(t *testing.T) {
 			th.TestEvalExpr(t, &tt)
 		})


### PR DESCRIPTION
## What issue is this change attempting to solve?
TimeSeriesLag function calculates time-based lag (e.g. for Kafka offsets) based on two offsets metrics - consumer and producer.

Currently the lag function has a bug that produces negative values in some cases.
<img width="1448" alt="image" src="https://github.com/bookingcom/carbonapi/assets/29065610/28fe60da-b96a-436d-86f3-0eb211f3da0a">

This MR simplifies and updates the logic of the function, and fixes this bug.

## How does this change solve the problem? Why is this the best approach?
Code changes make the logic of lag calculation more understandable and account for the bug that was producing the negative values

## How can we be sure this works as expected?
Additional tests were added, broken tests were fixed
