### PR TITLE
check for empty interval string

### DIFF
--- a/pkg/parser/interval.go
+++ b/pkg/parser/interval.go
@@ -6,6 +6,13 @@ import (
 
 // IntervalString converts a sign and string into a number of seconds
 func IntervalString(s string, defaultSign int) (int32, error) {
+	if len(s) == 0 {
+		return 0, ErrUnknownTimeUnits
+	}
+
+	if s == "-" || s == "+" {
+		return 0, ErrUnknownTimeUnits
+	}
 
 	sign := defaultSign
 

--- a/pkg/parser/interval_test.go
+++ b/pkg/parser/interval_test.go
@@ -40,6 +40,9 @@ func TestInterval(t *testing.T) {
 		err     string
 		sign    int
 	}{
+		{"", 0, "unknown time units", 1},
+		{"-", 0, "unknown time units", 1},
+		{"+", 0, "unknown time units", 1},
 		{"10x10s", 0, "unknown time units", 1},
 		{"10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000y", 0, "value out of range", 1},
 	}


### PR DESCRIPTION
## What issue is this change attempting to solve?

Panic in interval.go when interval is empty

## How does this change solve the problem? Why is this the best approach?

Backporting [fix](https://github.com/go-graphite/carbonapi/commit/3dfe0404f0f76994d806cb7ba4a4170e11e8660d#diff-bf4c665f5b3470f030914d05395c1b1140e49cc1dcbf1e071ad5361a3da2d5a8) from carbonapi 

## How can we be sure this works as expected?

Tests are also ported.