### PR TITLE
Added conversion to seconds for the time in back-end queue durations.

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -141,7 +141,7 @@ func (b *Backend) Proc() {
 			}
 			semaphore <- true
 			b.saturation.Inc()
-			b.timeInQSec.WithLabelValues(requestLabel).Observe(float64(time.Since(r.StartTime)))
+			b.timeInQSec.WithLabelValues(requestLabel).Observe(float64(time.Since(r.StartTime).Seconds()))
 			go func(req *renderReq) {
 				t := prometheus.NewTimer(b.backendDuration.WithLabelValues("render"))
 				res, err := b.BackendImpl.Render(req.Ctx, req.RenderRequest)
@@ -164,7 +164,7 @@ func (b *Backend) Proc() {
 			b.requestsInQueue.WithLabelValues(requestLabel).Dec()
 			semaphore <- true
 			b.saturation.Inc()
-			b.timeInQSec.WithLabelValues(requestLabel).Observe(float64(time.Since(r.StartTime)))
+			b.timeInQSec.WithLabelValues(requestLabel).Observe(float64(time.Since(r.StartTime).Seconds()))
 			go func(req *findReq) {
 				t := prometheus.NewTimer(b.backendDuration.WithLabelValues(requestLabel))
 				res, err := b.BackendImpl.Find(req.Ctx, req.FindRequest)


### PR DESCRIPTION
## What issue is this change attempting to solve?
This is a bug fix. Previously, the secondly histogram was counted in nanoseconds instead of seconds. 


