### PR TITLE
fix SummarizeValues

### DIFF
--- a/pkg/expr/functions/legendValue/function.go
+++ b/pkg/expr/functions/legendValue/function.go
@@ -57,7 +57,7 @@ func (f *legendValue) Do(ctx context.Context, e parser.Expr, from, until int32, 
 	for _, a := range arg {
 		var values []string
 		for _, method := range methods {
-			summaryVal, _, err := helper.SummarizeValues(method, a.Values)
+			summaryVal, _, err := helper.SummarizeValues(method, a.Values, a.IsAbsent)
 			if err != nil {
 				return []*types.MetricData{}, err
 			}

--- a/pkg/expr/functions/sortBy/function.go
+++ b/pkg/expr/functions/sortBy/function.go
@@ -42,11 +42,11 @@ func (f *sortBy) Do(ctx context.Context, e parser.Expr, from, until int32, value
 	for i, a := range arg {
 		switch e.Target() {
 		case "sortByTotal":
-			vals[i], _, _ = helper.SummarizeValues("sum", a.Values)
+			vals[i], _, _ = helper.SummarizeValues("sum", a.Values, a.IsAbsent)
 		case "sortByMaxima":
-			vals[i], _, _ = helper.SummarizeValues("max", a.Values)
+			vals[i], _, _ = helper.SummarizeValues("max", a.Values, a.IsAbsent)
 		case "sortByMinima":
-			min, _, _ := helper.SummarizeValues("min", a.Values)
+			min, _, _ := helper.SummarizeValues("min", a.Values, a.IsAbsent)
 			vals[i] = 1 / min
 		}
 	}

--- a/pkg/expr/helper/helper.go
+++ b/pkg/expr/helper/helper.go
@@ -210,8 +210,6 @@ func SummarizeValues(f string, values []float64, absent []bool) (float64, bool, 
 		}
 		if total > 0 {
 			rv /= float64(total)
-		} else {
-			rv = 0.0
 		}
 	case "max":
 		rv = math.Inf(-1)

--- a/pkg/expr/helper/helper.go
+++ b/pkg/expr/helper/helper.go
@@ -201,12 +201,16 @@ func SummarizeValues(f string, values []float64, absent []bool) (float64, bool, 
 			rv += av
 		}
 	case "avg", "average":
+		total := 0
 		for i, av := range values {
 			if !absent[i] {
 				rv += av
+				total++
 			}
 		}
-		rv /= float64(len(values))
+		if total > 0 {
+			rv /= float64(total)
+		}
 	case "max":
 		rv = math.Inf(-1)
 		for _, av := range values {

--- a/pkg/expr/helper/helper.go
+++ b/pkg/expr/helper/helper.go
@@ -238,7 +238,7 @@ func SummarizeValues(f string, values []float64, absent []bool) (float64, bool, 
 		}
 	case "count":
 		total := 0
-		for i, _ := range values {
+		for i := range values {
 			if !absent[i] {
 				total++
 			}

--- a/pkg/expr/helper/helper.go
+++ b/pkg/expr/helper/helper.go
@@ -210,6 +210,8 @@ func SummarizeValues(f string, values []float64, absent []bool) (float64, bool, 
 		}
 		if total > 0 {
 			rv /= float64(total)
+		} else {
+			rv = 0.0
 		}
 	case "max":
 		rv = math.Inf(-1)

--- a/pkg/expr/helper/helper.go
+++ b/pkg/expr/helper/helper.go
@@ -188,7 +188,7 @@ func AggregateSeriesWithWildcards(name string, args []*types.MetricData, fields 
 }
 
 // SummarizeValues summarizes values
-func SummarizeValues(f string, values []float64) (float64, bool, error) {
+func SummarizeValues(f string, values []float64, absent []bool) (float64, bool, error) {
 	rv := 0.0
 
 	if len(values) == 0 {
@@ -201,8 +201,10 @@ func SummarizeValues(f string, values []float64) (float64, bool, error) {
 			rv += av
 		}
 	case "avg", "average":
-		for _, av := range values {
-			rv += av
+		for i, av := range values {
+			if !absent[i] {
+				rv += av
+			}
 		}
 		rv /= float64(len(values))
 	case "max":
@@ -214,20 +216,31 @@ func SummarizeValues(f string, values []float64) (float64, bool, error) {
 		}
 	case "min":
 		rv = math.Inf(1)
-		for _, av := range values {
-			if av < rv {
-				rv = av
+		for i, av := range values {
+			if !absent[i] {
+				if av < rv {
+					rv = av
+				}
 			}
 		}
 	case "last":
-		if len(values) > 0 {
-			rv = values[len(values)-1]
+		for i := len(values) - 1; i >= 0; i-- {
+			if !absent[i] {
+				rv = values[i]
+				break
+			}
 		}
 	case "count":
-		rv = float64(len(values))
+		total := 0
+		for i, _ := range values {
+			if !absent[i] {
+				total++
+			}
+		}
+		rv = float64(total)
 	case "median":
-		val, absent := Percentile(values, 50, true)
-		return val, absent, nil
+		val, abs := Percentile(values, 50, true)
+		return val, abs, nil
 	default:
 		looks_like_percentile, err := regexp.MatchString(`^p\d\d?$`, f)
 		if err != nil {
@@ -239,8 +252,8 @@ func SummarizeValues(f string, values []float64) (float64, bool, error) {
 			if err != nil {
 				return 0, true, parser.ParseError(err.Error())
 			}
-			val, absent := Percentile(values, percent, true)
-			return val, absent, nil
+			val, abs := Percentile(values, percent, true)
+			return val, abs, nil
 		} else {
 			return 0, true, parser.ParseError(fmt.Sprintf("unsupported aggregation function: %s", f))
 		}


### PR DESCRIPTION
This PR fixes #533 (wrong last value being shown in legend) and also corrects the calculation of the average, min, last and count values.

By adding the parameter `absent` to `SummarizeValues`, it is now able to correctly account for absent values.

Logically all calls to SummarizeValues also had to be adapted.