### PR TITLE
Support none type

### DIFF
--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -24,6 +24,8 @@ const (
 	EtConst
 	// EtString is a const for 'String' type expression
 	EtString
+	// EtNil is a const for 'None' type expression
+	EtNil
 )
 
 var (

--- a/pkg/parser/internal.go
+++ b/pkg/parser/internal.go
@@ -22,6 +22,9 @@ func (e *expr) getNamedArg(name string) *expr {
 }
 
 func (e *expr) doGetFloatArg() (float64, error) {
+	if e.etype == EtNil {
+		return 0, ErrBadType
+	}
 	if e.etype != EtConst {
 		return 0, ErrBadType
 	}
@@ -30,6 +33,9 @@ func (e *expr) doGetFloatArg() (float64, error) {
 }
 
 func (e *expr) doGetStringArg() (string, error) {
+	if e.etype == EtNil {
+		return "", nil
+	}
 	if e.etype != EtString {
 		return "", ErrBadType
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -373,6 +373,11 @@ func parseExprWithoutPipe(e string) (Expr, string, error) {
 	if strings.ToLower(name) == "false" || strings.ToLower(name) == "true" {
 		return &expr{valStr: name, etype: EtString, target: name}, e, nil
 	}
+	//check for none arg explicitly
+	if strings.EqualFold(name, "none") {
+		return &expr{valStr: "", etype: EtNil, target: "none"}, e, nil
+	}
+
 	if name == "" {
 		return nil, e, ErrMissingArgument
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -199,6 +199,23 @@ func TestParseExpr(t *testing.T) {
 			},
 		},
 		{
+			s: "None",
+			e: &expr{target: "none", etype: EtNil},
+		},
+		{
+			s: "asPercent(metric, None, 1)",
+			e: &expr{
+				target: "asPercent",
+				etype:  EtFunc,
+				args: []*expr{
+					{target: "metric"},
+					{target: "none", etype: EtNil},
+					{val: 1, etype: EtConst},
+				},
+				argString: "metric, None, 1",
+			},
+		},
+		{
 			s: "func(metric, key=1)",
 			e: &expr{
 				target: "func",


### PR DESCRIPTION
## What issue is this change attempting to solve?
PR is dedicated to resolve None type issue faced below
Fixes [#295](https://github.com/bookingcom/carbonapi/issues/295)

## How does this change solve the problem? Why is this the best approach?

- EtNil constant is introduced in interface.go 
- By intercepting "None" (case-insensitive) in parser.go and assigning it EtNil, we provide a type-safe way for functions to handle  null arguments. This follows the existing architecture for constants and strings.

## How can we be sure this works as expected?

- Added unit tests in parser_test.go for standalone None and nested function calls.
- All 46 TestParseExpr cases passed on running-> `(go test -v ./pkg/parser/... -run TestParseExpr)`
